### PR TITLE
Changes due to the implicit index creation

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -5,6 +5,9 @@
 ---
 get_one_index_1: |-
   index = client.get_index('movies')
+  # Or
+  index = client.index('movies').fetch_info()
+
   index.uid
   index.primary_key
 list_all_indexes_1: |-

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -4,21 +4,23 @@
 # You can read more on https://github.com/meilisearch/documentation/tree/master/.vuepress/code-samples
 ---
 get_one_index_1: |-
-  client.get_index('movies').info()
+  index = client.get_index('movies')
+  index.uid
+  index.primary_key
 list_all_indexes_1: |-
   client.get_indexes()
 create_an_index_1: |-
   client.create_index('movies', {'primaryKey': 'movie_id'})
 update_an_index_1: |-
-  client.get_index('movies').update(primaryKey='movie_review_id')
+  client.index('movies').update(primaryKey='movie_review_id')
 delete_an_index_1: |-
-  client.get_index('movies').delete()
+  client.index('movies').delete()
 get_one_document_1: |-
-  client.get_index('movies').get_document(25684)
+  client.index('movies').get_document(25684)
 get_documents_1: |-
-  client.get_index('movies').get_documents({'limit':2})
+  client.index('movies').get_documents({'limit':2})
 add_or_replace_documents_1: |-
