### PR TITLE
Implement wait_for_pending_update method

### DIFF
--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -1,4 +1,6 @@
 import urllib
+from datetime import datetime
+from time import sleep
 from meilisearch._httprequests import HttpRequests
 
 # pylint: disable=R0904
@@ -170,7 +172,7 @@ class Index():
         Returns
         ----------
         update: `list`
-            List of all enqueued and processed actions of the index.
+            List containing the details of the update status.
         """
         return self.http.get(
             '{}/{}/{}/{}'.format(
@@ -180,6 +182,33 @@ class Index():
                 update_id
             )
         )
+
+    def wait_for_pending_update(self, update_id, timeout_in_ms=5000, interval_in_ms=50):
+        """Wait until MeiliSearch processes an update, and get its status
+
+        Parameters
+        ----------
+        update_id: int
+            identifier of the update to retrieve
+        timeout_in_ms (optional): int
+            time the method should wait before rising a TimeoutError
+        interval_in_ms (optional): int
+            time interval the method should wait (sleep) between requests
+        Returns
+        ----------
+        update: `dict`
+            Dictionary containing the details of the processed update status.
+        """
+        start_time = datetime.now()
+        elapsed_time = 0
+        while elapsed_time < timeout_in_ms:
+            get_update = self.get_update_status(update_id)
+            if get_update['status'] != 'enqueued':
+                return get_update
+            sleep(interval_in_ms / 1000)
+            time_delta = datetime.now() - start_time
+            elapsed_time = time_delta.seconds * 1000 + time_delta.microseconds / 1000
+        raise TimeoutError
 
     def get_stats(self):
         """Get stats of an index

--- a/meilisearch/tests/test_wait_for_pending_update.py
+++ b/meilisearch/tests/test_wait_for_pending_update.py
@@ -1,0 +1,61 @@
+from datetime import datetime
+import json
+import pytest
+import meilisearch
+from meilisearch.tests import BASE_URL, MASTER_KEY
+
+class TestUpdate:
+    client = meilisearch.Client(BASE_URL, MASTER_KEY)
+    index = None
+    dataset_file = open("datasets/small_movies.json", "r")
+    dataset_json = None
+
+    def setup_class(self):
+        self.index = self.client.create_index(uid='indexUID')
+        self.dataset_json = json.loads(self.dataset_file.read())
+
+    def teardown_class(self):
+        self.index.delete()
+
+    def test_wait_for_pending_update_default(self):
+        """Tests call to wait for an update with default parameters"""
+        response = self.index.add_documents([{'id': 1, 'title': 'Le Petit Prince'}])
+        assert 'updateId' in response
+        wait_update = self.index.wait_for_pending_update(response['updateId'])
+        assert isinstance(wait_update, object)
+        assert 'status' in wait_update
+        assert wait_update['status'] != 'enqueued'
+
+    def test_wait_for_pending_update_timeout(self):
+        """Tests timeout risen by waiting for an update"""
+        with pytest.raises(TimeoutError):
+            self.index.wait_for_pending_update(2, timeout_in_ms=0)
+
+    def test_wait_for_pending_update_interval_custom(self):
+        """Tests call to wait for an update with custom interval"""
+        response = self.index.add_documents(self.dataset_json)
+        assert 'updateId' in response
+        start_time = datetime.now()
+        wait_update = self.index.wait_for_pending_update(
+            response['updateId'],
+            interval_in_ms=1000,
+            timeout_in_ms=6000
+        )
+        time_delta = datetime.now() - start_time
+        assert isinstance(wait_update, object)
+        assert 'status' in wait_update
+        assert wait_update['status'] != 'enqueued'
+        assert time_delta.seconds >= 1
+
+    def test_wait_for_pending_update_interval_zero(self):
+        """Tests call to wait for an update with custom interval"""
+        response = self.index.add_documents(self.dataset_json)
+        assert 'updateId' in response
+        wait_update = self.index.wait_for_pending_update(
+            response['updateId'],
+            interval_in_ms=0,
+            timeout_in_ms=6000
+        )
+        assert isinstance(wait_update, object)
+        assert 'status' in wait_update
+        assert wait_update['status'] != 'enqueued'


### PR DESCRIPTION
[previously discussed in #79]

Based on [this discussion](https://github.com/meilisearch/integration-guides/issues/1), SDKs must provide a method that waits synchronously for an update to be processed by MeiliSearch.

*Parameters:*
- `update_id`: id of the update to be waited

*Optional parameters:*

- `timeout_in_ms` max number of millisecond this method should wait before rising a `TimeoutError` (default=2000ms)
- `interval_in_ms` number of millisecond to set an interval of time this method should wait (sleep) between requests (default=10ms)

*tests*

* Added `wait_for_pending_update` method in the `Index` class
* Added tests for default values, test for timeout and test for interval.

Closes #64 