### PR TITLE
Change create_index prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,8 @@ NB: you can also download MeiliSearch from **Homebrew** or **APT**.
 import meilisearch
 
 client = meilisearch.Client('http://127.0.0.1:7700', 'masterKey')
-index = client.create_index(uid='books') # If your index does not exist
-index = client.get_index('books')        # If you already created your index
+index = client.create_index('books') # If your index does not exist
+index = client.get_index('books')    # If you already created your index
 
 documents = [
   { 'book_id': 123,  'title': 'Pride and Prejudice' },
@@ -118,9 +118,9 @@ You can check out [the API documentation](https://docs.meilisearch.com/reference
 #### Create an index <!-- omit in toc -->
 ```python
 # Create an index
-client.create_index(uid='books')
+client.create_index('books')
 # Create an index and give the primary-key
-client.create_index(uid='books', primary_key='book_id')
+client.create_index('books', {'primaryKey': 'book_id'})
 ```
 
 #### List all indexes <!-- omit in toc -->

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -36,7 +36,7 @@ class Client():
         uid: str
             UID of the index
         options: dict, optional
-            Options passed during creation (ex: primaryKey)
+            Options passed during index creation (ex: primaryKey)
 
         Returns
         -------

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -25,7 +25,7 @@ class Client():
         self.config = Config(url, apiKey)
         self.http = HttpRequests(self.config)
 
-    def create_index(self, uid, primary_key=None, name=None):
+    def create_index(self, uid, options=None):
         """Create an index.
 
         If the argument `uid` isn't passed in, it will be generated
@@ -35,10 +35,9 @@ class Client():
         ----------
         uid: str
             UID of the index
-        primary_key: str, optional
-            Attribute used as unique document identifier
-        name: str, optional
-            Name of the index
+        options: dict, optional
+            Options passed during creation (ex: primaryKey)
+
         Returns
         -------
         index : Index
@@ -48,8 +47,8 @@ class Client():
         HTTPError
             In case of any other error found here https://docs.meilisearch.com/references/#errors-status-code
         """
-        index = Index(self.config, uid=uid)
-        index.create(self.config, uid=uid, primary_key=primary_key, name=name)
+        index = Index(self.config, uid)
+        index.create(self.config, uid, options)
         return index
 
     def get_indexes(self):

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -84,13 +84,15 @@ class Index():
         return self.info()['primaryKey']
 
     @staticmethod
-    def create(config, **body):
+    def create(config, uid, options=None):
         """Create an index.
 
         Parameters
         ----------
-            body: **kwargs
-            Accepts uid, name and primaryKey as parameter.
+        uid: str
+            UID of the index
+        options: dict, optional
+            Options passed during creation (ex: primaryKey)
 
         Returns
         -------
@@ -101,16 +103,9 @@ class Index():
         HTTPError
             In case of any error found here https://docs.meilisearch.com/references/#errors-status-code
         """
-        payload = {}
-        uid = body.get('uid', None)
-        if uid is not None:
-            payload['uid'] = uid
-        name = body.get('name', None)
-        if name is not None:
-            payload['name'] = name
-        primary_key = body.get('primary_key', None)
-        if primary_key is not None:
-            payload['primaryKey'] = primary_key
+        if options is None:
+            options = {}
+        payload = {'uid': uid, **options}
         return HttpRequests(config).post(config.paths.index, payload)
 
     @staticmethod

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -92,7 +92,7 @@ class Index():
         uid: str
             UID of the index
         options: dict, optional
-            Options passed during creation (ex: primaryKey)
+            Options passed during index creation (ex: primaryKey)
 
         Returns
         -------

--- a/meilisearch/tests/index/test_index.py
+++ b/meilisearch/tests/index/test_index.py
@@ -8,6 +8,7 @@ class TestIndex:
 
     client = meilisearch.Client(BASE_URL, MASTER_KEY)
     index_uid = 'indexUID'
+    index_uid2 = 'indexUID2'
 
     def setup_class(self):
         clear_all_indexes(self.client)
@@ -17,6 +18,14 @@ class TestIndex:
         index = self.client.create_index(uid=self.index_uid)
         assert isinstance(index, object)
         assert index.uid == self.index_uid
+        assert index.get_primary_key() is None
+
+    def test_create_index_with_primary_key(self):
+        """Tests creating an index with a primary key"""
+        index = self.client.create_index(uid=self.index_uid2, options={'primaryKey': 'book_id'})
+        assert isinstance(index, object)
+        assert index.uid == self.index_uid2
+        assert index.get_primary_key() == 'book_id'
 
     def test_get_indexes(self):
         """Tests getting all indexes"""
@@ -69,3 +78,9 @@ class TestIndex:
         assert response.status_code == 204
         with pytest.raises(Exception):
             self.client.get_index(uid=self.index_uid).info()
+        index = self.client.get_index(uid=self.index_uid2)
+        response = index.delete()
+        assert isinstance(response, object)
+        assert response.status_code == 204
+        with pytest.raises(Exception):
+            self.client.get_index(uid=self.index_uid2).info()


### PR DESCRIPTION
Related to [this comment](https://github.com/meilisearch/integration-guides/issues/2#issuecomment-642012475).

Before:
```python
client.create_index(uid='books')
client.create_index(uid='books', primary_key='book_id')
```

After:
```python
client.create_index(uid='books')
client.create_index(uid='books', options={'primaryKey': 'book_id'})
```