### PR TITLE
Fix bug: Search optional params are not applied when they are a list of strings

### DIFF
--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -246,6 +246,9 @@ class Index():
         if opt_params is None:
             opt_params = {}
         search_param = {'q': query}
+        for key in opt_params:
+            if isinstance(opt_params[key], list):
+                opt_params[key] = ",".join(opt_params[key])
         params = {**search_param, **opt_params}
         return self.http.get(
             '{}/{}/{}?{}'.format(

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -248,7 +248,7 @@ class Index():
         search_param = {'q': query}
         for key in opt_params:
             if isinstance(opt_params[key], list):
-                opt_params[key] = ",".join(opt_params[key])
+                opt_params[key] = ','.join(opt_params[key])
         params = {**search_param, **opt_params}
         return self.http.get(
             '{}/{}/{}?{}'.format(

--- a/meilisearch/tests/index/test_index_document_meilisearch.py
+++ b/meilisearch/tests/index/test_index_document_meilisearch.py
@@ -14,7 +14,7 @@ class TestDocument:
 
     def setup_class(self):
         self.index = self.client.create_index(uid='indexUID')
-        self.dataset_file = open("./datasets/small_movies.json", "r")
+        self.dataset_file = open('./datasets/small_movies.json', 'r')
         self.dataset_json = json.loads(self.dataset_file.read())
         self.dataset_file.close()
 
@@ -38,7 +38,7 @@ class TestDocument:
 
     def test_get_document(self):
         """Tests getting one document on a populated index"""
-        response = self.index.get_document("500682")
+        response = self.index.get_document('500682')
         assert isinstance(response, object)
         assert 'title' in response
         assert response['title'] == 'The Highwaymen'
@@ -46,7 +46,7 @@ class TestDocument:
     def test_get_document_inexistent(self):
         """Tests getting one INEXISTENT document on a populated index"""
         with pytest.raises(Exception):
-            self.index.get_document("123")
+            self.index.get_document('123')
 
     def test_get_documents_populated(self):
         """Tests getting documents on a populated index"""
@@ -70,30 +70,30 @@ class TestDocument:
     def test_update_documents(self):
         """Tests updating a single document and a set of documents """
         response = self.index.get_documents()
-        response[0]['title'] = "Some title"
+        response[0]['title'] = 'Some title'
         update = self.index.update_documents([response[0]])
         assert isinstance(update, object)
         assert 'updateId' in update
         self.index.wait_for_pending_update(update['updateId'])
         response = self.index.get_documents()
-        assert response[0]['title'] == "Some title"
+        assert response[0]['title'] == 'Some title'
         update = self.index.update_documents(self.dataset_json)
         self.index.wait_for_pending_update(update['updateId'])
         response = self.index.get_documents()
-        assert response[0]['title'] != "Some title"
+        assert response[0]['title'] != 'Some title'
 
     def test_delete_document(self):
         """Tests deleting a single document"""
-        response = self.index.delete_document("500682")
+        response = self.index.delete_document('500682')
         assert isinstance(response, object)
         assert 'updateId' in response
         self.index.wait_for_pending_update(response['updateId'])
         with pytest.raises(Exception):
-            self.index.get_document("500682")
+            self.index.get_document('500682')
 
     def test_delete_documents(self):
         """Tests deleting a set of documents """
-        to_delete = ["522681", "450465", "329996"]
+        to_delete = ['522681', '450465', '329996']
         response = self.index.delete_documents(to_delete)
         assert isinstance(response, object)
         assert 'updateId' in response

--- a/meilisearch/tests/index/test_index_search_meilisearch.py
+++ b/meilisearch/tests/index/test_index_search_meilisearch.py
@@ -13,7 +13,7 @@ class TestSearch:
 
     def setup_class(self):
         self.index = self.client.create_index(uid='indexUID')
-        self.dataset_file = open("./datasets/small_movies.json", "r")
+        self.dataset_file = open('./datasets/small_movies.json', 'r')
         self.dataset_json = json.loads(self.dataset_file.read())
         self.dataset_file.close()
         response = self.index.add_documents(self.dataset_json, primary_key='id')
@@ -83,8 +83,8 @@ class TestSearch:
         assert isinstance(response, object)
         assert len(response['hits']) == 5
         assert '_formatted' in response['hits'][0]
-        assert "title" in response['hits'][0]['_formatted']
-        assert not "release_date" in response['hits'][0]['_formatted']
+        assert 'title' in response['hits'][0]['_formatted']
+        assert not 'release_date' in response['hits'][0]['_formatted']
 
     def test_basic_search_params_with_string_list(self):
         """Tests search with string list in query params"""
@@ -93,13 +93,13 @@ class TestSearch:
             {
                 'limit': 5,
                 'attributesToRetrieve': ['title', 'overview'],
-                "attributesToHighlight": ["title"],
+                'attributesToHighlight': ['title'],
             }
         )
         assert isinstance(response, object)
         assert len(response['hits']) == 5
-        assert "title" in response['hits'][0]
-        assert "overview" in response['hits'][0]
-        assert not "release_date" in response['hits'][0]
-        assert "title" in response['hits'][0]['_formatted']
-        assert not "overview" in response['hits'][0]['_formatted']
+        assert 'title' in response['hits'][0]
+        assert 'overview' in response['hits'][0]
+        assert not 'release_date' in response['hits'][0]
+        assert 'title' in response['hits'][0]['_formatted']
+        assert not 'overview' in response['hits'][0]['_formatted']

--- a/meilisearch/tests/index/test_index_search_meilisearch.py
+++ b/meilisearch/tests/index/test_index_search_meilisearch.py
@@ -86,5 +86,20 @@ class TestSearch:
         assert "title" in response['hits'][0]['_formatted']
         assert not "release_date" in response['hits'][0]['_formatted']
 
-    # Add def test_basic_search_params_with_string_list(self):
-    # when bug (issue #85) is fixed
+    def test_basic_search_params_with_string_list(self):
+        """Tests search with string list in query params"""
+        response = self.index.search(
+            'a',
+            {
+                'limit': 5,
+                'attributesToRetrieve': ['title', 'overview'],
+                "attributesToHighlight": ["title"],
+            }
+        )
+        assert isinstance(response, object)
+        assert len(response['hits']) == 5
+        assert "title" in response['hits'][0]
+        assert "overview" in response['hits'][0]
+        assert not "release_date" in response['hits'][0]
+        assert "title" in response['hits'][0]['_formatted']
+        assert not "overview" in response['hits'][0]['_formatted']

--- a/meilisearch/tests/index/test_index_update_meilisearch.py
+++ b/meilisearch/tests/index/test_index_update_meilisearch.py
@@ -14,7 +14,7 @@ class TestUpdate:
 
     def setup_class(self):
         self.index = self.client.create_index(uid='indexUID')
-        self.dataset_file = open("./datasets/small_movies.json", "r")
+        self.dataset_file = open('./datasets/small_movies.json', 'r')
         self.dataset_json = json.loads(self.dataset_file.read())
         self.dataset_file.close()
 

--- a/meilisearch/tests/index/test_index_wait_for_pending_update.py
+++ b/meilisearch/tests/index/test_index_wait_for_pending_update.py
@@ -15,7 +15,7 @@ class TestUpdate:
 
     def setup_class(self):
         self.index = self.client.create_index(uid='indexUID')
-        self.dataset_file = open("./datasets/small_movies.json", "r")
+        self.dataset_file = open('./datasets/small_movies.json', 'r')
         self.dataset_json = json.loads(self.dataset_file.read())
         self.dataset_file.close()
 

--- a/meilisearch/tests/settings/test_settings_displayed_attributes_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_displayed_attributes_meilisearch.py
@@ -14,7 +14,7 @@ class TestDisplayedAttributes:
 
     def setup_class(self):
         self.index = self.client.create_index(uid='indexUID')
-        self.dataset_file = open("./datasets/small_movies.json", "r")
+        self.dataset_file = open('./datasets/small_movies.json', 'r')
         self.dataset_json = json.loads(self.dataset_file.read())
         self.dataset_file.close()
 

--- a/meilisearch/tests/settings/test_settings_searchable_attributes_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_searchable_attributes_meilisearch.py
@@ -15,7 +15,7 @@ class TestSearchableAttributes:
 
     def setup_class(self):
         self.index = self.client.create_index(uid='indexUID')
-        self.dataset_file = open("./datasets/small_movies.json", "r")
+        self.dataset_file = open('./datasets/small_movies.json', 'r')
         self.dataset_json = json.loads(self.dataset_file.read())
         self.dataset_file.close()
 


### PR DESCRIPTION
When a search parameter like `attributesToHighlight` or `attributesToRetrieve` are given as a list of strings, they should be encoded as a comma separated string into the url:

```python
attributesToRetrieve = ["some", "string"]
```

should become 

```
... &attributesToRetrieve=some,string ...
```

This encoding is not the default behaviour of the url lib encoding and it was introducing the `[` and `]` characters in the url (and some `+`) so MeiliSearch was ignoring those parameters.

Before encoding this parameters, I added a few lines:

```python
for key in opt_params:
    if isinstance(opt_params[key], list):
        opt_params[key] = ",".join(opt_params[key])
```

this will transform the lists of strings in the expected format.

A test was added to the `meilisearch/tests/index/test_index_document_meilisearch.py` file to check this behavior

Closes #85 