### PR TITLE
Implement get_or_create_index method

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ You can check out [the API documentation](https://docs.meilisearch.com/reference
 client.create_index('books')
 # Create an index and give the primary-key
 client.create_index('books', {'primaryKey': 'book_id'})
+# Get an index or create it if it doesn't exist
+client.get_or_create_index('books', {'primaryKey': 'book_id'})
 ```
 
 #### List all indexes <!-- omit in toc -->

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -1,6 +1,7 @@
 from meilisearch.index import Index
 from meilisearch.config import Config
 from meilisearch._httprequests import HttpRequests
+from meilisearch.errors import MeiliSearchApiError
 
 class Client():
     """
@@ -79,6 +80,33 @@ class Client():
             an instance of Index containing the information of the index found
         """
         return Index.get_index(self.config, uid=uid)
+
+    def get_or_create_index(self, uid, options=None):
+        """Get an index, or create it if it doesn't exist.
+
+        Parameters
+        ----------
+        uid: str
+            UID of the index
+        options: dict, optional
+            Options passed during index creation (ex: primaryKey)
+
+        Returns
+        -------
+        index : Index
+            an instance of Index containing the information of the retrieved or newly created index
+        Raises
+        ------
+        HTTPError
+            In case of any other error found here https://docs.meilisearch.com/references/#errors-status-code
+        """
+        index = self.get_index(uid)
+        try:
+            index.create(self.config, uid, options)
+        except MeiliSearchApiError as err:
+            if err.error_code != 'index_already_exists':
+                raise err
+        return index
 
     def get_all_stats(self):
         """Get all stats of MeiliSearch


### PR DESCRIPTION
Implements the `get_or_create_index` method, as specified in [this discussion](https://github.com/meilisearch/integration-guides/issues/2)

Depends on #117

Closes #70 