### PR TITLE
Changes due to the implicit index creation

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -4,7 +4,7 @@
 # You can read more on https://github.com/meilisearch/documentation/tree/master/.vuepress/code-samples
 ---
 get_one_index_1: |-
-  index = client.get_index('movies')
+  client.get_index('movies')
 list_all_indexes_1: |-
   client.get_indexes()
 create_an_index_1: |-

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -4,21 +4,26 @@
 # You can read more on https://github.com/meilisearch/documentation/tree/master/.vuepress/code-samples
 ---
 get_one_index_1: |-
-  client.get_index('movies').info()
+  index = client.get_index('movies')
+  # Or
+  index = client.index('movies').fetch_info()
+
+  index.uid
+  index.primary_key
 list_all_indexes_1: |-
   client.get_indexes()
 create_an_index_1: |-
   client.create_index('movies', {'primaryKey': 'movie_id'})
 update_an_index_1: |-
-  client.get_index('movies').update(primaryKey='movie_review_id')
+  client.index('movies').update(primaryKey='movie_review_id')
 delete_an_index_1: |-
-  client.get_index('movies').delete()
+  client.index('movies').delete()
 get_one_document_1: |-
-  client.get_index('movies').get_document(25684)
+  client.index('movies').get_document(25684)
 get_documents_1: |-
-  client.get_index('movies').get_documents({'limit':2})
+  client.index('movies').get_documents({'limit':2})
 add_or_replace_documents_1: |-
