### PR TITLE
Expect dump status to exist, without expecting a specific value

### DIFF
--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -46,7 +46,7 @@ class TestClientDumps:
         assert dump['status'] == 'processing'
         dump_status = self.client.get_dump_status(dump['uid'])
         assert dump_status['uid'] is not None
-        assert dump_status['status'] == 'processing'
+        assert dump_status['status'] is not None
         wait_for_dump_creation(self.client, dump['uid'])
 
     def test_dump_status_nonexistent_uid_raises_error(self):


### PR DESCRIPTION
When testing `get_dump_status` method, we should only check if the status is present in the response, but not expecting to have a specific value, as this can introduce random fails depending on the dump creation performance at every single execution.