### PR TITLE
Add python docs examples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -1,0 +1,330 @@
+get_one_index_1: |-
+  client.get_index('movies')
+list_all_indexes_1: |-
+  client.get_indexes()
+create_an_index_1: |-
+  client.create_index('movies', {'primary_key': 'movie_id'})
+update_an_index_1: |-
+  client.get_index('movies').update(primaryKey='movie_review_id')
+delete_an_index_1: |-
+  client.get_index('movies').delete()
+get_one_document_1: |-
+  client.get_index('movies').get_document(25684)
+get_documents_1: |-
+  client.get_index('movies').get_documents({'limit':2})
+add_or_replace_documents_1: |-
+  client.get_index('movies').add_documents([{
+    'id': 287947,
+    'title': 'Shazam',
+    'poster': 'https://image.tmdb.org/t/p/w1280/xnopI5Xtky18MPhK40cZAGAOVeV.jpg',
+    'overview': 'A boy is given the ability to become an adult superhero in times of need with a single magic word.',
+    'release_date': '2019-03-23'
+  }])
+add_or_update_documents_1: |-
+  client.get_index('movies').update_documents([{
+    'id': 287947,
+    'title': 'Shazam12'
+  }])
+delete_all_documents_1: |-
+  client.get_index('movies').delete_all_documents()
+delete_one_document_1: |-
+  client.get_index('movies').delete_document(25684)
+delete_documents_1: |-
+  client.get_index('movies').delete_documents([23488, 153738, 437035, 363869])
+search_1: |-
+  client.get_index('movies').search('American ninja')
+get_update_1: |-
+  client.get_index('movies').get_update_status(1)
+get_all_updates_1: |-
+  client.get_index('movies').get_all_update_status()
+get_keys_1: |-
+  client.get_keys()
+get_settings_1: |-
+  client.get_index('movies').get_settings()
+update_settings_1: |-
+  client.get_index('movies').update_settings({
+    'rankingRules': [
+        'typo',
+        'words',
+        'proximity',
+        'attribute',
+        'wordsPosition',
+        'exactness',
+        'desc(release_date)',
+        'desc(rank)'
+    ],
+    'distinctAttribute': 'movie_id',
+    'searchableAttributes': [
+        'uid',
+        'movie_id',
+        'title',
+        'description',
+        'poster',
+        'release_date',
+        'rank'
+    ],
+    'displayedAttributes': [
+        'title',
+        'description',
+        'poster',
+        'release_date',
+        'rank'
+    ],
+    'stopWords': [
+        'the',
+        'a',
+        'an'
+    ],
+    'synonyms': {
+        'wolverine': ['xmen', 'logan'],
+        'logan': ['wolverine']
+    },
+    'acceptNewFields': False
+  })
+reset_settings_1: |-
+  client.get_index('movies').reset_settings()
+get_synonyms_1: |-
+  client.get_index('movies').get_synonyms()
+update_synonyms_1: |-
+  client.get_index('movies').update_synonyms({
+    'wolverine': ['xmen', 'logan'],
+    'logan': ['wolverine', 'xmen'],
+    'wow': ['world of warcraft']
+  })
+reset_synonyms_1: |-
+  client.get_index('movies').reset_synonyms()
+get_stop_words_1: |-
+  client.get_index('movies').get_stop_words()
+update_stop_words_1: |-
+  client.get_index('movies').update_stop_words(['of', 'the', 'to'])
+reset_stop_words_1: |-
+  client.get_index('movies').reset_stop_words()
+get_ranking_rules_1: |-
+  client.get_index('movies').get_ranking_rules()
+update_ranking_rules_1: |-
+  client.get_index('movies').update_ranking_rules([
+      'typo',
+      'words',
+      'proximity',
+      'attribute',
+      'wordsPosition',
+      'exactness',
+      'asc(release_date)',
+      'desc(rank)'
+  ])
+reset_ranking_rules_1: |-
+  client.get_index('movies').reset_ranking_rules()
+get_distinct_attribute_1: |-
+  client.get_index('movies').get_distinct_attribute()
+update_distinct_attribute_1: |-
+  client.get_index('movies').update_distinct_attribute('movie_id')
+reset_distinct_attribute_1: |-
+  client.get_index('movies').reset_distinct_attribute()
+get_searchable_attributes_1: |-
+  client.get_index('movies').get_searchable_attributes()
+update_searchable_attributes_1: |-
+  client.get_index('movies').update_searchable_attributes([
+      'title',
+      'description',
+      'uid'
+  ])
+reset_searchable_attributes_1: |-
+  client.get_index('movies').reset_searchable_attributes()
+get_displayed_attributes_1: |-
+  client.get_index('movies').get_displayed_attributes()
+update_displayed_attributes_1: |-
+  client.get_index('movies').update_displayed_attributes([
+      "title",
+      'description',
+      'release_date',
+      'rank',
+      'poster'
+  ])
+reset_displayed_attributes_1: |-
+  client.get_index('movies').reset_displayed_attributes()
+get_accept_new_fields_1: |-
+  client.get_index('movies').get_accept_new_fields()
+update_accept_new_fields_1: |-
+  client.get_index('movies').update_accept_new_fields(False)
+get_index_stats_1: |-
+  client.get_index('movies').get_stats()
+get_indexes_stats_1: |-
+  client.get_all_stats()
+get_health_1: |-
+  client.health()
+update_health_1: |-
+  client.update_health()
+get_version_1: |-
+  clien.get_version()
+get_pretty_sys_info_1: |-
+get_sys_info_1: |-
+  client.get_sys_info()
+distinct_attribute_guide_1: |-
+  client.get_index('movies').update_settings({'distinctAttribute': 'product_id'})
+field_properties_guide_searchable_1: |-
+  client.get_index('movies').update_settings({
+    'searchableAttributes': [
+        'uid',
+        'movie_id',
+        'title',
+        'description',
+        'poster',
+        'release_date',
+        'rank'
+  ]})
+field_properties_guide_displayed_1: |-
+  client.get_index('movies').update_settings({
+    'displayedAttributes': [
+        'title',
+        'description',
+        'poster',
+        'release_date',
+        'rank'
+  ]})
+filtering_guide_1: |-
+  client.get_index('movies').search('Avengers', {
+    'filters': 'release_date > 795484800'
+  })
+filtering_guide_2: |-
+  client.get_index('movies').search('Batman', {
+    'filters': 'release_date > 795484800 AND (director = "Tim Burton" OR director = "Christopher Nolan")'
+  })
+filtering_guide_3: |-
+  client.get_index('movies').search('horror', {
+    'filters': 'director = "Jordan Peele"'
+  })
+filtering_guide_4: |-
+  client.get_index('movies').search('Planet of the Apes', {
+    'filters': 'rating >= 3 AND (NOT director = "Tim Burton")'
+  })
+search_parameter_guide_query_1: |-
+  client.get_index('movies').search('shifu')
+search_parameter_guide_offset_1: |-
+  client.get_index('movies').search('shifu', {
+    'offset': 1
+  })
+search_parameter_guide_limit_1: |-
+  client.get_index('movies').search('shifu', {
+    'limit': 2
+  })
+search_parameter_guide_retrieve_1: |-
+  client.get_index('movies').search('shifu', {
+    'attributesToRetrieve': ['overview', 'title']
+  })
+search_parameter_guide_crop_1: |-
+  client.get_index('movies').search('shifu', {
+    'attributesToCrop': ['overview'],
+    'cropLength': 10
+  })
+search_parameter_guide_highlight_1: |-
+  client.get_index('movies').search('shifu', {
+    'attributesToHighlight': ['overview']
+  })
+search_parameter_guide_filter_1: |-
+  client.get_index('movies').search('n', {
+    'filters': 'title = Nightshift'
+  })
+search_parameter_guide_filter_2: |-
+  client.get_index('movies').search('n', {
+    'filters': 'title = "Kung Fu Panda"'
+  })
+search_parameter_guide_matches_1: |-
+  client.get_index('movies').search('n', {
+    'filters': 'title = "Kung Fu Panda"',
+    'attributesToHighlight': ['overview'],
+    'matches': 'true'
+  })
+settings_guide_stop_words_1: |-
+  client.get_index('movies').update_settings({
+    'stopWords': [
+        'the',
+        'a',
+        'an'
+    ],
+  })
+settings_guide_ranking_rules_1: |-
+  client.get_index('movies').update_settings({
+    'rankingRules': [
+        'typo',
+        'words',
+        'proximity',
+        'attribute',
+        'wordsPosition',
+        'exactness',
+        'asc(release_date)',
+        'desc(rank)'
+    ]
+  })
+settings_guide_distinct_1: |-
+  client.get_index('movies').update_settings({
+    'distinctAttribute': 'product_id'
+  })
+settings_guide_searchable_1: |-
+  client.get_index('movies').update_settings({
+    'searchableAttributes': [
+      'uid',
+      'movie_id',
+      'title',
+      'description',
+      'poster',
+      'release_date',
+      'rank'
+    ]
+  })
+settings_guide_displayed_1: |-
+  client.get_index('movies').update_settings({
+    'displayedAttributes': [
+      'title',
+      'description',
+      'poster',
+      'release_date',
+      'rank'
+    ]
+  })
+settings_guide_accept_new_fields_1: |-
+  client.get_index('movies').update_settings({
+    'acceptNewFields': False
+  })
+documents_guide_add_movie_1: |-
+  client.get_index('movies').add_documents([{
+    'movie_id': '123sq178',
+    'title': 'Amélie Poulain'
+  }])
+search_guide_1: |-
+  client.get_index('movies').search('shifu', {
+    'limit': 5,
+    'offset': 10
+  })
+search_guide_2: |-
+  client.get_index('movies').search('Avengers', {
+    'filters': 'release_date > 795484800'
+  })
+getting_started_create_index_md: |-
+  ```bash
+    $ pip3 install meilisearch
+  ```
+
+  ```python
+    import meilisearch
+
+    client = meilisearch.Client('http://127.0.0.1:7700')
+    index = client.create_index(uid='movies')
+  ```
+
+  [About this package](https://github.com/meilisearch/meilisearch-python/)
+getting_started_add_documents_md: |-
+  ```python
+    import json
+
+    json_file = open('movies.json')
+    movies = json.load(json_file)
+    index.add_documents(movies)
+  ```
+
+  [About this package](https://github.com/meilisearch/meilisearch-python/)
+getting_started_search_md: |-
+  ```python
+    index.search('botman')
+  ```
+
+  [About this package](https://github.com/meilisearch/meilisearch-python/)


### PR DESCRIPTION
Creates `.code-samples.meilisearch.yaml` file, in order to display examples for Python in MeiliSearch documentation.

Closes #77 