-  client.get_index('movies').add_documents([{
+  client.index('movies').add_documents([{
     'id': 287947,
     'title': 'Shazam',
     'poster': 'https://image.tmdb.org/t/p/w1280/xnopI5Xtky18MPhK40cZAGAOVeV.jpg',
@@ -26,29 +31,29 @@ add_or_replace_documents_1: |-
     'release_date': '2019-03-23'
   }])
 add_or_update_documents_1: |-
-  client.get_index('movies').update_documents([{
+  client.index('movies').update_documents([{
       'id': 287947,
       'title': 'Shazam ⚡️',
       'genres': 'comedy'
   }])
 delete_all_documents_1: |-
-  client.get_index('movies').delete_all_documents()
+  client.index('movies').delete_all_documents()
 delete_one_document_1: |-
-  client.get_index('movies').delete_document(25684)
+  client.index('movies').delete_document(25684)
 delete_documents_1: |-
-  client.get_index('movies').delete_documents([23488, 153738, 437035, 363869])
+  client.index('movies').delete_documents([23488, 153738, 437035, 363869])
 search_1: |-
-  client.get_index('movies').search('American ninja')
+  client.index('movies').search('American ninja')
 get_update_1: |-
-  client.get_index('movies').get_update_status(1)
+  client.index('movies').get_update_status(1)
 get_all_updates_1: |-
-  client.get_index('movies').get_all_update_status()
+  client.index('movies').get_all_update_status()
 get_keys_1: |-
   client.get_keys()
 get_settings_1: |-
-  client.get_index('movies').get_settings()
+  client.index('movies').get_settings()
 update_settings_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'rankingRules': [
         'typo',
         'words',
@@ -88,27 +93,27 @@ update_settings_1: |-
     'acceptNewFields': False
   })
 reset_settings_1: |-
-  client.get_index('movies').reset_settings()
+  client.index('movies').reset_settings()
 get_synonyms_1: |-
-  client.get_index('movies').get_synonyms()
+  client.index('movies').get_synonyms()
 update_synonyms_1: |-
-  client.get_index('movies').update_synonyms({
+  client.index('movies').update_synonyms({
     'wolverine': ['xmen', 'logan'],
     'logan': ['wolverine', 'xmen'],
     'wow': ['world of warcraft']
   })
 reset_synonyms_1: |-
-  client.get_index('movies').reset_synonyms()
+  client.index('movies').reset_synonyms()
 get_stop_words_1: |-
-  client.get_index('movies').get_stop_words()
+  client.index('movies').get_stop_words()
 update_stop_words_1: |-
-  client.get_index('movies').update_stop_words(['of', 'the', 'to'])
+  client.index('movies').update_stop_words(['of', 'the', 'to'])
 reset_stop_words_1: |-
-  client.get_index('movies').reset_stop_words()
+  client.index('movies').reset_stop_words()
 get_ranking_rules_1: |-
-  client.get_index('movies').get_ranking_rules()
+  client.index('movies').get_ranking_rules()
 update_ranking_rules_1: |-
-  client.get_index('movies').update_ranking_rules([
+  client.index('movies').update_ranking_rules([
       'typo',
       'words',
       'proximity',
@@ -119,27 +124,27 @@ update_ranking_rules_1: |-
       'desc(rank)'
   ])
 reset_ranking_rules_1: |-
-  client.get_index('movies').reset_ranking_rules()
+  client.index('movies').reset_ranking_rules()
 get_distinct_attribute_1: |-
-  client.get_index('movies').get_distinct_attribute()
+  client.index('movies').get_distinct_attribute()
 update_distinct_attribute_1: |-
-  client.get_index('movies').update_distinct_attribute('movie_id')
+  client.index('movies').update_distinct_attribute('movie_id')
 reset_distinct_attribute_1: |-
-  client.get_index('movies').reset_distinct_attribute()
+  client.index('movies').reset_distinct_attribute()
 get_searchable_attributes_1: |-
-  client.get_index('movies').get_searchable_attributes()
+  client.index('movies').get_searchable_attributes()
 update_searchable_attributes_1: |-
-  client.get_index('movies').update_searchable_attributes([
+  client.index('movies').update_searchable_attributes([
       'title',
       'description',
       'uid'
   ])
 reset_searchable_attributes_1: |-
-  client.get_index('movies').reset_searchable_attributes()
+  client.index('movies').reset_searchable_attributes()
 get_displayed_attributes_1: |-
-  client.get_index('movies').get_displayed_attributes()
+  client.index('movies').get_displayed_attributes()
 update_displayed_attributes_1: |-
-  client.get_index('movies').update_displayed_attributes([
+  client.index('movies').update_displayed_attributes([
       "title",
       'description',
       'release_date',
@@ -147,22 +152,19 @@ update_displayed_attributes_1: |-
       'poster'
   ])
 reset_displayed_attributes_1: |-
-  client.get_index('movies').reset_displayed_attributes()
+  client.index('movies').reset_displayed_attributes()
 get_index_stats_1: |-
-  client.get_index('movies').get_stats()
+  client.index('movies').get_stats()
 get_indexes_stats_1: |-
   client.get_all_stats()
 get_health_1: |-
   client.health()
 get_version_1: |-
   clien.get_version()
-get_pretty_sys_info_1: |-
-get_sys_info_1: |-
-  client.get_sys_info()
 distinct_attribute_guide_1: |-
-  client.get_index('jackets').update_settings({'distinctAttribute': 'product_id'})
+  client.index('jackets').update_settings({'distinctAttribute': 'product_id'})
 field_properties_guide_searchable_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'searchableAttributes': [
         'uid',
         'movie_id',
@@ -173,7 +175,7 @@ field_properties_guide_searchable_1: |-
         'rank'
   ]})
 field_properties_guide_displayed_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'displayedAttributes': [
         'title',
         'description',
@@ -182,67 +184,67 @@ field_properties_guide_displayed_1: |-
         'rank'
   ]})
 filtering_guide_1: |-
-  client.get_index('movies').search('Avengers', {
+  client.index('movies').search('Avengers', {
     'filters': 'release_date > 795484800'
   })
 filtering_guide_2: |-
-  client.get_index('movies').search('Batman', {
+  client.index('movies').search('Batman', {
     'filters': 'release_date > 795484800 AND (director = "Tim Burton" OR director = "Christopher Nolan")'
   })
 filtering_guide_3: |-
-  client.get_index('movies').search('horror', {
+  client.index('movies').search('horror', {
     'filters': 'director = "Jordan Peele"'
   })
 filtering_guide_4: |-
-  client.get_index('movies').search('Planet of the Apes', {
+  client.index('movies').search('Planet of the Apes', {
     'filters': 'rating >= 3 AND (NOT director = "Tim Burton")'
   })
 search_parameter_guide_query_1: |-
-  client.get_index('movies').search('shifu')
+  client.index('movies').search('shifu')
 search_parameter_guide_offset_1: |-
-  client.get_index('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     'offset': 1
   })
 search_parameter_guide_limit_1: |-
-  client.get_index('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     'limit': 2
   })
 search_parameter_guide_retrieve_1: |-
-  client.get_index('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     'attributesToRetrieve': ['overview', 'title']
   })
 search_parameter_guide_crop_1: |-
-  client.get_index('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     'attributesToCrop': ['overview'],
     'cropLength': 10
   })
 search_parameter_guide_highlight_1: |-
-  client.get_index('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     'attributesToHighlight': ['overview']
   })
 search_parameter_guide_filter_1: |-
-  client.get_index('movies').search('n', {
+  client.index('movies').search('n', {
     'filters': 'title = Nightshift'
   })
 search_parameter_guide_filter_2: |-
-  client.get_index('movies').search('n', {
+  client.index('movies').search('n', {
     'filters': 'title = "Kung Fu Panda"'
   })
 search_parameter_guide_matches_1: |-
-  client.get_index('movies').search('n', {
+  client.index('movies').search('n', {
     'filters': 'title = "Kung Fu Panda"',
     'attributesToHighlight': ['overview'],
     'matches': 'true'
   })
 settings_guide_synonyms_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'synonyms': {
       sweater: ['jumper'],
       jumper: ['sweater']
     },
   })
 settings_guide_stop_words_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'stopWords': [
         'the',
         'a',
@@ -250,7 +252,7 @@ settings_guide_stop_words_1: |-
     ],
   })
 settings_guide_ranking_rules_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'rankingRules': [
         'typo',
         'words',
@@ -263,11 +265,11 @@ settings_guide_ranking_rules_1: |-
     ]
   })
 settings_guide_distinct_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'distinctAttribute': 'product_id'
   })
 settings_guide_searchable_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'searchableAttributes': [
       'uid',
       'movie_id',
@@ -279,7 +281,7 @@ settings_guide_searchable_1: |-
     ]
   })
 settings_guide_displayed_1: |-
-  client.get_index('movies').update_settings({
+  client.index('movies').update_settings({
     'displayedAttributes': [
       'title',
       'description',
@@ -289,17 +291,17 @@ settings_guide_displayed_1: |-
     ]
   })
 documents_guide_add_movie_1: |-
-  client.get_index('movies').add_documents([{
+  client.index('movies').add_documents([{
     'movie_id': '123sq178',
     'title': 'Amélie Poulain'
   }])
 search_guide_1: |-
-  client.get_index('movies').search('shifu', {
+  client.index('movies').search('shifu', {
     'limit': 5,
     'offset': 10
   })
 search_guide_2: |-
-  client.get_index('movies').search('Avengers', {
+  client.index('movies').search('Avengers', {
     'filters': 'release_date > 795484800'
   })
 getting_started_create_index_md: |-
@@ -332,31 +334,31 @@ getting_started_search_md: |-
 
   [About this package](https://github.com/meilisearch/meilisearch-python/)
 faceted_search_update_settings_1: |-
-  client.get_index('movies').update_attributes_for_faceting([
+  client.index('movies').update_attributes_for_faceting([
       'director',
       'genres',
   ])
 faceted_search_facet_filters_1: |-
-  client.get_index('movies').search('thriller', {
+  client.index('movies').search('thriller', {
     'facetFilters': [['genres:Horror', 'genres:Mystery'], 'director:Jordan Peele']
   })
 faceted_search_facets_distribution_1: |-
-  client.get_index('movies').search('Batman', {
+  client.index('movies').search('Batman', {
     'facetsDistribution': ['genres']
   })
 faceted_search_walkthrough_attributes_for_faceting_1: |-
-  client.get_index('movies').update_attributes_for_faceting([
+  client.index('movies').update_attributes_for_faceting([
       'director',
       'producer',
       'genres',
       'production_companies'
   ])
 faceted_search_walkthrough_facet_filters_1: |-
-  client.get_index('movies').search('thriller', {
+  client.index('movies').search('thriller', {
     'facetFilters': [['genres:Horror', 'genres:Mystery'], 'director:Jordan Peele']
   })
 faceted_search_walkthrough_facets_distribution_1: |-
-  client.get_index('movies').search('Batman', {
+  client.index('movies').search('Batman', {
     'facetsDistribution': ['genres']
   })
 post_dump_1: |-

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -5,11 +5,6 @@
 ---
 get_one_index_1: |-
   index = client.get_index('movies')
-  # Or
-  index = client.index('movies').fetch_info()
-
-  index.uid
-  index.primary_key
 list_all_indexes_1: |-
   client.get_indexes()
 create_an_index_1: |-

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ NB: you can also download MeiliSearch from **Homebrew** or **APT**.
 import meilisearch
 
 client = meilisearch.Client('http://127.0.0.1:7700', 'masterKey')
-index = client.create_index('books') # If your index does not exist
-index = client.get_index('books')    # If you already created your index
+
+# An index is where the documents are stored.
+index = client.index('books')
 
 documents = [
   { 'book_id': 123,  'title': 'Pride and Prejudice' },
@@ -79,6 +80,7 @@ documents = [
   { 'book_id': 42,   'title': 'The Hitchhiker\'s Guide to the Galaxy' }
 ]
 
+# If the index 'books' does not exist, MeiliSearch creates it when you first add the documents.
 index.add_documents(documents) # => { "updateId": 0 }
 ```
 

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -119,12 +119,12 @@ class Client():
         MeiliSearchApiError
             In case of any other error found here https://docs.meilisearch.com/references/#errors-status-code
         """
-        index_instance = self.index(uid)
         try:
-            index_instance = self.create_index(uid, options)
+            index_instance = self.get_index(uid)
         except MeiliSearchApiError as err:
-            if err.error_code != 'index_already_exists':
+            if err.error_code != 'index_not_found':
                 raise err
+            index_instance = self.create_index(uid, options)
         return index_instance
 
     def get_all_stats(self):

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -78,13 +78,13 @@ class Client():
         Returns
         -------
         index : Index
-            An Index instance containing the information the fetched index.
+            An Index instance containing the information of the fetched index.
         """
         return Index(self.config, uid).fetch_info()
 
     def index(self, uid):
-        """Create an Index instance.
-        This method doesn't trigger any HTTP call.
+        """Create a local reference to an index identified by `uid`, without doing an HTTP call.
+        Calling this method doesn't create an index by itself, but grants access to all the other methods in the Index class.
 
         Parameters
         ----------
@@ -101,7 +101,7 @@ class Client():
         raise Exception('The index UID should not be None')
 
     def get_or_create_index(self, uid, options=None):
-        """Get an index, or create it if it doesn't exist.
+        """Retrieve an index in MeiliSearch, or create it if it doesn't exist yet.
 
         Parameters
         ----------
@@ -113,10 +113,10 @@ class Client():
         Returns
         -------
         index : Index
-            An instance of Index containing the information of the retrieved or newly created index.
+            An Index instance containing the information of the retrieved or newly created index.
         Raises
         ------
-        HTTPError
+        MeiliSearchApiError
             In case of any other error found here https://docs.meilisearch.com/references/#errors-status-code
         """
         index_instance = self.index(uid)

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -14,22 +14,24 @@ class Index():
 
     config = None
     http = None
-    uid = ""
+    uid = None
+    primary_key = None
 
-    def __init__(self, config, uid):
+    def __init__(self, config, uid, primary_key=None):
         """
         Parameters
         ----------
-        config : Config
-            Config object containing permission and location of meilisearch
+        config : dict
+            Config object containing permission and location of MeiliSearch.
         uid: str
-            Uid of the index on which to perform the index actions.
-        index_path: str
-            Index url path
+            UID of the index on which to perform the index actions.
+        primary_key: str, optional
+            Primary-key of the index.
         """
         self.config = config
-        self.uid = uid
         self.http = HttpRequests(config)
+        self.uid = uid
+        self.primary_key = primary_key
 
     def delete(self):
         """Delete an index from meilisearch
@@ -43,60 +45,64 @@ class Index():
         return self.http.delete('{}/{}'.format(self.config.paths.index, self.uid))
 
     def update(self, **body):
-        """Update an index from meilisearch
+        """Update the index primary-key.
 
         Parameters
         ----------
         body: **kwargs
             Accepts primaryKey as an updatable parameter.
+            Ex: index.update(primaryKey='name')
 
         Returns
-        ----------
-        update: `dict`
-            Dictionnary containing an update id to track the action:
-            https://docs.meilisearch.com/references/updates.html#get-an-update-status
+        -------
+        index: dict
+            Dictionary containing index information.
         """
         payload = {}
         primary_key = body.get('primaryKey', None)
         if primary_key is not None:
             payload['primaryKey'] = primary_key
-        return self.http.put('{}/{}'.format(self.config.paths.index, self.uid), payload)
+        response = self.http.put('{}/{}'.format(self.config.paths.index, self.uid), payload)
+        self.primary_key = response['primaryKey']
+        return response
 
-    def info(self):
-        """Get info of index
-
-        Returns
-        ----------
-        index: `dict`
-            Dictionnary containing index information.
-        """
-        return self.http.get('{}/{}'.format(self.config.paths.index, self.uid))
-
-    def get_primary_key(self):
-        """Get the primary key
-
-        Returns
-        ----------
-        primary_key: str
-            String containing primary key.
-        """
-        return self.info()['primaryKey']
-
-    @staticmethod
-    def create(config, uid, options=None):
-        """Create an index.
-
-        Parameters
-        ----------
-        uid: str
-            UID of the index
-        options: dict, optional
-            Options passed during index creation (ex: primaryKey)
+    def fetch_info(self):
+        """Fetch the info of the index.
 
         Returns
         -------
         index : Index
-            an instance of Index containing the information of the newly created index
+            An instance of Index containing the information of the index.
+        """
+        index_dict = self.http.get('{}/{}'.format(self.config.paths.index, self.uid))
+        self.primary_key = index_dict['primaryKey']
+        return self
+
+    def get_primary_key(self):
+        """Get the primary key.
+
+        Returns
+        -------
+        primary_key: str
+            String containing the primary key.
+        """
+        return self.fetch_info().primary_key
+
+    @staticmethod
+    def create(config, uid, options=None):
+        """Create the index.
+
+        Parameters
+        ----------
+        uid: str
+            UID of the index.
+        options: dict, optional
+            Options passed during index creation (ex: { 'primaryKey': 'name' }).
+
+        Returns
+        -------
+        index : Index
+            An instance of Index containing the information of the newly created index.
         Raises
         ------
         HTTPError
@@ -121,25 +127,6 @@ class Index():
             In case of any error found here https://docs.meilisearch.com/references/#errors-status-code
         """
         return HttpRequests(config).get(config.paths.index)
-
-    @staticmethod
-    def get_index(config, uid):
-        """Get Index instance from given index
-
-        If the argument `uid` aren't passed in, it will raise an exception.
-
-        Returns
-        -------
-        index : Index
-            Instance of Index with the given index.
-        Raises
-        ------
-        Exception
-            If index UID is missing.
-        """
-        if uid is not None:
-            return Index(config, uid=uid)
-        raise Exception('Uid is needed to find index')
 
     def get_all_update_status(self):
         """Get all update status from MeiliSearch

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -22,9 +22,9 @@ class Index():
         Parameters
         ----------
         config : dict
-            Config object containing permission and location of MeiliSearch.
+            Config object containing MeiliSearch configuration data, such as url and API Key.
         uid: str
-            UID of the index on which to perform the index actions.
+            UID of the index in which further actions will be performed.
         primary_key: str, optional
             Primary-key of the index.
         """
@@ -45,7 +45,7 @@ class Index():
         return self.http.delete('{}/{}'.format(self.config.paths.index, self.uid))
 
     def update(self, **body):
-        """Update the index primary-key.
+        """Update the primary-key of the index.
 
         Parameters
         ----------
@@ -67,23 +67,23 @@ class Index():
         return response
 
     def fetch_info(self):
-        """Fetch the info of the index.
+        """Fetch the information of the index.
 
         Returns
         -------
         index : Index
-            An instance of Index containing the information of the index.
+            An Index instance containing the information of the index.
         """
         index_dict = self.http.get('{}/{}'.format(self.config.paths.index, self.uid))
         self.primary_key = index_dict['primaryKey']
         return self
 
     def get_primary_key(self):
-        """Get the primary key.
+        """Fetch the primary key of the index.
 
         Returns
         -------
-        primary_key: str
+        primary_key: str | None
             String containing the primary key.
         """
         return self.fetch_info().primary_key
@@ -97,12 +97,13 @@ class Index():
         uid: str
             UID of the index.
         options: dict, optional
-            Options passed during index creation (ex: { 'primaryKey': 'name' }).
+            Options passed during index creation.
+            Ex: Index.create('indexUID', { 'primaryKey': 'name' })
 
         Returns
         -------
         index : Index
-            An instance of Index containing the information of the newly created index.
+            An Index instance containing the information of the newly created index.
         Raises
         ------
         HTTPError

--- a/meilisearch/tests/__init__.py
+++ b/meilisearch/tests/__init__.py
@@ -7,7 +7,7 @@ BASE_URL = 'http://127.0.0.1:7700'
 def clear_all_indexes(client):
     indexes = client.get_indexes()
     for index in indexes:
-        client.get_index(index['uid']).delete()
+        client.index(index['uid']).delete()
 
 
 # Waits until the end of the dump creation.

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -26,7 +26,7 @@ class TestClientDumps:
         self.index.wait_for_pending_update(response['updateId'])
 
     def teardown_method(self, method):
-        self.client.get_index('indexUID-' + method.__name__).delete()
+        self.client.index('indexUID-' + method.__name__).delete()
 
     def teardown_class(self):
         """Cleans all indexes in MEiliSearch when all the test are done"""

--- a/meilisearch/tests/index/test_index.py
+++ b/meilisearch/tests/index/test_index.py
@@ -20,6 +20,7 @@ class TestIndex:
         index = self.client.create_index(uid=self.index_uid)
         assert isinstance(index, object)
         assert index.uid == self.index_uid
+        assert index.primary_key is None
         assert index.get_primary_key() is None
 
     def test_create_index_with_primary_key(self):
@@ -27,6 +28,7 @@ class TestIndex:
         index = self.client.create_index(uid=self.index_uid2, options={'primaryKey': 'book_id'})
         assert isinstance(index, object)
         assert index.uid == self.index_uid2
+        assert index.primary_key == 'book_id'
         assert index.get_primary_key() == 'book_id'
 
     def test_create_index_with_uid_in_options(self):
@@ -34,6 +36,7 @@ class TestIndex:
         index = self.client.create_index(uid=self.index_uid3, options={'uid': 'wrong', 'primaryKey': 'book_id'})
         assert isinstance(index, object)
         assert index.uid == self.index_uid3
+        assert index.primary_key == 'book_id'
         assert index.get_primary_key() == 'book_id'
 
     def test_get_indexes(self):
@@ -46,7 +49,19 @@ class TestIndex:
         assert self.index_uid3 in uids
         assert len(response) == 3
 
-    def test_get_index_with_uid(self):
+    def test_index_with_any_uid(self):
+        index = self.client.index('anyUID')
+        assert isinstance(index, object)
+        assert index.uid == 'anyUID'
+        assert index.primary_key is None
+        assert index.config is not None
+        assert index.http is not None
+
+    def test_index_with_none_uid(self):
+        with pytest.raises(Exception):
+            self.client.index(None)
+
+    def test_get_index_with_valid_uid(self):
         """Tests getting one index with uid"""
         response = self.client.get_index(uid=self.index_uid)
         assert isinstance(response, object)
@@ -56,6 +71,11 @@ class TestIndex:
         """Test raising an exception if the index UID is None"""
         with pytest.raises(Exception):
             self.client.get_index(uid=None)
+
+    def test_get_index_with_wrong_uid(self):
+        """Tests get_index with an non-existing index"""
+        with pytest.raises(Exception):
+            self.client.get_index(uid='wrongUID')
 
     def test_get_or_create_index(self):
         """Test get_or_create_index method"""
@@ -73,60 +93,71 @@ class TestIndex:
         assert len(documents) == 1
         index_2.delete()
         with pytest.raises(Exception):
-            self.client.get_index(index_3).info()
+            self.client.get_index(index_3)
 
     def test_get_or_create_index_with_primary_key(self):
         """Test get_or_create_index method with primary key"""
         index_1 = self.client.get_or_create_index('books', {'primaryKey': self.index_uid4})
         index_2 = self.client.get_or_create_index('books', {'primaryKey': 'some_wrong_key'})
+        assert index_1.primary_key == self.index_uid4
         assert index_1.get_primary_key() == self.index_uid4
+        assert index_2.primary_key is None
         assert index_2.get_primary_key() == self.index_uid4
+        assert index_2.primary_key == self.index_uid4
         index_1.delete()
 
-    def test_index_info(self):
-        """Tests getting an index's info"""
-        index = self.client.get_index(uid=self.index_uid)
-        response = index.info()
+    def test_index_fetch_info(self):
+        """Tests getting the index info"""
+        index = self.client.index(uid=self.index_uid)
+        response = index.fetch_info()
         assert isinstance(response, object)
-        assert response['uid'] == self.index_uid
-        assert response['primaryKey'] is None
+        assert response.uid == self.index_uid
+        assert response.primary_key is None
+        assert response.primary_key == index.primary_key
+        assert response.primary_key == index.get_primary_key()
 
-    def test_index_info_with_wrong_uid(self):
-        """Tests getting an index's info in MeiliSearch with a wrong UID"""
-        with pytest.raises(Exception):
-            self.client.get_index(uid='wrongUID').info()
+    def test_index_fetch_info_containing_primary_key(self):
+        """Tests getting the index info"""
+        index = self.client.index(uid=self.index_uid3)
+        response = index.fetch_info()
+        assert isinstance(response, object)
+        assert response.uid == self.index_uid3
+        assert response.primary_key == 'book_id'
+        assert response.primary_key == index.primary_key
+        assert response.primary_key == index.get_primary_key()
 
     def test_get_primary_key(self):
         """Tests getting the primary-key of an index"""
-        index = self.client.get_index(uid=self.index_uid)
+        index = self.client.index(uid=self.index_uid3)
+        assert index.primary_key is None
         response = index.get_primary_key()
-        assert response is None
+        assert response == 'book_id'
+        assert index.primary_key == 'book_id'
+        assert index.get_primary_key() == 'book_id'
 
     def test_update_index(self):
         """Tests updating an index"""
-        index = self.client.get_index(uid=self.index_uid)
+        index = self.client.index(uid=self.index_uid)
         response = index.update(primaryKey='objectID')
         assert isinstance(response, object)
+        assert index.primary_key == 'objectID'
         assert index.get_primary_key() == 'objectID'
 
     def test_delete_index(self):
         """Tests deleting an index"""
-        index = self.client.get_index(uid=self.index_uid)
-        response = index.delete()
+        response = self.client.index(uid=self.index_uid).delete()
         assert isinstance(response, object)
         assert response.status_code == 204
         with pytest.raises(Exception):
-            self.client.get_index(uid=self.index_uid).info()
-        index = self.client.get_index(uid=self.index_uid2)
-        response = index.delete()
+            self.client.get_index(uid=self.index_uid)
+        response = self.client.index(uid=self.index_uid2).delete()
         assert isinstance(response, object)
         assert response.status_code == 204
         with pytest.raises(Exception):
-            self.client.get_index(uid=self.index_uid2).info()
-        index = self.client.get_index(uid=self.index_uid3)
-        response = index.delete()
+            self.client.get_index(uid=self.index_uid2)
+        response = self.client.index(uid=self.index_uid3).delete()
         assert isinstance(response, object)
         assert response.status_code == 204
         with pytest.raises(Exception):
-            self.client.get_index(uid=self.index_uid3).info()
+            self.client.get_index(uid=self.index_uid3)
         assert len(self.client.get_indexes()) == 0

--- a/meilisearch/tests/index/test_index.py
+++ b/meilisearch/tests/index/test_index.py
@@ -146,17 +146,14 @@ class TestIndex:
     def test_delete_index(self):
         """Tests deleting an index"""
         response = self.client.index(uid=self.index_uid).delete()
-        assert isinstance(response, object)
         assert response.status_code == 204
         with pytest.raises(Exception):
             self.client.get_index(uid=self.index_uid)
         response = self.client.index(uid=self.index_uid2).delete()
-        assert isinstance(response, object)
         assert response.status_code == 204
         with pytest.raises(Exception):
             self.client.get_index(uid=self.index_uid2)
         response = self.client.index(uid=self.index_uid3).delete()
-        assert isinstance(response, object)
         assert response.status_code == 204
         with pytest.raises(Exception):
             self.client.get_index(uid=self.index_uid3)

--- a/meilisearch/tests/index/test_index.py
+++ b/meilisearch/tests/index/test_index.py
@@ -101,9 +101,8 @@ class TestIndex:
         index_2 = self.client.get_or_create_index('books', {'primaryKey': 'some_wrong_key'})
         assert index_1.primary_key == self.index_uid4
         assert index_1.get_primary_key() == self.index_uid4
-        assert index_2.primary_key is None
-        assert index_2.get_primary_key() == self.index_uid4
         assert index_2.primary_key == self.index_uid4
+        assert index_2.get_primary_key() == self.index_uid4
         index_1.delete()
 
     def test_index_fetch_info(self):


### PR DESCRIPTION
Related to https://github.com/meilisearch/integration-guides/issues/48

Here is the list of changes you have to check:
- Change code-samples.
- Change the Getting Started as described in the main issue.
- `get_index()` does an HTTP call and is not the main method to use anymore.
- Add the `index()` method
- Add tests for `index()` method
- Update `get_or_create_index` with the new way of using `index()`
- Add a `primary_key` attribute in `Index` class. This attribute is updated when an HTTP call to the index is done (creation, update, or fetch the info). The attribute is obviously not up-to-date when using the `index()` method: the method does not do any HTTP call. Refer to the limitation section in the main issue.
- Rename `info()` method into `fetch_info()` to make the HTTP call explicit. Now, the right usage to get the index information is `client.get_index('movies')` or `client.index('movies').fetch_info()`.
- Remove the internal method `get_index` from the `Index` class because not used anymore.

⚠️ the `index.py` changes might be not visible if you don't click on `load diff`:
<img width="1640" alt="Capture d’écran 2020-11-10 à 18 32 56" src="https://user-images.githubusercontent.com/20380692/98709877-3ada3900-2383-11eb-8ae2-2b5224d3a75d.png">