### PR TITLE
Changes about the MeiliSearch's next release (v0.16.0)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -154,8 +154,6 @@ get_indexes_stats_1: |-
   client.get_all_stats()
 get_health_1: |-
   client.health()
-update_health_1: |-
-  client.update_health()
 get_version_1: |-
   clien.get_version()
 get_pretty_sys_info_1: |-

--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ JSON output:
 
 ## 🤖 Compatibility with MeiliSearch
 
-This package only guarantees the compatibility with the [version v0.15.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.15.0).
+This package only guarantees the compatibility with the [version v0.16.0 of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.16.0).
 
 ## 💡 Learn More
 

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -132,18 +132,6 @@ class Client():
         """
         return self.http.get(self.config.paths.health)
 
-    def update_health(self, health):
-        """Update health of meilisearch
-
-        Update health of MeiliSearch to true or false.
-
-        Parameters
-        ----------
-        health: bool
-            Boolean representing the health status of MeiliSearch. True for healthy.
-        """
-        return self.http.put(self.config.paths.health, {'health': health})
-
     def get_keys(self):
         """Get all keys created
 

--- a/meilisearch/tests/__init__.py
+++ b/meilisearch/tests/__init__.py
@@ -10,6 +10,6 @@ def clear_all_indexes(client):
 
 def wait_for_dump_creation(client, dump_uid):
     dump_status = client.get_dump_status(dump_uid)
-    while dump_status['status'] == 'processing':
+    while dump_status['status'] == 'in_progress':
         time.sleep(0.1)
         dump_status = client.get_dump_status(dump_uid)

--- a/meilisearch/tests/client/test_client.py
+++ b/meilisearch/tests/client/test_client.py
@@ -12,7 +12,7 @@ class TestClient:
         client = meilisearch.Client(BASE_URL, MASTER_KEY)
         assert client.config
         response = client.health()
-        assert response.status_code == 200
+        assert response.status_code < 400
 
     @staticmethod
     def test_get_client_without_master_key():

--- a/meilisearch/tests/client/test_client.py
+++ b/meilisearch/tests/client/test_client.py
@@ -12,7 +12,7 @@ class TestClient:
         client = meilisearch.Client(BASE_URL, MASTER_KEY)
         assert client.config
         response = client.health()
-        assert response.status_code < 400
+        assert response.status_code >= 200 and response.status_code < 400
 
     @staticmethod
     def test_get_client_without_master_key():

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -36,14 +36,14 @@ class TestClientDumps:
         """Tests the creation of a MeiliSearch dump"""
         dump = self.client.create_dump()
         assert dump['uid'] is not None
-        assert dump['status'] == 'processing'
+        assert dump['status'] == 'in_progress'
         wait_for_dump_creation(self.client, dump['uid'])
 
     def test_dump_status_route(self):
         """Tests the route for getting a MeiliSearch dump status"""
         dump = self.client.create_dump()
         assert dump['uid'] is not None
-        assert dump['status'] == 'processing'
+        assert dump['status'] == 'in_progress'
         dump_status = self.client.get_dump_status(dump['uid'])
         assert dump_status['uid'] is not None
         assert dump_status['status'] is not None

--- a/meilisearch/tests/client/test_client_health_meilisearch.py
+++ b/meilisearch/tests/client/test_client_health_meilisearch.py
@@ -10,4 +10,4 @@ class TestHealth:
     def test_health(self):
         """Tests checking the health of MeiliSearch instance"""
         response = self.client.health()
-        assert response.status_code == 200
+        assert response.status_code == 204

--- a/meilisearch/tests/client/test_client_health_meilisearch.py
+++ b/meilisearch/tests/client/test_client_health_meilisearch.py
@@ -10,4 +10,4 @@ class TestHealth:
     def test_health(self):
         """Tests checking the health of MeiliSearch instance"""
         response = self.client.health()
-        assert response.status_code == 204
+        assert response.status_code >= 200 and response.status_code < 400


### PR DESCRIPTION
Related to this issue: meilisearch/integration-guides#52

- [x] Update README
- [x] Remove `update_health` method 

This PR:
- gathers the changes related to the next release of MeiliSearch (v0.16.0) so that this package is ready when the official release is out.
- should pass the tests against the [latest prerelease of MeiliSearch](https://github.com/meilisearch/MeiliSearch/releases). This should be tested locally.
- might eventually fail until the MeiliSearch v0.16.0 is out.

⚠️ This PR should NOT be merged until the MeiliSearch's next release (v0.16.0) is out.