-  client.get_index('movies').add_documents([{
+  client.index('movies').add_documents([{
     'id': 287947,
     'title': 'Shazam',
     'poster': 'https://image.tmdb.org/t/p/w1280/xnopI5Xtky18MPhK40cZAGAOVeV.jpg',
@@ -26,29 +28,29 @@ add_or_replace_documents_1: |-
     'release_date': '2019-03-23'
   }])
 add_or_update_documents_1: |-
-  client.get_index('movies').update_documents([{
+  client.index('movies').update_documents([{
       'id': 287947,
       'title': 'Shazam ⚡️',
       'genres': 'comedy'
   }])
 delete_all_documents_1: |-
-  client.get_index('movies').delete_all_documents()
+  client.index('movies').delete_all_documents()
 delete_one_document_1: |-
-  client.get_index('movies').delete_document(25684)
+  client.index('movies').delete_document(25684)
 delete_documents_1: |-
-  client.get_index('movies').delete_documents([23488, 153738, 437035, 363869])
+  client.index('movies').delete_documents([23488, 153738, 437035, 363869])
 search_1: |-
-  client.get_index('movies').search('American ninja')
+  client.index('movies').search('American ninja')
 get_update_1: |-
-  client.get_index('movies').get_update_status(1)
+  client.index('movies').get_update_status(1)
 get_all_updates_1: |-
-  client.get_index('movies').get_all_update_status()
+  client.index('movies').get_all_update_status()
 get_keys_1: |-
   client.get_keys()
 get_settings_1: |-
-  client.get_index('movies').get_settings()
+  client.index('movies').get_settings()
 update_settings_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'rankingRules': [
         'typo',
         'words',
@@ -88,27 +90,27 @@ update_settings_1: |-
     'acceptNewFields': False
   })
 reset_settings_1: |-
-  client.get_index('movies').reset_settings()
+  client.index('movies').reset_settings()
 get_synonyms_1: |-
-  client.get_index('movies').get_synonyms()
+  client.index('movies').get_synonyms()
 update_synonyms_1: |-
-  client.get_index('movies').update_synonyms({
+  client.index('movies').update_synonyms({
     'wolverine': ['xmen', 'logan'],
     'logan': ['wolverine', 'xmen'],
     'wow': ['world of warcraft']
   })
 reset_synonyms_1: |-
-  client.get_index('movies').reset_synonyms()
+  client.index('movies').reset_synonyms()
 get_stop_words_1: |-
-  client.get_index('movies').get_stop_words()
+  client.index('movies').get_stop_words()
 update_stop_words_1: |-
-  client.get_index('movies').update_stop_words(['of', 'the', 'to'])
+  client.index('movies').update_stop_words(['of', 'the', 'to'])
 reset_stop_words_1: |-
-  client.get_index('movies').reset_stop_words()
+  client.index('movies').reset_stop_words()
 get_ranking_rules_1: |-
-  client.get_index('movies').get_ranking_rules()
+  client.index('movies').get_ranking_rules()
 update_ranking_rules_1: |-
-  client.get_index('movies').update_ranking_rules([
+  client.index('movies').update_ranking_rules([
       'typo',
       'words',
       'proximity',
@@ -119,27 +121,27 @@ update_ranking_rules_1: |-
       'desc(rank)'
   ])
 reset_ranking_rules_1: |-
-  client.get_index('movies').reset_ranking_rules()
+  client.index('movies').reset_ranking_rules()
 get_distinct_attribute_1: |-
-  client.get_index('movies').get_distinct_attribute()
+  client.index('movies').get_distinct_attribute()
 update_distinct_attribute_1: |-
-  client.get_index('movies').update_distinct_attribute('movie_id')
+  client.index('movies').update_distinct_attribute('movie_id')
 reset_distinct_attribute_1: |-
-  client.get_index('movies').reset_distinct_attribute()
+  client.index('movies').reset_distinct_attribute()
 get_searchable_attributes_1: |-
-  client.get_index('movies').get_searchable_attributes()
+  client.index('movies').get_searchable_attributes()
 update_searchable_attributes_1: |-
-  client.get_index('movies').update_searchable_attributes([
+  client.index('movies').update_searchable_attributes([
       'title',
       'description',
       'uid'
   ])
 reset_searchable_attributes_1: |-
-  client.get_index('movies').reset_searchable_attributes()
+  client.index('movies').reset_searchable_attributes()
 get_displayed_attributes_1: |-
-  client.get_index('movies').get_displayed_attributes()
+  client.index('movies').get_displayed_attributes()
 update_displayed_attributes_1: |-
-  client.get_index('movies').update_displayed_attributes([
+  client.index('movies').update_displayed_attributes([
       "title",
       'description',
       'release_date',
@@ -147,22 +149,19 @@ update_displayed_attributes_1: |-
       'poster'
   ])
 reset_displayed_attributes_1: |-
-  client.get_index('movies').reset_displayed_attributes()
+  client.index('movies').reset_displayed_attributes()
 get_index_stats_1: |-
-  client.get_index('movies').get_stats()
+  client.index('movies').get_stats()
 get_indexes_stats_1: |-
   client.get_all_stats()
 get_health_1: |-
   client.health()
 get_version_1: |-
   clien.get_version()
-get_pretty_sys_info_1: |-
-get_sys_info_1: |-
-  client.get_sys_info()
 distinct_attribute_guide_1: |-
-  client.get_index('jackets').update_settings({'distinctAttribute': 'product_id'})
+  client.index('jackets').update_settings({'distinctAttribute': 'product_id'})
 field_properties_guide_searchable_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'searchableAttributes': [
         'uid',
         'movie_id',
@@ -173,7 +172,7 @@ field_properties_guide_searchable_1: |-
         'rank'
   ]})
 field_properties_guide_displayed_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'displayedAttributes': [
         'title',
         'description',
@@ -182,67 +181,67 @@ field_properties_guide_displayed_1: |-
         'rank'
   ]})
 filtering_guide_1: |-
-  client.get_index('movies').search('Avengers', {
+  client.index('movies').search('Avengers', {
     'filters': 'release_date > 795484800'
   })
 filtering_guide_2: |-
-  client.get_index('movies').search('Batman', {
+  client.index('movies').search('Batman', {
     'filters': 'release_date > 795484800 AND (director = "Tim Burton" OR director = "Christopher Nolan")'
   })
 filtering_guide_3: |-
-  client.get_index('movies').search('horror', {
+  client.index('movies').search('horror', {
     'filters': 'director = "Jordan Peele"'
   })
 filtering_guide_4: |-
-  client.get_index('movies').search('Planet of the Apes', {
+  client.index('movies').search('Planet of the Apes', {
     'filters': 'rating >= 3 AND (NOT director = "Tim Burton")'
   })
 search_parameter_guide_query_1: |-
-  client.get_index('movies').search('shifu')
+  client.index('movies').search('shifu')
 search_parameter_guide_offset_1: |-
-  client.get_index('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     'offset': 1
   })
 search_parameter_guide_limit_1: |-
-  client.get_index('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     'limit': 2
   })
 search_parameter_guide_retrieve_1: |-
-  client.get_index('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     'attributesToRetrieve': ['overview', 'title']
   })
 search_parameter_guide_crop_1: |-
-  client.get_index('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     'attributesToCrop': ['overview'],
     'cropLength': 10
   })
 search_parameter_guide_highlight_1: |-
-  client.get_index('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     'attributesToHighlight': ['overview']
   })
 search_parameter_guide_filter_1: |-
-  client.get_index('movies').search('n', {
+  client.index('movies').search('n', {
     'filters': 'title = Nightshift'
   })
 search_parameter_guide_filter_2: |-
-  client.get_index('movies').search('n', {
+  client.index('movies').search('n', {
     'filters': 'title = "Kung Fu Panda"'
   })
 search_parameter_guide_matches_1: |-
-  client.get_index('movies').search('n', {
+  client.index('movies').search('n', {
     'filters': 'title = "Kung Fu Panda"',
     'attributesToHighlight': ['overview'],
     'matches': 'true'
   })
 settings_guide_synonyms_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'synonyms': {
       sweater: ['jumper'],
       jumper: ['sweater']
     },
   })
 settings_guide_stop_words_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'stopWords': [
         'the',
         'a',
@@ -250,7 +249,7 @@ settings_guide_stop_words_1: |-
     ],
   })
 settings_guide_ranking_rules_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'rankingRules': [
         'typo',
         'words',
@@ -263,11 +262,11 @@ settings_guide_ranking_rules_1: |-
     ]
   })
 settings_guide_distinct_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'distinctAttribute': 'product_id'
   })
 settings_guide_searchable_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'searchableAttributes': [
       'uid',
       'movie_id',
@@ -279,7 +278,7 @@ settings_guide_searchable_1: |-
     ]
   })
 settings_guide_displayed_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'displayedAttributes': [
       'title',
       'description',
@@ -289,17 +288,17 @@ settings_guide_displayed_1: |-
     ]
   })
 documents_guide_add_movie_1: |-
-  client.get_index('movies').add_documents([{
+  client.index('movies').add_documents([{
     'movie_id': '123sq178',
     'title': 'Amélie Poulain'
   }])
 search_guide_1: |-
-  client.get_index('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     'limit': 5,
     'offset': 10
   })
 search_guide_2: |-
-  client.get_index('movies').search('Avengers', {
+  client.index('movies').search('Avengers', {
     'filters': 'release_date > 795484800'
   })
 getting_started_create_index_md: |-
@@ -332,31 +331,31 @@ getting_started_search_md: |-
 
   [About this package](https://github.com/meilisearch/meilisearch-python/)
 faceted_search_update_settings_1: |-
-  client.get_index('movies').update_attributes_for_faceting([
+  client.index('movies').update_attributes_for_faceting([
       'director',
       'genres',
   ])
 faceted_search_facet_filters_1: |-
-  client.get_index('movies').search('thriller', {
+  client.index('movies').search('thriller', {
     'facetFilters': [['genres:Horror', 'genres:Mystery'], 'director:Jordan Peele']
   })
 faceted_search_facets_distribution_1: |-
-  client.get_index('movies').search('Batman', {
+  client.index('movies').search('Batman', {
     'facetsDistribution': ['genres']
   })
 faceted_search_walkthrough_attributes_for_faceting_1: |-
-  client.get_index('movies').update_attributes_for_faceting([
+  client.index('movies').update_attributes_for_faceting([
       'director',
       'producer',
       'genres',
       'production_companies'
   ])
 faceted_search_walkthrough_facet_filters_1: |-
-  client.get_index('movies').search('thriller', {
+  client.index('movies').search('thriller', {
     'facetFilters': [['genres:Horror', 'genres:Mystery'], 'director:Jordan Peele']
   })
 faceted_search_walkthrough_facets_distribution_1: |-
-  client.get_index('movies').search('Batman', {
+  client.index('movies').search('Batman', {
     'facetsDistribution': ['genres']
   })
 post_dump_1: |-

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ NB: you can also download MeiliSearch from **Homebrew** or **APT**.
 import meilisearch
 
 client = meilisearch.Client('http://127.0.0.1:7700', 'masterKey')
-index = client.create_index('books') # If your index does not exist
-index = client.get_index('books')    # If you already created your index
+
+# An index is where the documents are stored.
+index = client.index('books')
 
 documents = [
   { 'book_id': 123,  'title': 'Pride and Prejudice' },
@@ -79,6 +80,7 @@ documents = [
   { 'book_id': 42,   'title': 'The Hitchhiker\'s Guide to the Galaxy' }
 ]
 
+# If the index 'books' does not exist, MeiliSearch creates it when you first add the documents.
 index.add_documents(documents) # => { "updateId": 0 }
 ```
 

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -60,7 +60,7 @@ class Client():
         list
             List of indexes in dictionnary format. (e.g [{ 'uid': 'movies' 'primaryKey': 'objectID' }])
         """
-        return Index.list_all(self.config)
+        return Index.get_indexes(self.config)
 
     def get_index(self, uid):
         """Get the index.

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -32,14 +32,14 @@ class Client():
         Parameters
         ----------
         uid: str
-            UID of the index.
+            UID of the index
         options: dict, optional
-            Options passed during index creation (ex: primaryKey).
+            Options passed during index creation (ex: primaryKey)
 
         Returns
         -------
         index : Index
-            An instance of Index containing the information of the newly created index.
+            an instance of Index containing the information of the newly created index
         Raises
         ------
         HTTPError
@@ -57,8 +57,8 @@ class Client():
             In case of any error found here https://docs.meilisearch.com/references/#errors-status-code
         Returns
         -------
-        indexes: list
-            List of indexes in dictionary format. (e.g [{ 'uid': 'movies' 'primaryKey': 'objectID' }])
+        list
+            List of indexes in dictionnary format. (e.g [{ 'uid': 'movies' 'primaryKey': 'objectID' }])
         """
         return Index.list_all(self.config)
 
@@ -133,30 +133,29 @@ class Client():
 
         Get information about database size and all indexes
         https://docs.meilisearch.com/references/stats.html
-
         Returns
-        -------
+        ----------
         stats: `dict`
-            Dictionary containing stats about your MeiliSearch instance.
+            Dictionnary containing stats about your MeiliSearch instance
         """
         return self.http.get(self.config.paths.stat)
 
     def health(self):
-        """Get health of the MeiliSearch server.
+        """Get health of MeiliSearch
 
         `204` HTTP status response when MeiliSearch is healthy.
 
         Raises
         ----------
         HTTPError
-            If MeiliSearch is not healthy.
+            If MeiliSearch is not healthy
         """
         return self.http.get(self.config.paths.health)
 
     def get_keys(self):
-        """Get all keys.
+        """Get all keys created
 
-        Get list of all the keys.
+        Get list of all the keys that were created and all their related information.
 
         Returns
         ----------
@@ -187,7 +186,7 @@ class Client():
         return self.get_version()
 
     def create_dump(self):
-        """Trigger the creation of a MeiliSearch dump.
+        """Triggers the creation of a MeiliSearch dump
 
         Returns
         ----------
@@ -198,15 +197,15 @@ class Client():
         return self.http.post(self.config.paths.dumps)
 
     def get_dump_status(self, uid):
-        """Retrieve the status of a MeiliSearch dump creation.
+        """Retrieves the status of a MeiliSearch dump creation
 
         Parameters
         ----------
         uid: str
-            UID of the dump.
+            UID of the dump
 
         Returns
-        -------
+        ----------
         Dump status: dict
             Information about the dump status.
             https://docs.meilisearch.com/references/dump.html#get-dump-status

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -58,7 +58,7 @@ class Client():
         Returns
         -------
         indexes: list
-            List of indexes in dictionnary format. (e.g [{ 'uid': 'movies' 'primaryKey': 'objectID' }])
+            List of indexes in dictionary format. (e.g [{ 'uid': 'movies' 'primaryKey': 'objectID' }])
         """
         return Index.list_all(self.config)
 
@@ -78,7 +78,7 @@ class Client():
         Returns
         -------
         index : Index
-            An Index instance containing the information the fetched index
+            An Index instance containing the information the fetched index.
         """
         index_dict = Index(self.config, uid).fetch_info()
         return Index(self.config, index_dict['uid'], index_dict['primaryKey'])
@@ -137,7 +137,7 @@ class Client():
         Returns
         -------
         stats: `dict`
-            Dictionnary containing stats about your MeiliSearch instance.
+            Dictionary containing stats about your MeiliSearch instance.
         """
         return self.http.get(self.config.paths.stat)
 
@@ -149,7 +149,7 @@ class Client():
         Raises
         ----------
         HTTPError
-            If MeiliSearch is not healthy
+            If MeiliSearch is not healthy.
         """
         return self.http.get(self.config.paths.health)
 
@@ -187,7 +187,7 @@ class Client():
         return self.get_version()
 
     def create_dump(self):
-        """Triggers the creation of a MeiliSearch dump.
+        """Trigger the creation of a MeiliSearch dump.
 
         Returns
         ----------
@@ -198,7 +198,7 @@ class Client():
         return self.http.post(self.config.paths.dumps)
 
     def get_dump_status(self, uid):
-        """Retrieves the status of a MeiliSearch dump creation.
+        """Retrieve the status of a MeiliSearch dump creation.
 
         Parameters
         ----------

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -32,14 +32,14 @@ class Client():
         Parameters
         ----------
         uid: str
-            UID of the index
+            UID of the index.
         options: dict, optional
-            Options passed during index creation (ex: primaryKey)
+            Options passed during index creation (ex: primaryKey).
 
         Returns
         -------
         index : Index
-            An instance of Index containing the information of the newly created index
+            An instance of Index containing the information of the newly created index.
         Raises
         ------
         HTTPError
@@ -57,7 +57,7 @@ class Client():
             In case of any error found here https://docs.meilisearch.com/references/#errors-status-code
         Returns
         -------
-        list
+        indexes: list
             List of indexes in dictionnary format. (e.g [{ 'uid': 'movies' 'primaryKey': 'objectID' }])
         """
         return Index.list_all(self.config)
@@ -65,6 +65,11 @@ class Client():
     def get_index(self, uid):
         """Get the index.
         This index should already exist.
+
+        Parameters
+        ----------
+        uid: str
+            UID of the index.
 
         Raises
         ------
@@ -82,10 +87,15 @@ class Client():
         """Create an Index instance.
         This method doesn't trigger any HTTP call.
 
+        Parameters
+        ----------
+        uid: str
+            UID of the index.
+
         Returns
         -------
         index : Index
-            An Index instance
+            An Index instance.
         """
         if uid is not None:
             return Index(self.config, uid=uid)
@@ -104,7 +114,7 @@ class Client():
         Returns
         -------
         index : Index
-            An instance of Index containing the information of the retrieved or newly created index
+            An instance of Index containing the information of the retrieved or newly created index.
         Raises
         ------
         HTTPError
@@ -123,15 +133,16 @@ class Client():
 
         Get information about database size and all indexes
         https://docs.meilisearch.com/references/stats.html
+
         Returns
-        ----------
+        -------
         stats: `dict`
-            Dictionnary containing stats about your MeiliSearch instance
+            Dictionnary containing stats about your MeiliSearch instance.
         """
         return self.http.get(self.config.paths.stat)
 
     def health(self):
-        """Get health of MeiliSearch
+        """Get health of the MeiliSearch server.
 
         `204` HTTP status response when MeiliSearch is healthy.
 
@@ -143,9 +154,9 @@ class Client():
         return self.http.get(self.config.paths.health)
 
     def get_keys(self):
-        """Get all keys created
+        """Get all keys.
 
-        Get list of all the keys that were created and all their related information.
+        Get list of all the keys.
 
         Returns
         ----------
@@ -176,7 +187,7 @@ class Client():
         return self.get_version()
 
     def create_dump(self):
-        """Triggers the creation of a MeiliSearch dump
+        """Triggers the creation of a MeiliSearch dump.
 
         Returns
         ----------
@@ -187,15 +198,15 @@ class Client():
         return self.http.post(self.config.paths.dumps)
 
     def get_dump_status(self, uid):
-        """Retrieves the status of a MeiliSearch dump creation
+        """Retrieves the status of a MeiliSearch dump creation.
 
         Parameters
         ----------
         uid: str
-            UID of the dump
+            UID of the dump.
 
         Returns
-        ----------
+        -------
         Dump status: dict
             Information about the dump status.
             https://docs.meilisearch.com/references/dump.html#get-dump-status

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -80,8 +80,7 @@ class Client():
         index : Index
             An Index instance containing the information the fetched index.
         """
-        index_dict = Index(self.config, uid).fetch_info()
-        return Index(self.config, index_dict['uid'], index_dict['primaryKey'])
+        return Index(self.config, uid).fetch_info()
 
     def index(self, uid):
         """Create an Index instance.

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -29,9 +29,6 @@ class Client():
     def create_index(self, uid, options=None):
         """Create an index.
 
-        If the argument `uid` isn't passed in, it will be generated
-        by MeiliSearch.
-
         Parameters
         ----------
         uid: str
@@ -42,15 +39,14 @@ class Client():
         Returns
         -------
         index : Index
-            an instance of Index containing the information of the newly created index
+            An instance of Index containing the information of the newly created index
         Raises
         ------
         HTTPError
             In case of any other error found here https://docs.meilisearch.com/references/#errors-status-code
         """
-        index = Index(self.config, uid)
-        index.create(self.config, uid, options)
-        return index
+        index_dict = Index.create(self.config, uid, options)
+        return Index(self.config, index_dict['uid'], index_dict['primaryKey'])
 
     def get_indexes(self):
         """Get all indexes.
@@ -64,11 +60,11 @@ class Client():
         list
             List of indexes in dictionnary format. (e.g [{ 'uid': 'movies' 'primaryKey': 'objectID' }])
         """
-        return Index.get_indexes(self.config)
-
+        return Index.list_all(self.config)
 
     def get_index(self, uid):
-        """Get an index.
+        """Get the index.
+        This index should already exist.
 
         Raises
         ------
@@ -77,9 +73,23 @@ class Client():
         Returns
         -------
         index : Index
-            an instance of Index containing the information of the index found
+            An Index instance containing the information the fetched index
         """
-        return Index.get_index(self.config, uid=uid)
+        index_dict = Index(self.config, uid).fetch_info()
+        return Index(self.config, index_dict['uid'], index_dict['primaryKey'])
+
+    def index(self, uid):
+        """Create an Index instance.
+        This method doesn't trigger any HTTP call.
+
+        Returns
+        -------
+        index : Index
+            An Index instance
+        """
+        if uid is not None:
+            return Index(self.config, uid=uid)
+        raise Exception('The index UID should not be None')
 
     def get_or_create_index(self, uid, options=None):
         """Get an index, or create it if it doesn't exist.
@@ -94,19 +104,19 @@ class Client():
         Returns
         -------
         index : Index
-            an instance of Index containing the information of the retrieved or newly created index
+            An instance of Index containing the information of the retrieved or newly created index
         Raises
         ------
         HTTPError
             In case of any other error found here https://docs.meilisearch.com/references/#errors-status-code
         """
-        index = self.get_index(uid)
+        index_instance = self.index(uid)
         try:
-            index.create(self.config, uid, options)
+            index_instance = self.create_index(uid, options)
         except MeiliSearchApiError as err:
             if err.error_code != 'index_already_exists':
                 raise err
-        return index
+        return index_instance
 
     def get_all_stats(self):
         """Get all stats of MeiliSearch

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -6,7 +6,7 @@ from meilisearch._httprequests import HttpRequests
 # pylint: disable=too-many-public-methods
 class Index():
     """
-    Indexes routes wrapper.
+    Indexes routes wrapper
 
     Index class gives access to all indexes routes and child routes (herited).
     https://docs.meilisearch.com/references/indexes.html
@@ -34,12 +34,13 @@ class Index():
         self.primary_key = primary_key
 
     def delete(self):
-        """Delete the index.
+        """Delete an index from meilisearch
 
-        Raises
-        ------
-        HTTPError
-            In case of any error found here https://docs.meilisearch.com/references/#errors-status-code
+        Returns
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
+            https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete('{}/{}'.format(self.config.paths.index, self.uid))
 
@@ -129,11 +130,11 @@ class Index():
         return HttpRequests(config).get(config.paths.index)
 
     def get_all_update_status(self):
-        """Get all update status
+        """Get all update status from MeiliSearch
 
         Returns
-        -------
-        update: list
+        ----------
+        update: `list`
             List of all enqueued and processed actions of the index.
         """
         return self.http.get(
@@ -145,15 +146,15 @@ class Index():
         )
 
     def get_update_status(self, update_id):
-        """Get one update status
+        """Get one update from MeiliSearch
 
         Parameters
         ----------
         update_id: int
             identifier of the update to retrieve
         Returns
-        -------
-        update: list
+        ----------
+        update: `list`
             List containing the details of the update status.
         """
         return self.http.get(
@@ -166,7 +167,7 @@ class Index():
         )
 
     def wait_for_pending_update(self, update_id, timeout_in_ms=5000, interval_in_ms=50):
-        """Wait until MeiliSearch processes an update, and get its status.
+        """Wait until MeiliSearch processes an update, and get its status
 
         Parameters
         ----------
@@ -177,8 +178,8 @@ class Index():
         interval_in_ms (optional): int
             time interval the method should wait (sleep) between requests
         Returns
-        -------
-        update: dict
+        ----------
+        update: `dict`
             Dictionary containing the details of the processed update status.
         """
         start_time = datetime.now()
@@ -193,14 +194,14 @@ class Index():
         raise TimeoutError
 
     def get_stats(self):
-        """Get stats of the index.
+        """Get stats of an index
 
         Get information about the number of documents, field frequencies, ...
         https://docs.meilisearch.com/references/stats.html
         Returns
-        -------
-        stats: dict
-            Dictionary containing stats about the given index.
+        ----------
+        stats: `dict`
+            Dictionnary containing stats about the given index.
         """
         return self.http.get(
             '{}/{}/{}'.format(
@@ -211,20 +212,19 @@ class Index():
         )
 
     def search(self, query, opt_params=None):
-        """Search in the index.
+        """Search in meilisearch
 
         Parameters
         ----------
         query: str
             String containing the searched word(s)
-        opt_params: dict, optional
-            Dictionary containing optional query parameters
+        opt_params: dict
+            Dictionnary containing optional query parameters
             https://docs.meilisearch.com/references/search.html#search-in-an-index
-
         Returns
-        -------
-        results: dict
-            Dictionary with hits, offset, limit, processingTime and initial query
+        ----------
+        results: `dict`
+            Dictionnary with hits, offset, limit, processingTime and initial query
         """
         if opt_params is None:
             opt_params = {}
@@ -241,17 +241,16 @@ class Index():
         )
 
     def get_document(self, document_id):
-        """Get one document with given document identifier.
+        """Get one document with given document identifier
 
         Parameters
         ----------
         document_id: str
             Unique identifier of the document.
-
         Returns
-        -------
-        document: dict
-            Dictionary containing the documents information.
+        ----------
+        document: `dict`
+            Dictionnary containing the documents information
         """
         return self.http.get(
             '{}/{}/{}/{}'.format(
@@ -263,17 +262,16 @@ class Index():
         )
 
     def get_documents(self, parameters=None):
-        """Get a set of documents from the index.
+        """Get a set of documents from the index
 
         Parameters
         ----------
         parameters (optional): dict
             parameters accepted by the get documents route: https://docs.meilisearch.com/references/documents.html#get-all-documents
-
         Returns
-        -------
-        document: dict
-            Dictionary containing the documents information.
+        ----------
+        document: `dict`
+            Dictionnary containing the documents information
         """
         if parameters is None:
             parameters = {}
@@ -287,19 +285,18 @@ class Index():
             )
 
     def add_documents(self, documents, primary_key=None):
-        """Add documents to the index.
+        """Add documents to the index
 
         Parameters
         ----------
         documents: list
-            List of documents. Each document should be a dictionary.
-        primary_key: string, optional
-            The primary-key used in index. Ignored if already set up.
-
+            List of dics containing each a document, or json string
+        primary_key: string
+            The primary-key used in MeiliSearch index. Ignored if already set up.
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         if primary_key is None:
@@ -318,19 +315,18 @@ class Index():
         return self.http.post(url, documents)
 
     def update_documents(self, documents, primary_key=None):
-        """Update documents in the index.
+        """Update documents in the index
 
         Parameters
         ----------
         documents: list
-            List of documents. Each document should be a dictionary.
-        primary_key: string, optional
-            The primary-key used in index. Ignored if already set up
-
+            List of dics containing each a document, or json string
+        primary_key: string
+            The primary-key used in MeiliSearch index. Ignored if already set up.
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         if primary_key is None:
@@ -350,17 +346,16 @@ class Index():
 
 
     def delete_document(self, document_id):
-        """Delete one document from the index.
+        """Add documents to the index
 
         Parameters
         ----------
         document_id: str
             Unique identifier of the document.
-
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -373,17 +368,16 @@ class Index():
         )
 
     def delete_documents(self, ids):
-        """Delete multiple documents from the index.
+        """Delete multiple documents of the index
 
         Parameters
         ----------
         list: list
             List of unique identifiers of documents.
-
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -396,12 +390,12 @@ class Index():
         )
 
     def delete_all_documents(self):
-        """Delete all documents from the index.
+        """Delete all documents of the index
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -416,14 +410,14 @@ class Index():
     # GENERAL SETTINGS ROUTES
 
     def get_settings(self):
-        """Get settings of the index.
+        """Get settings of an index
 
         https://docs.meilisearch.com/references/settings.html
 
         Returns
-        -------
-        settings: dict
-            Dictionary containing the settings of the index.
+        ----------
+        settings: `dict`
+            Dictionnary containing the settings of the index
         """
         return self.http.get(
             '{}/{}/{}'.format(
@@ -434,21 +428,20 @@ class Index():
         )
 
     def update_settings(self, body):
-        """Update settings of the index.
+        """Update settings of an index
 
         https://docs.meilisearch.com/references/settings.html#update-settings
-
         Parameters
         ----------
-        body: dict
-            Dictionary containing the settings of the index.
+        body: `dict`
+            Dictionnary containing the settings of the index
             More information:
             https://docs.meilisearch.com/references/settings.html#update-settings
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -461,14 +454,14 @@ class Index():
         )
 
     def reset_settings(self):
-        """Reset settings of the index to default values..
+        """Reset settings of an index to default values
 
         https://docs.meilisearch.com/references/settings.html#reset-settings
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -483,12 +476,12 @@ class Index():
 
     def get_ranking_rules(self):
         """
-        Get ranking rules of the index.
+        Get ranking rules of an index
 
         Returns
-        -------
-        settings: list
-            List containing the ranking rules of the index.
+        ----------
+        settings: `list`
+            List containing the ranking rules of the index
         """
         return self.http.get(
             self.__settings_url_for(self.config.paths.ranking_rules)
@@ -496,17 +489,17 @@ class Index():
 
     def update_ranking_rules(self, body):
         """
-        Update ranking rules of the index.
+        Update ranking rules of an index
 
         Parameters
         ----------
-        body: list
-            List containing the ranking rules.
+        body: `list`
+            List containing the ranking rules
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -515,12 +508,12 @@ class Index():
         )
 
     def reset_ranking_rules(self):
-        """Reset ranking rules of the index to default values.
+        """Reset ranking rules of an index to default values
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -532,12 +525,12 @@ class Index():
 
     def get_distinct_attribute(self):
         """
-        Get distinct attribute of the index.
+        Get distinct attribute of an index
 
         Returns
-        -------
-        settings: str
-            String containing the distinct attribute of the index.
+        ----------
+        settings: `str`
+            String containing the distinct attribute of the index
         """
         return self.http.get(
             self.__settings_url_for(self.config.paths.distinct_attribute)
@@ -545,17 +538,17 @@ class Index():
 
     def update_distinct_attribute(self, body):
         """
-        Update distinct attribute of the index.
+        Update distinct attribute of an index
 
         Parameters
         ----------
-        body: str
-            String containing the distinct attribute.
+        body: `str`
+            String containing the distinct attribute
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -564,12 +557,12 @@ class Index():
         )
 
     def reset_distinct_attribute(self):
-        """Reset distinct attribute of the index to default values.
+        """Reset distinct attribute of an index to default values
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -580,12 +573,12 @@ class Index():
 
     def get_searchable_attributes(self):
         """
-        Get searchable attributes of the index.
+        Get searchable attributes of an index
 
         Returns
-        -------
-        settings: list
-            List containing the searchable attributes of the index.
+        ----------
+        settings: `list`
+            List containing the searchable attributes of the index
         """
         return self.http.get(
             self.__settings_url_for(self.config.paths.searchable_attributes)
@@ -593,17 +586,17 @@ class Index():
 
     def update_searchable_attributes(self, body):
         """
-        Update searchable attributes of the index.
+        Update searchable attributes of an index
 
         Parameters
         ----------
-        body: list
-            List containing the searchable attributes.
+        body: `list`
+            List containing the searchable attributes
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -612,12 +605,12 @@ class Index():
         )
 
     def reset_searchable_attributes(self):
-        """Reset searchable attributes of the index to default values.
+        """Reset searchable attributes of an index to default values
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -628,12 +621,12 @@ class Index():
 
     def get_displayed_attributes(self):
         """
-        Get displayed attributes of the index.
+        Get displayed attributes of an index
 
         Returns
-        -------
-        settings: list
-            List containing the displayed attributes of the index.
+        ----------
+        settings: `list`
+            List containing the displayed attributes of the index
         """
         return self.http.get(
             self.__settings_url_for(self.config.paths.displayed_attributes)
@@ -641,17 +634,17 @@ class Index():
 
     def update_displayed_attributes(self, body):
         """
-        Update displayed attributes of the index.
+        Update displayed attributes of an index
 
         Parameters
         ----------
-        body: list
-            List containing the displayed attributes.
+        body: `list`
+            List containing the displayed attributes
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -660,12 +653,12 @@ class Index():
         )
 
     def reset_displayed_attributes(self):
-        """Reset displayed attributes of the index to default values.
+        """Reset displayed attributes of an index to default values
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -676,12 +669,12 @@ class Index():
 
     def get_stop_words(self):
         """
-        Get stop words of the index.
+        Get stop words of an index
 
         Returns
-        -------
-        settings: list
-            List containing the stop words of the index.
+        ----------
+        settings: `list`
+            List containing the stop words of the index
         """
         return self.http.get(
             self.__settings_url_for(self.config.paths.stop_words)
@@ -689,17 +682,17 @@ class Index():
 
     def update_stop_words(self, body):
         """
-        Update stop words of the index.
+        Update stop words of an index
 
         Parameters
         ----------
-        body: list
-            List containing the stop words.
+        body: `list`
+            List containing the stop words
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -708,12 +701,12 @@ class Index():
         )
 
     def reset_stop_words(self):
-        """Reset stop words of the index to default values.
+        """Reset stop words of an index to default values
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -724,12 +717,12 @@ class Index():
 
     def get_synonyms(self):
         """
-        Get synonyms of the index.
+        Get synonyms of an index
 
         Returns
-        -------
-        settings: dict
-            Dictionary containing the synonyms of the index.
+        ----------
+        settings: `dict`
+            Dictionnary containing the synonyms of the index
         """
         return self.http.get(
             self.__settings_url_for(self.config.paths.synonyms)
@@ -737,17 +730,17 @@ class Index():
 
     def update_synonyms(self, body):
         """
-        Update synonyms of the index.
+        Update synonyms of an index
 
         Parameters
         ----------
-        body: dict
-            Dictionary containing the synonyms.
+        body: `dict`
+            Dictionnary containing the synonyms
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -756,12 +749,12 @@ class Index():
         )
 
     def reset_synonyms(self):
-        """Reset synonyms of the index to default values.
+        """Reset synonyms of an index to default values
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -772,11 +765,11 @@ class Index():
 
     def get_attributes_for_faceting(self):
         """
-        Get attributes for faceting of the index.
+        Get attributes for faceting of an index
 
         Returns
-        -------
-        settings: list
+        ----------
+        settings: `list`
             List containing the attributes for faceting of the index
         """
         return self.http.get(
@@ -785,17 +778,17 @@ class Index():
 
     def update_attributes_for_faceting(self, body):
         """
-        Update attributes for faceting of the index.
+        Update attributes for faceting of an index
 
         Parameters
         ----------
-        body: list
-            List containing the attributes for faceting.
+        body: `list`
+            List containing the attributes for faceting
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -804,12 +797,12 @@ class Index():
         )
 
     def reset_attributes_for_faceting(self):
-        """Reset attributes for faceting of the index to default values.
+        """Reset attributes for faceting of an index to default values
 
         Returns
-        -------
-        update: dict
-            Dictionary containing an update id to track the action:
+        ----------
+        update: `dict`
+            Dictionnary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -71,12 +71,12 @@ class Index():
 
         Returns
         -------
-        index: dict
-            Dictionary containing the index information.
+        index : Index
+            An instance of Index containing the information of the index.
         """
         index_dict = self.http.get('{}/{}'.format(self.config.paths.index, self.uid))
         self.primary_key = index_dict['primaryKey']
-        return index_dict
+        return self
 
     def get_primary_key(self):
         """Get the primary key.
@@ -86,8 +86,7 @@ class Index():
         primary_key: str
             String containing the primary key.
         """
-        self.primary_key = self.fetch_info()['primaryKey']
-        return self.primary_key
+        return self.fetch_info().primary_key
 
     @staticmethod
     def create(config, uid, options=None):

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -24,9 +24,9 @@ class Index():
         config : Config
             Config object containing permission and location of MeiliSearch.
         uid: str
-            Uid of the index on which to perform the index actions.
-        index_path: str
-            Index url path.
+            UID of the index on which to perform the index actions.
+        primary_key: str, optional
+            Primary-key of the index.
         """
         self.config = config
         self.http = HttpRequests(config)
@@ -44,12 +44,13 @@ class Index():
         return self.http.delete('{}/{}'.format(self.config.paths.index, self.uid))
 
     def update(self, **body):
-        """Update the index.
+        """Update the index primary-key.
 
         Parameters
         ----------
         body: **kwargs
             Accepts primaryKey as an updatable parameter.
+            Ex: index.update(primaryKey='name')
 
         Returns
         -------
@@ -82,7 +83,7 @@ class Index():
         Returns
         -------
         primary_key: str
-            String containing primary key.
+            String containing the primary key.
         """
         self.primary_key = self.fetch_info()['primaryKey']
         return self.primary_key
@@ -114,12 +115,12 @@ class Index():
 
     @staticmethod
     def list_all(config):
-        """Get all indexes
+        """Get all indexes.
 
         Returns
         -------
         indexes : list
-            List of indexes. Each index is a dictionnary.
+            List of the indexes. Each index is a dictionnary.
         Raises
         ------
         HTTPError

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -6,7 +6,7 @@ from meilisearch._httprequests import HttpRequests
 # pylint: disable=too-many-public-methods
 class Index():
     """
-    Indexes routes wrapper
+    Indexes routes wrapper.
 
     Index class gives access to all indexes routes and child routes (herited).
     https://docs.meilisearch.com/references/indexes.html
@@ -21,7 +21,7 @@ class Index():
         """
         Parameters
         ----------
-        config : Config
+        config : dict
             Config object containing permission and location of MeiliSearch.
         uid: str
             UID of the index on which to perform the index actions.
@@ -54,8 +54,8 @@ class Index():
 
         Returns
         -------
-        index: `dict`
-            Dictionnary containing index information.
+        index: dict
+            Dictionary containing index information.
         """
         payload = {}
         primary_key = body.get('primaryKey', None)
@@ -70,8 +70,8 @@ class Index():
 
         Returns
         -------
-        index: `dict`
-            Dictionnary containing the index information.
+        index: dict
+            Dictionary containing the index information.
         """
         index_dict = self.http.get('{}/{}'.format(self.config.paths.index, self.uid))
         self.primary_key = index_dict['primaryKey']
@@ -90,7 +90,7 @@ class Index():
 
     @staticmethod
     def create(config, uid, options=None):
-        """Create an index.
+        """Create the index.
 
         Parameters
         ----------
@@ -120,7 +120,7 @@ class Index():
         Returns
         -------
         indexes : list
-            List of the indexes. Each index is a dictionnary.
+            List of the indexes. Each index is a dictionary.
         Raises
         ------
         HTTPError
@@ -132,8 +132,8 @@ class Index():
         """Get all update status
 
         Returns
-        ----------
-        update: `list`
+        -------
+        update: list
             List of all enqueued and processed actions of the index.
         """
         return self.http.get(
@@ -152,8 +152,8 @@ class Index():
         update_id: int
             identifier of the update to retrieve
         Returns
-        ----------
-        update: `list`
+        -------
+        update: list
             List containing the details of the update status.
         """
         return self.http.get(
@@ -166,7 +166,7 @@ class Index():
         )
 
     def wait_for_pending_update(self, update_id, timeout_in_ms=5000, interval_in_ms=50):
-        """Wait until MeiliSearch processes an update, and get its status
+        """Wait until MeiliSearch processes an update, and get its status.
 
         Parameters
         ----------
@@ -177,8 +177,8 @@ class Index():
         interval_in_ms (optional): int
             time interval the method should wait (sleep) between requests
         Returns
-        ----------
-        update: `dict`
+        -------
+        update: dict
             Dictionary containing the details of the processed update status.
         """
         start_time = datetime.now()
@@ -193,14 +193,14 @@ class Index():
         raise TimeoutError
 
     def get_stats(self):
-        """Get stats of an index
+        """Get stats of the index.
 
         Get information about the number of documents, field frequencies, ...
         https://docs.meilisearch.com/references/stats.html
         Returns
-        ----------
-        stats: `dict`
-            Dictionnary containing stats about the given index.
+        -------
+        stats: dict
+            Dictionary containing stats about the given index.
         """
         return self.http.get(
             '{}/{}/{}'.format(
@@ -211,19 +211,20 @@ class Index():
         )
 
     def search(self, query, opt_params=None):
-        """Search in the index
+        """Search in the index.
 
         Parameters
         ----------
         query: str
             String containing the searched word(s)
-        opt_params: dict
-            Dictionnary containing optional query parameters
+        opt_params: dict, optional
+            Dictionary containing optional query parameters
             https://docs.meilisearch.com/references/search.html#search-in-an-index
+
         Returns
-        ----------
-        results: `dict`
-            Dictionnary with hits, offset, limit, processingTime and initial query
+        -------
+        results: dict
+            Dictionary with hits, offset, limit, processingTime and initial query
         """
         if opt_params is None:
             opt_params = {}
@@ -240,16 +241,17 @@ class Index():
         )
 
     def get_document(self, document_id):
-        """Get one document with given document identifier
+        """Get one document with given document identifier.
 
         Parameters
         ----------
         document_id: str
             Unique identifier of the document.
+
         Returns
-        ----------
-        document: `dict`
-            Dictionnary containing the documents information
+        -------
+        document: dict
+            Dictionary containing the documents information.
         """
         return self.http.get(
             '{}/{}/{}/{}'.format(
@@ -261,16 +263,17 @@ class Index():
         )
 
     def get_documents(self, parameters=None):
-        """Get a set of documents from the index
+        """Get a set of documents from the index.
 
         Parameters
         ----------
         parameters (optional): dict
             parameters accepted by the get documents route: https://docs.meilisearch.com/references/documents.html#get-all-documents
+
         Returns
-        ----------
-        document: `dict`
-            Dictionnary containing the documents information
+        -------
+        document: dict
+            Dictionary containing the documents information.
         """
         if parameters is None:
             parameters = {}
@@ -284,18 +287,19 @@ class Index():
             )
 
     def add_documents(self, documents, primary_key=None):
-        """Add documents to the index
+        """Add documents to the index.
 
         Parameters
         ----------
         documents: list
-            List of dics containing each a document, or json string
-        primary_key: string
-            The primary-key used in MeiliSearch index. Ignored if already set up.
+            List of documents. Each document should be a dictionary.
+        primary_key: string, optional
+            The primary-key used in index. Ignored if already set up.
+
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         if primary_key is None:
@@ -314,18 +318,19 @@ class Index():
         return self.http.post(url, documents)
 
     def update_documents(self, documents, primary_key=None):
-        """Update documents in the index
+        """Update documents in the index.
 
         Parameters
         ----------
         documents: list
-            List of dics containing each a document, or json string
-        primary_key: string
-            The primary-key used in MeiliSearch index. Ignored if already set up.
+            List of documents. Each document should be a dictionary.
+        primary_key: string, optional
+            The primary-key used in index. Ignored if already set up
+
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         if primary_key is None:
@@ -345,16 +350,17 @@ class Index():
 
 
     def delete_document(self, document_id):
-        """Add documents to the index
+        """Delete one document from the index.
 
         Parameters
         ----------
         document_id: str
             Unique identifier of the document.
+
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -367,16 +373,17 @@ class Index():
         )
 
     def delete_documents(self, ids):
-        """Delete multiple documents of the index
+        """Delete multiple documents from the index.
 
         Parameters
         ----------
         list: list
             List of unique identifiers of documents.
+
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -389,12 +396,12 @@ class Index():
         )
 
     def delete_all_documents(self):
-        """Delete all documents of the index
+        """Delete all documents from the index.
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -409,14 +416,14 @@ class Index():
     # GENERAL SETTINGS ROUTES
 
     def get_settings(self):
-        """Get settings of an index
+        """Get settings of the index.
 
         https://docs.meilisearch.com/references/settings.html
 
         Returns
-        ----------
-        settings: `dict`
-            Dictionnary containing the settings of the index
+        -------
+        settings: dict
+            Dictionary containing the settings of the index.
         """
         return self.http.get(
             '{}/{}/{}'.format(
@@ -427,20 +434,21 @@ class Index():
         )
 
     def update_settings(self, body):
-        """Update settings of an index
+        """Update settings of the index.
 
         https://docs.meilisearch.com/references/settings.html#update-settings
+
         Parameters
         ----------
-        body: `dict`
-            Dictionnary containing the settings of the index
+        body: dict
+            Dictionary containing the settings of the index.
             More information:
             https://docs.meilisearch.com/references/settings.html#update-settings
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -453,14 +461,14 @@ class Index():
         )
 
     def reset_settings(self):
-        """Reset settings of an index to default values
+        """Reset settings of the index to default values..
 
         https://docs.meilisearch.com/references/settings.html#reset-settings
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -475,12 +483,12 @@ class Index():
 
     def get_ranking_rules(self):
         """
-        Get ranking rules of an index
+        Get ranking rules of the index.
 
         Returns
-        ----------
-        settings: `list`
-            List containing the ranking rules of the index
+        -------
+        settings: list
+            List containing the ranking rules of the index.
         """
         return self.http.get(
             self.__settings_url_for(self.config.paths.ranking_rules)
@@ -488,17 +496,17 @@ class Index():
 
     def update_ranking_rules(self, body):
         """
-        Update ranking rules of an index
+        Update ranking rules of the index.
 
         Parameters
         ----------
-        body: `list`
-            List containing the ranking rules
+        body: list
+            List containing the ranking rules.
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -507,12 +515,12 @@ class Index():
         )
 
     def reset_ranking_rules(self):
-        """Reset ranking rules of an index to default values
+        """Reset ranking rules of the index to default values.
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -524,12 +532,12 @@ class Index():
 
     def get_distinct_attribute(self):
         """
-        Get distinct attribute of an index
+        Get distinct attribute of the index.
 
         Returns
-        ----------
-        settings: `str`
-            String containing the distinct attribute of the index
+        -------
+        settings: str
+            String containing the distinct attribute of the index.
         """
         return self.http.get(
             self.__settings_url_for(self.config.paths.distinct_attribute)
@@ -537,17 +545,17 @@ class Index():
 
     def update_distinct_attribute(self, body):
         """
-        Update distinct attribute of an index
+        Update distinct attribute of the index.
 
         Parameters
         ----------
-        body: `str`
-            String containing the distinct attribute
+        body: str
+            String containing the distinct attribute.
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -556,12 +564,12 @@ class Index():
         )
 
     def reset_distinct_attribute(self):
-        """Reset distinct attribute of an index to default values
+        """Reset distinct attribute of the index to default values.
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -572,12 +580,12 @@ class Index():
 
     def get_searchable_attributes(self):
         """
-        Get searchable attributes of an index
+        Get searchable attributes of the index.
 
         Returns
-        ----------
-        settings: `list`
-            List containing the searchable attributes of the index
+        -------
+        settings: list
+            List containing the searchable attributes of the index.
         """
         return self.http.get(
             self.__settings_url_for(self.config.paths.searchable_attributes)
@@ -585,17 +593,17 @@ class Index():
 
     def update_searchable_attributes(self, body):
         """
-        Update searchable attributes of an index
+        Update searchable attributes of the index.
 
         Parameters
         ----------
-        body: `list`
-            List containing the searchable attributes
+        body: list
+            List containing the searchable attributes.
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -604,12 +612,12 @@ class Index():
         )
 
     def reset_searchable_attributes(self):
-        """Reset searchable attributes of an index to default values
+        """Reset searchable attributes of the index to default values.
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -620,12 +628,12 @@ class Index():
 
     def get_displayed_attributes(self):
         """
-        Get displayed attributes of an index
+        Get displayed attributes of the index.
 
         Returns
-        ----------
-        settings: `list`
-            List containing the displayed attributes of the index
+        -------
+        settings: list
+            List containing the displayed attributes of the index.
         """
         return self.http.get(
             self.__settings_url_for(self.config.paths.displayed_attributes)
@@ -633,17 +641,17 @@ class Index():
 
     def update_displayed_attributes(self, body):
         """
-        Update displayed attributes of an index
+        Update displayed attributes of the index.
 
         Parameters
         ----------
-        body: `list`
-            List containing the displayed attributes
+        body: list
+            List containing the displayed attributes.
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -652,12 +660,12 @@ class Index():
         )
 
     def reset_displayed_attributes(self):
-        """Reset displayed attributes of an index to default values
+        """Reset displayed attributes of the index to default values.
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -668,12 +676,12 @@ class Index():
 
     def get_stop_words(self):
         """
-        Get stop words of an index
+        Get stop words of the index.
 
         Returns
-        ----------
-        settings: `list`
-            List containing the stop words of the index
+        -------
+        settings: list
+            List containing the stop words of the index.
         """
         return self.http.get(
             self.__settings_url_for(self.config.paths.stop_words)
@@ -681,17 +689,17 @@ class Index():
 
     def update_stop_words(self, body):
         """
-        Update stop words of an index
+        Update stop words of the index.
 
         Parameters
         ----------
-        body: `list`
-            List containing the stop words
+        body: list
+            List containing the stop words.
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -700,12 +708,12 @@ class Index():
         )
 
     def reset_stop_words(self):
-        """Reset stop words of an index to default values
+        """Reset stop words of the index to default values.
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -716,12 +724,12 @@ class Index():
 
     def get_synonyms(self):
         """
-        Get synonyms of an index
+        Get synonyms of the index.
 
         Returns
-        ----------
-        settings: `dict`
-            Dictionnary containing the synonyms of the index
+        -------
+        settings: dict
+            Dictionary containing the synonyms of the index.
         """
         return self.http.get(
             self.__settings_url_for(self.config.paths.synonyms)
@@ -729,17 +737,17 @@ class Index():
 
     def update_synonyms(self, body):
         """
-        Update synonyms of an index
+        Update synonyms of the index.
 
         Parameters
         ----------
-        body: `dict`
-            Dictionnary containing the synonyms
+        body: dict
+            Dictionary containing the synonyms.
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -748,12 +756,12 @@ class Index():
         )
 
     def reset_synonyms(self):
-        """Reset synonyms of an index to default values
+        """Reset synonyms of the index to default values.
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(
@@ -764,11 +772,11 @@ class Index():
 
     def get_attributes_for_faceting(self):
         """
-        Get attributes for faceting of an index
+        Get attributes for faceting of the index.
 
         Returns
-        ----------
-        settings: `list`
+        -------
+        settings: list
             List containing the attributes for faceting of the index
         """
         return self.http.get(
@@ -777,17 +785,17 @@ class Index():
 
     def update_attributes_for_faceting(self, body):
         """
-        Update attributes for faceting of an index
+        Update attributes for faceting of the index.
 
         Parameters
         ----------
-        body: `list`
-            List containing the attributes for faceting
+        body: list
+            List containing the attributes for faceting.
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.post(
@@ -796,12 +804,12 @@ class Index():
         )
 
     def reset_attributes_for_faceting(self):
-        """Reset attributes for faceting of an index to default values
+        """Reset attributes for faceting of the index to default values.
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
+        -------
+        update: dict
+            Dictionary containing an update id to track the action:
             https://docs.meilisearch.com/references/updates.html#get-an-update-status
         """
         return self.http.delete(

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -114,13 +114,13 @@ class Index():
         return HttpRequests(config).post(config.paths.index, payload)
 
     @staticmethod
-    def list_all(config):
-        """Get all indexes.
+    def get_indexes(config):
+        """Get all indexes from meilisearch.
 
         Returns
         -------
         indexes : list
-            List of the indexes. Each index is a dictionary.
+            List of indexes (dict)
         Raises
         ------
         HTTPError

--- a/meilisearch/tests/__init__.py
+++ b/meilisearch/tests/__init__.py
@@ -6,7 +6,7 @@ BASE_URL = 'http://127.0.0.1:7700'
 def clear_all_indexes(client):
     indexes = client.get_indexes()
     for index in indexes:
-        client.get_index(index['uid']).delete()
+        client.index(index['uid']).delete()
 
 def wait_for_dump_creation(client, dump_uid):
     dump_status = client.get_dump_status(dump_uid)

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -29,7 +29,7 @@ class TestClientDumps:
         self.client.index('indexUID-' + method.__name__).delete()
 
     def teardown_class(self):
-        """Cleans all indexes in MeiliSearch when all the test are done"""
+        """Cleans all indexes in MeiliSearch when all the tests are done"""
         clear_all_indexes(self.client)
 
     def test_dump_creation(self):

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -29,7 +29,7 @@ class TestClientDumps:
         self.client.index('indexUID-' + method.__name__).delete()
 
     def teardown_class(self):
-        """Cleans all indexes in MeiliSearch when all the tests are done"""
+        """Cleans all indexes in MEiliSearch when all the test are done"""
         clear_all_indexes(self.client)
 
     def test_dump_creation(self):

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -26,10 +26,10 @@ class TestClientDumps:
         self.index.wait_for_pending_update(response['updateId'])
 
     def teardown_method(self, method):
-        self.client.get_index('indexUID-' + method.__name__).delete()
+        self.client.index('indexUID-' + method.__name__).delete()
 
     def teardown_class(self):
-        """Cleans all indexes in MEiliSearch when all the test are done"""
+        """Cleans all indexes in MeiliSearch when all the test are done"""
         clear_all_indexes(self.client)
 
     def test_dump_creation(self):

--- a/meilisearch/tests/index/test_index.py
+++ b/meilisearch/tests/index/test_index.py
@@ -20,6 +20,7 @@ class TestIndex:
         index = self.client.create_index(uid=self.index_uid)
         assert isinstance(index, object)
         assert index.uid == self.index_uid
+        assert index.primary_key is None
         assert index.get_primary_key() is None
 
     def test_create_index_with_primary_key(self):
@@ -27,6 +28,7 @@ class TestIndex:
         index = self.client.create_index(uid=self.index_uid2, options={'primaryKey': 'book_id'})
         assert isinstance(index, object)
         assert index.uid == self.index_uid2
+        assert index.primary_key == 'book_id'
         assert index.get_primary_key() == 'book_id'
 
     def test_create_index_with_uid_in_options(self):
@@ -34,6 +36,7 @@ class TestIndex:
         index = self.client.create_index(uid=self.index_uid3, options={'uid': 'wrong', 'primaryKey': 'book_id'})
         assert isinstance(index, object)
         assert index.uid == self.index_uid3
+        assert index.primary_key == 'book_id'
         assert index.get_primary_key() == 'book_id'
 
     def test_get_indexes(self):
@@ -46,7 +49,19 @@ class TestIndex:
         assert self.index_uid3 in uids
         assert len(response) == 3
 
-    def test_get_index_with_uid(self):
+    def test_index_with_any_uid(self):
+        index = self.client.index('anyUID')
+        assert isinstance(index, object)
+        assert index.uid == 'anyUID'
+        assert index.primary_key is None
+        assert index.config is not None
+        assert index.http is not None
+
+    def test_index_with_none_uid(self):
+        with pytest.raises(Exception):
+            self.client.index(None)
+
+    def test_get_index_with_valid_uid(self):
         """Tests getting one index with uid"""
         response = self.client.get_index(uid=self.index_uid)
         assert isinstance(response, object)
@@ -56,6 +71,11 @@ class TestIndex:
         """Test raising an exception if the index UID is None"""
         with pytest.raises(Exception):
             self.client.get_index(uid=None)
+
+    def test_get_index_with_wrong_uid(self):
+        """Tests get_index with an non-existing index"""
+        with pytest.raises(Exception):
+            self.client.get_index(uid='wrongUID')
 
     def test_get_or_create_index(self):
         """Test get_or_create_index method"""
@@ -73,60 +93,71 @@ class TestIndex:
         assert len(documents) == 1
         index_2.delete()
         with pytest.raises(Exception):
-            self.client.get_index(index_3).info()
+            self.client.get_index(index_3)
 
     def test_get_or_create_index_with_primary_key(self):
         """Test get_or_create_index method with primary key"""
         index_1 = self.client.get_or_create_index('books', {'primaryKey': self.index_uid4})
         index_2 = self.client.get_or_create_index('books', {'primaryKey': 'some_wrong_key'})
+        assert index_1.primary_key == self.index_uid4
         assert index_1.get_primary_key() == self.index_uid4
+        assert index_2.primary_key is None
         assert index_2.get_primary_key() == self.index_uid4
+        assert index_2.primary_key == self.index_uid4
         index_1.delete()
 
-    def test_index_info(self):
-        """Tests getting an index's info"""
-        index = self.client.get_index(uid=self.index_uid)
-        response = index.info()
+    def test_index_fetch_info(self):
+        """Tests getting the index info"""
+        index = self.client.index(uid=self.index_uid)
+        response = index.fetch_info()
         assert isinstance(response, object)
         assert response['uid'] == self.index_uid
         assert response['primaryKey'] is None
+        assert index.primary_key == response['primaryKey']
+        assert index.get_primary_key() == response['primaryKey']
 
-    def test_index_info_with_wrong_uid(self):
-        """Tests getting an index's info in MeiliSearch with a wrong UID"""
-        with pytest.raises(Exception):
-            self.client.get_index(uid='wrongUID').info()
+    def test_index_fetch_info_containing_primary_key(self):
+        """Tests getting the index info"""
+        index = self.client.index(uid=self.index_uid3)
+        response = index.fetch_info()
+        assert isinstance(response, object)
+        assert response['uid'] == self.index_uid3
+        assert response['primaryKey'] == 'book_id'
+        assert index.primary_key == response['primaryKey']
+        assert index.get_primary_key() == response['primaryKey']
 
     def test_get_primary_key(self):
         """Tests getting the primary-key of an index"""
-        index = self.client.get_index(uid=self.index_uid)
+        index = self.client.index(uid=self.index_uid3)
+        assert index.primary_key is None
         response = index.get_primary_key()
-        assert response is None
+        assert response == 'book_id'
+        assert index.primary_key == 'book_id'
+        assert index.get_primary_key() == 'book_id'
 
     def test_update_index(self):
         """Tests updating an index"""
-        index = self.client.get_index(uid=self.index_uid)
+        index = self.client.index(uid=self.index_uid)
         response = index.update(primaryKey='objectID')
         assert isinstance(response, object)
+        assert index.primary_key == 'objectID'
         assert index.get_primary_key() == 'objectID'
 
     def test_delete_index(self):
         """Tests deleting an index"""
-        index = self.client.get_index(uid=self.index_uid)
-        response = index.delete()
+        response = self.client.index(uid=self.index_uid).delete()
         assert isinstance(response, object)
         assert response.status_code == 204
         with pytest.raises(Exception):
-            self.client.get_index(uid=self.index_uid).info()
-        index = self.client.get_index(uid=self.index_uid2)
-        response = index.delete()
+            self.client.get_index(uid=self.index_uid)
+        response = self.client.index(uid=self.index_uid2).delete()
         assert isinstance(response, object)
         assert response.status_code == 204
         with pytest.raises(Exception):
-            self.client.get_index(uid=self.index_uid2).info()
-        index = self.client.get_index(uid=self.index_uid3)
-        response = index.delete()
+            self.client.get_index(uid=self.index_uid2)
+        response = self.client.index(uid=self.index_uid3).delete()
         assert isinstance(response, object)
         assert response.status_code == 204
         with pytest.raises(Exception):
-            self.client.get_index(uid=self.index_uid3).info()
+            self.client.get_index(uid=self.index_uid3)
         assert len(self.client.get_indexes()) == 0

--- a/meilisearch/tests/index/test_index.py
+++ b/meilisearch/tests/index/test_index.py
@@ -111,20 +111,20 @@ class TestIndex:
         index = self.client.index(uid=self.index_uid)
         response = index.fetch_info()
         assert isinstance(response, object)
-        assert response['uid'] == self.index_uid
-        assert response['primaryKey'] is None
-        assert index.primary_key == response['primaryKey']
-        assert index.get_primary_key() == response['primaryKey']
+        assert response.uid == self.index_uid
+        assert response.primary_key is None
+        assert response.primary_key == index.primary_key
+        assert response.primary_key == index.get_primary_key()
 
     def test_index_fetch_info_containing_primary_key(self):
         """Tests getting the index info"""
         index = self.client.index(uid=self.index_uid3)
         response = index.fetch_info()
         assert isinstance(response, object)
-        assert response['uid'] == self.index_uid3
-        assert response['primaryKey'] == 'book_id'
-        assert index.primary_key == response['primaryKey']
-        assert index.get_primary_key() == response['primaryKey']
+        assert response.uid == self.index_uid3
+        assert response.primary_key == 'book_id'
+        assert response.primary_key == index.primary_key
+        assert response.primary_key == index.get_primary_key()
 
     def test_get_primary_key(self):
         """Tests getting the primary-key of an index"""


### PR DESCRIPTION
Related to https://github.com/meilisearch/integration-guides/issues/48

📣 So sorry for all the "pollution" changes in the code-base comments. In order to help you with this huge PR, here is the list of changes you have to check:
- The Getting Started changed as described in the main issue.
- `get_index()` does an HTTP call and is not the main method to use anymore.
- Add the `index()` method
- Add tests for `index()` method
- Update `get_or_create_index` with the new way of using `index()`
- Rename `Index.get_indexes` into `Index.list_all` to avoid repetition. This method is not provided in the docs so this is mostly an internal usage.
- Add a `primary_key` attribute in `Index` class. This attribute is updated when an HTTP call to the index is done (creation, update, or fetch the info). The attribute is obviously not up-to-date when using the `index()` method. See the limitation section in the main issue.
- The `info()` method is not documented anymore because `get_index` does the job now. I renamed it to `fetch_info()` to make the HTTP call explicit. Since it's not documented, its usage is mostly internal, but I also updated the tests accordingly, so this method is still well tested.
- Remove `get_index` from the `Index` class. This method is not used internally, and if the users would use it, they would have to write `Index.get_index('movies')` which is not really intuitive. The right usage is `client.get_index('movies')` or `client.index('movies').fetch_info()`.
- Change code-samples.

⚠️ the `index.py` changes might be not visible if you don't click on `load diff`:
<img width="1640" alt="Capture d’écran 2020-11-10 à 18 32 56" src="https://user-images.githubusercontent.com/20380692/98709877-3ada3900-2383-11eb-8ae2-2b5224d3a75d.png">

Good luck ♥️