### PR TITLE
Add dumps implementation, tests and code samples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -361,3 +361,7 @@ faceted_search_walkthrough_facets_distribution_1: |-
   client.get_index('movies').search('Batman', {
     'facetsDistribution': ['genres']
   })
+post_dump_1: |-
+  client.create_dump()
+get_dump_status_1: |-
+  client.get_dump_status('20201101-110357260')

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -176,3 +176,32 @@ class Client():
             Information about the version of MeiliSearch.
         """
         return self.get_version()
+
+    def create_dump(self):
+        """Triggers the creation of a MeiliSearch dump
+
+        Returns
+        ----------
+        Dump: dict
+            Information about the dump.
+            https://docs.meilisearch.com/references/dump.html#create-a-dump
+        """
+        return self.http.post(self.config.paths.dumps)
+
+    def get_dump_status(self, uid):
+        """Retrieves the status of a MeiliSearch dump creation
+
+        Parameters
+        ----------
+        uid: str
+            UID of the dump
+
+        Returns
+        ----------
+        Dump status: dict
+            Information about the dump status.
+            https://docs.meilisearch.com/references/dump.html#get-dump-status
+        """
+        return self.http.get(
+            self.config.paths.dumps + '/' + str(uid) + '/status'
+        )

--- a/meilisearch/config.py
+++ b/meilisearch/config.py
@@ -22,7 +22,6 @@ class Config:
         accept_new_fields = 'accept-new-fields'
         attributes_for_faceting = 'attributes-for-faceting'
         dumps = 'dumps'
-        dump_status = 'dump_status'
 
     def __init__(self, url, api_key=None):
         """

--- a/meilisearch/config.py
+++ b/meilisearch/config.py
@@ -21,6 +21,8 @@ class Config:
         synonyms = 'synonyms'
         accept_new_fields = 'accept-new-fields'
         attributes_for_faceting = 'attributes-for-faceting'
