### PR TITLE
Fix code samples errors

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -162,7 +162,7 @@ get_pretty_sys_info_1: |-
 get_sys_info_1: |-
   client.get_sys_info()
 distinct_attribute_guide_1: |-
-  client.get_index('movies').update_settings({'distinctAttribute': 'product_id'})
+  client.get_index('jackets').update_settings({'distinctAttribute': 'product_id'})
 field_properties_guide_searchable_1: |-
   client.get_index('movies').update_settings({
     'searchableAttributes': [

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -236,6 +236,13 @@ search_parameter_guide_matches_1: |-
     'attributesToHighlight': ['overview'],
     'matches': 'true'
   })
+settings_guide_synonyms_1: |-
+  client.get_index('movies').update_settings({
+    'synonyms': {
+      sweater: ['jumper'],
+      jumper: ['sweater']
+    },
+  })
 settings_guide_stop_words_1: |-
   client.get_index('movies').update_settings({
     'stopWords': [

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -335,8 +335,8 @@ getting_started_search_md: |-
   [About this package](https://github.com/meilisearch/meilisearch-python/)
 faceted_search_update_settings_1: |-
   client.get_index('movies').update_attributes_for_faceting([
-      'genres',
       'director',
+      'genres',
   ])
 faceted_search_facet_filters_1: |-
   client.get_index('movies').search('thriller', {


### PR DESCRIPTION
Fix 1. `distinct_attribute_guide_1` -> Rename index

Index is 'jackets', not 'movies'

https://docs.meilisearch.com/guides/advanced_guides/distinct.html#example

Fix 2. `settings_guide_synonyms_1` -> Fill missing sample

Was missing at https://docs.meilisearch.com/guides/advanced_guides/settings.html#example

Fix 3. `faceted_search_update_settings_1` -> Change order in params

Just to keep documentation tidy, the list of parameters should have the same order in the different SDKs examples (using cURL as reference)

https://docs.meilisearch.com/guides/advanced_guides/settings.html#example-3