### PR TITLE
Add method to use faceting sub routes

### DIFF
--- a/meilisearch/config.py
+++ b/meilisearch/config.py
@@ -21,6 +21,7 @@ class Config:
         stop_words = 'stop-words'
         synonyms = 'synonyms'
         accept_new_fields = 'accept-new-fields'
+        attributes_for_faceting = 'attributes-for-faceting'
 
     def __init__(self, url, apikey=None):
         """

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -814,6 +814,54 @@ class Index():
             body
         )
 
+    # ATTRIBUTES FOR FACETING SUB-ROUTES
+
+    def get_attributes_for_faceting(self):
+        """
+        Get attributes for faceting of an index
+
+        Returns
+        ----------
+        settings: `list`
+            List containing the attributes for faceting of the index
+        """
+        return self.http.get(
+            self.__settings_url_for(self.config.paths.attributes_for_faceting)
+        )
+
+    def update_attributes_for_faceting(self, body):
+        """
+        Update attributes for faceting of an index
+
+        Parameters
+        ----------
+        body: `list`
+            List containing the attributes for faceting
+
+        Returns
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
+            https://docs.meilisearch.com/references/updates.html#get-an-update-status
+        """
+        return self.http.post(
+            self.__settings_url_for(self.config.paths.attributes_for_faceting),
+            body
+        )
+
+    def reset_attributes_for_faceting(self):
+        """Reset attributes for faceting of an index to default values
+
+        Returns
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
+            https://docs.meilisearch.com/references/updates.html#get-an-update-status
+        """
+        return self.http.delete(
+            self.__settings_url_for(self.config.paths.attributes_for_faceting),
+        )
+
     def __settings_url_for(self, sub_route):
         return '{}/{}/{}/{}'.format(
             self.config.paths.index,

--- a/meilisearch/tests/settings/test_settings_attributes_for_faceting_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_attributes_for_faceting_meilisearch.py
@@ -1,0 +1,48 @@
+import json
+import meilisearch
+from meilisearch.tests import BASE_URL, MASTER_KEY
+
+class TestAttributesForFaceting:
+
+    """ TESTS: attributesForFaceting setting """
+
+    client = meilisearch.Client(BASE_URL, MASTER_KEY)
+    index = None
+    attributes_for_faceting = ['title', 'release_date']
+    dataset_file = None
+    dataset_json = None
+
+    def setup_class(self):
+        self.index = self.client.create_index(uid='indexUID')
+        self.dataset_file = open('./datasets/small_movies.json', 'r')
+        self.dataset_json = json.loads(self.dataset_file.read())
+        self.dataset_file.close()
+
+    def teardown_class(self):
+        self.index.delete()
+
+    def test_get_attributes_for_faceting(self):
+        """ Tests getting the attributes for faceting """
+        response = self.index.get_attributes_for_faceting()
+        assert isinstance(response, object)
+        assert response == []
+
+    def test_update_attributes_for_faceting(self):
+        """Tests updating the attributes for faceting"""
+        response = self.index.update_attributes_for_faceting(self.attributes_for_faceting)
+        self.index.wait_for_pending_update(response['updateId'])
+        get_attributes_new = self.index.get_attributes_for_faceting()
+        assert len(get_attributes_new) == len(self.attributes_for_faceting)
+        get_attributes = self.index.get_attributes_for_faceting()
+        for attribute in self.attributes_for_faceting:
+            assert attribute in get_attributes
+
+    def test_reset_attributes_for_faceting(self):
+        """Tests the reset of attributes for faceting to default values (in dataset)"""
+        response = self.index.reset_attributes_for_faceting()
+        assert isinstance(response, object)
+        assert 'updateId' in response
+        self.index.wait_for_pending_update(response['updateId'])
+        response = self.index.get_attributes_for_faceting()
+        assert isinstance(response, object)
+        assert response == []


### PR DESCRIPTION
NB: tests do not run yet because the v0.11 is not out.
If you want to run the tests with the last version of MeiliSearch, use `cargo` in the MeiliSearch repo, and go on my branch.