### PR TITLE
Add custom search section in Getting Started

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Output:
 
 #### Custom Search <!-- omit in toc -->
 
-All the supported options are described in [this documentation section](https://docs.meilisearch.com/guides/advanced_guides/search_parameters.html).
+All the supported options are described in [the search parameters documentation section](https://docs.meilisearch.com/guides/advanced_guides/search_parameters.html).
 
 ```python
 index.search(

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ index.add_documents(documents) # => { "updateId": 0 }
 
 With the `updateId`, you can check the status (`processed` or `failed`) of your documents addition thanks to this [method](https://docs.meilisearch.com/references/updates.html#get-an-update-status).
 
-#### Search in index <!-- omit in toc -->
+#### Basic Search <!-- omit in toc -->
 
 ``` python
 # MeiliSearch is typo-tolerant:
@@ -95,6 +95,29 @@ Output:
   "limit" => 20,
   "processingTimeMs" => 1,
   "query" => "harry pottre"
+}
+```
+
+#### Custom Search <!-- omit in toc -->
+
+All the supported options are described in [this documentation section](https://docs.meilisearch.com/guides/advanced_guides/search_parameters.html).
+
+```python
+index.search('prince', { 'limit': 1 })
+```
+
+```json
+{
+    "hits": [
+        {
+            "book_id": 456,
+            "title": "Le Petit Prince"
+        }
+    ],
+    "offset": 0,
+    "limit": 1,
+    "processingTimeMs": 10,
+    "query": "prince"
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,13 @@ Output:
 All the supported options are described in [this documentation section](https://docs.meilisearch.com/guides/advanced_guides/search_parameters.html).
 
 ```python
-index.search('prince', { 'limit': 1 })
+index.search(
+  'prince',
+  {
+    'limit': 1,
+    'attributesToHighlight': ['title']
+  }
+)
 ```
 
 ```json
@@ -111,7 +117,11 @@ index.search('prince', { 'limit': 1 })
     "hits": [
         {
             "book_id": 456,
-            "title": "Le Petit Prince"
+            "title": "Le Petit Prince",
+            "_formatted": {
+                "book_id": 456,
+                "title": "Le Petit <em>Prince</em>"
+            }
         }
     ],
     "offset": 0,


### PR DESCRIPTION
Some time ago, some users in the PHP and JS SDKs told us the custom search is not that easy to apprehend. An example + a link to the docs might be useful for python users too 🙂