### PR TITLE
Simple error handler

### DIFF
--- a/meilisearch/errors.py
+++ b/meilisearch/errors.py
@@ -1,0 +1,31 @@
+import json
+
+class MeiliSearchError(Exception):
+    """Generic class for MeiliSearch error handling"""
+
+    def __init__(self, message):
+        self.message = message
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f'MeiliSearchError, {self.message}'
+
+class MeiliSearchApiError(MeiliSearchError):
+    """Error sent by MeiliSearch API"""
+
+    def __init__(self, error, request):
+        self.status_code = request.status_code
+        if request.text:
+            self.message = f'{json.loads(request.text)["message"]}'
+        else:
+            self.message = error
+        super().__init__(self.message)
+
+    def __str__(self):
+        return f'MeiliSearchApiError, HTTP status: {self.status_code} -> {self.message}'
+
+class MeiliSearchCommunicationError(MeiliSearchError):
+    """Error connecting to MeiliSearch"""
+
+    def __str__(self):
+        return f'MeiliSearchCommunicationError, {self.message}'

--- a/meilisearch/tests/errors/test_api_error_meilisearch.py
+++ b/meilisearch/tests/errors/test_api_error_meilisearch.py
@@ -1,0 +1,20 @@
+import pytest
+import meilisearch
+from meilisearch.errors import MeiliSearchApiError
+from meilisearch.tests import BASE_URL, MASTER_KEY
+
+class TestMeiliSearchApiError:
+
+    """ TESTS: MeiliSearchApiError class """
+
+    @staticmethod
+    def test_meilisearch_api_error_no_master_key():
+        client = meilisearch.Client(BASE_URL)
+        with pytest.raises(MeiliSearchApiError):
+            client.create_index("some_index")
+
+    @staticmethod
+    def test_meilisearch_api_error_wrong_master_key():
+        client = meilisearch.Client(BASE_URL, MASTER_KEY + '123')
+        with pytest.raises(MeiliSearchApiError):
+            client.create_index("some_index")

--- a/meilisearch/tests/errors/test_communication_error_meilisearch.py
+++ b/meilisearch/tests/errors/test_communication_error_meilisearch.py
@@ -1,0 +1,14 @@
+import pytest
+import meilisearch
+from meilisearch.errors import MeiliSearchCommunicationError
+from meilisearch.tests import MASTER_KEY
+
+class TestMeiliSearchCommunicationError:
+
+    """ TESTS: MeiliSearchCommunicationError class """
+
+    @staticmethod
+    def test_meilisearch_communication_error_host():
+        client = meilisearch.Client("http://wrongurl:1234", MASTER_KEY)
+        with pytest.raises(MeiliSearchCommunicationError):
+            client.create_index("some_index")


### PR DESCRIPTION
## Error handling in python

### Custom error created

- MeiliSearchApiError: Throws when API returns bad status code
- MeiliSearchCommunicationError: Throws when problem accessing the API


### Usage
```python
# test.py
import meilisearch


client = meilisearch.Client("http://127.0.0.1:7700")
try:
    index = client.create_index(uid="movies1")
    index = client.create_index(uid="movies1")
except meilisearch.meilisearch_api_error.MeiliSearchApiError as err:
    print(err)
except meilisearch.meilisearch_communication_error.MeiliSearchCommunicationError as err:
    print(err)
```

MeiliSearchApiError will output 
```
MeiliSearchApiError, HTTP status: 400 -> Impossible to create index; index already exists
```
### Implementation

#### MeiliSearchApiError

```python
import json

class MeiliSearchApiError(Exception):
    """Error from MeiliSearch API"""
    def __init__(self, error, request):
        self.status_code = request.status_code
        if request.text:
            self.message = f'HTTP status: {self.status_code} -> {json.loads(request.text)["message"]}'
        else:
            self.message = error
        super().__init__(self.message)

    def __str__(self):
        return f'MeiliSearchApiError, {self.message}'

```
This error will use the default HTTP error message if MeiliSearch did not return a message. 

It is called in the __validate method of the `httpRequests` class: 

```python
try:
     request.raise_for_status()
     return HttpRequests.__to_json(request)
except requests.exceptions.HTTPError as err:
     raise MeiliSearchApiError(err, request) from None
```

By adding from None we prevent the chaining of errors.

#### MeiliSearchCommunicationError

```python
class MeiliSearchCommunicationError(Exception):
    """Error when communicating with MeiliSearch"""
    def __init__(self, message):
        self.message = message
        super().__init__(self.message)

    def __str__(self):
        return f'MeiliSearchCommunicationError, {self.message}'

```
This error will use the default error thrown by the HTTP request library to display the communication problem.

Mentionned in: /meilisearch/integration-guides#19