+        dumps = 'dumps'
+        dump_status = 'dump_status'
 
     def __init__(self, url, api_key=None):
         """

--- a/meilisearch/tests/__init__.py
+++ b/meilisearch/tests/__init__.py
@@ -1,3 +1,5 @@
+import time
+
 MASTER_KEY = 'masterKey'
 BASE_URL = 'http://127.0.0.1:7700'
 
@@ -5,3 +7,9 @@ def clear_all_indexes(client):
     indexes = client.get_indexes()
     for index in indexes:
         client.get_index(index['uid']).delete()
+
+def wait_for_dump_creation(client, dump_uid):
+    dump_status = client.get_dump_status(dump_uid)
+    while dump_status['status'] == 'processing':
+        time.sleep(0.1)
+        dump_status = client.get_dump_status(dump_uid)

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -15,12 +15,22 @@ class TestClientDumps:
 
     def setup_class(self):
         clear_all_indexes(self.client)
-        self.index = self.client.create_index(uid='indexUID')
         self.dataset_file = open('./datasets/small_movies.json', 'r')
         self.dataset_json = json.loads(self.dataset_file.read())
         self.dataset_file.close()
+
+    def setup_method(self, method):
+        """Creates and populates an index before each test is run"""
+        self.index = self.client.create_index(uid='indexUID-' + method.__name__)
         response = self.index.add_documents(self.dataset_json, primary_key='id')
         self.index.wait_for_pending_update(response['updateId'])
+
+    def teardown_method(self, method):
+        self.client.get_index('indexUID-' + method.__name__).delete()
+
+    def teardown_class(self):
+        """Cleans all indexes in MEiliSearch when all the test are done"""
+        clear_all_indexes(self.client)
 
     def test_dump_creation(self):
         """Tests the creation of a MeiliSearch dump"""

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -1,0 +1,44 @@
+import pytest
+import meilisearch
+import json
+import time
+from meilisearch.tests import BASE_URL, MASTER_KEY, clear_all_indexes
+
+class TestClientDumps:
+
+    """ TESTS: Client dumps creation and status """
+
+    client = meilisearch.Client(BASE_URL, MASTER_KEY)
+    index = None
+    dataset_file = None
+    dataset_json = None
+
+    def setup_class(self):
+        clear_all_indexes(self.client)
+        self.index = self.client.create_index(uid='indexUID')
+        self.dataset_file = open('./datasets/small_movies.json', 'r')
+        self.dataset_json = json.loads(self.dataset_file.read())
+        self.dataset_file.close()
+
+    def test_dump_creation(self):
+        """Tests the creation of a MeiliSearch dump"""
+        dump = self.client.create_dump()
+        assert dump['uid'] is not None
+        assert dump['status'] is not None
+        assert dump['status'] == 'processing'
+
+    def test_dump_status_route(self):
+        """Tests the route for getting a MeiliSearch dump status"""
+        response = self.index.add_documents(self.dataset_json, primary_key='id')
+        self.index.wait_for_pending_update(response['updateId'])
+        dump = self.client.create_dump()
+        assert dump['uid'] is not None
+        assert dump['status'] is not None
+        dump_status = self.client.get_dump_status(dump['uid'])
+        assert dump_status['uid'] is not None
+        assert dump_status['status'] is not None
+        assert dump_status['status'] == 'processing'
+        while dump_status['status'] == 'processing':
+            time.sleep(0.1)
+            dump_status = self.client.get_dump_status(dump['uid'])
+        assert dump_status['status'] == 'done'

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -1,7 +1,9 @@
 import json
 import time
+import pytest
 import meilisearch
 from meilisearch.tests import BASE_URL, MASTER_KEY, clear_all_indexes
+from meilisearch.errors import MeiliSearchApiError
 
 class TestClientDumps:
 
@@ -39,3 +41,8 @@ class TestClientDumps:
             time.sleep(0.1)
             dump_status = self.client.get_dump_status(dump['uid'])
         assert dump_status['status'] == 'done'
+
+    def test_dump_status_nonexistent_uid_raises_error(self):
+        """Tests the route for getting a nonexistent dump status"""
+        with pytest.raises(MeiliSearchApiError):
+            self.client.get_dump_status('uid_not_exists')

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -1,8 +1,7 @@
 import json
-import time
 import pytest
 import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY, clear_all_indexes
+from meilisearch.tests import BASE_URL, MASTER_KEY, clear_all_indexes, wait_for_dump_creation
 from meilisearch.errors import MeiliSearchApiError
 
 class TestClientDumps:
@@ -37,10 +36,7 @@ class TestClientDumps:
         dump_status = self.client.get_dump_status(dump['uid'])
         assert dump_status['uid'] is not None
         assert dump_status['status'] == 'processing'
-        while dump_status['status'] == 'processing':
-            time.sleep(0.1)
-            dump_status = self.client.get_dump_status(dump['uid'])
-        assert dump_status['status'] == 'done'
+        wait_for_dump_creation(self.client, dump_status['uid'])
 
     def test_dump_status_nonexistent_uid_raises_error(self):
         """Tests the route for getting a nonexistent dump status"""

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -19,24 +19,25 @@ class TestClientDumps:
         self.dataset_file = open('./datasets/small_movies.json', 'r')
         self.dataset_json = json.loads(self.dataset_file.read())
         self.dataset_file.close()
+        response = self.index.add_documents(self.dataset_json, primary_key='id')
+        self.index.wait_for_pending_update(response['updateId'])
 
     def test_dump_creation(self):
         """Tests the creation of a MeiliSearch dump"""
         dump = self.client.create_dump()
         assert dump['uid'] is not None
         assert dump['status'] == 'processing'
+        wait_for_dump_creation(self.client, dump['uid'])
 
     def test_dump_status_route(self):
         """Tests the route for getting a MeiliSearch dump status"""
-        response = self.index.add_documents(self.dataset_json, primary_key='id')
-        self.index.wait_for_pending_update(response['updateId'])
         dump = self.client.create_dump()
         assert dump['uid'] is not None
         assert dump['status'] == 'processing'
         dump_status = self.client.get_dump_status(dump['uid'])
         assert dump_status['uid'] is not None
         assert dump_status['status'] == 'processing'
-        wait_for_dump_creation(self.client, dump_status['uid'])
+        wait_for_dump_creation(self.client, dump['uid'])
 
     def test_dump_status_nonexistent_uid_raises_error(self):
         """Tests the route for getting a nonexistent dump status"""

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -1,7 +1,6 @@
-import pytest
-import meilisearch
 import json
 import time
+import meilisearch
 from meilisearch.tests import BASE_URL, MASTER_KEY, clear_all_indexes
 
 class TestClientDumps:

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -23,7 +23,6 @@ class TestClientDumps:
         """Tests the creation of a MeiliSearch dump"""
         dump = self.client.create_dump()
         assert dump['uid'] is not None
-        assert dump['status'] is not None
         assert dump['status'] == 'processing'
 
     def test_dump_status_route(self):
@@ -32,10 +31,9 @@ class TestClientDumps:
         self.index.wait_for_pending_update(response['updateId'])
         dump = self.client.create_dump()
         assert dump['uid'] is not None
-        assert dump['status'] is not None
+        assert dump['status'] == 'processing'
         dump_status = self.client.get_dump_status(dump['uid'])
         assert dump_status['uid'] is not None
-        assert dump_status['status'] is not None
         assert dump_status['status'] == 'processing'
         while dump_status['status'] == 'processing':
             time.sleep(0.1)


### PR DESCRIPTION
As stated in https://github.com/meilisearch/integration-guides/issues/44, SDKs should implement the `dump` feature, by adding 2 new routes, testing and adding code samples