### PR TITLE
Restructure code

### DIFF
--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -45,8 +45,7 @@ class Client():
         HTTPError
             In case of any other error found here https://docs.meilisearch.com/references/#errors-status-code
         """
-        index_dict = Index.create(self.config, uid, options)
-        return Index(self.config, index_dict['uid'], index_dict['primaryKey'])
+        return Index.create(self.config, uid, options)
 
     def get_indexes(self):
         """Get all indexes.

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -59,7 +59,7 @@ class Client():
         list
             List of indexes in dictionnary format. (e.g [{ 'uid': 'movies' 'primaryKey': 'objectID' }])
         """
-        return Index.get_indexes(self.config)
+        return self.http.get(self.config.paths.index)
 
     def get_index(self, uid):
         """Get the index.

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -64,7 +64,7 @@ class Index():
             payload['primaryKey'] = primary_key
         response = self.http.put('{}/{}'.format(self.config.paths.index, self.uid), payload)
         self.primary_key = response['primaryKey']
-        return response
+        return self
 
     def fetch_info(self):
         """Fetch the information of the index.

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -88,8 +88,8 @@ class Index():
         """
         return self.fetch_info().primary_key
 
-    @staticmethod
-    def create(config, uid, options=None):
+    @classmethod
+    def create(cls, config, uid, options=None):
         """Create the index.
 
         Parameters
@@ -112,7 +112,8 @@ class Index():
         if options is None:
             options = {}
         payload = {**options, 'uid': uid}
-        return HttpRequests(config).post(config.paths.index, payload)
+        index_dict = HttpRequests(config).post(config.paths.index, payload)
+        return cls(config, index_dict['uid'], index_dict['primaryKey'])
 
     @staticmethod
     def get_indexes(config):

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -115,21 +115,6 @@ class Index():
         index_dict = HttpRequests(config).post(config.paths.index, payload)
         return cls(config, index_dict['uid'], index_dict['primaryKey'])
 
-    @staticmethod
-    def get_indexes(config):
-        """Get all indexes from meilisearch.
-
-        Returns
-        -------
-        indexes : list
-            List of indexes (dict)
-        Raises
-        ------
-        HTTPError
-            In case of any error found here https://docs.meilisearch.com/references/#errors-status-code
-        """
-        return HttpRequests(config).get(config.paths.index)
-
     def get_all_update_status(self):
         """Get all update status from MeiliSearch
 

--- a/meilisearch/tests/index/test_index.py
+++ b/meilisearch/tests/index/test_index.py
@@ -1,5 +1,6 @@
 import pytest
 import meilisearch
+from meilisearch.index import Index
 from meilisearch.tests import BASE_URL, MASTER_KEY, clear_all_indexes
 
 class TestIndex:
@@ -18,7 +19,7 @@ class TestIndex:
     def test_create_index(self):
         """Tests creating an index"""
         index = self.client.create_index(uid=self.index_uid)
-        assert isinstance(index, object)
+        assert isinstance(index, Index)
         assert index.uid == self.index_uid
         assert index.primary_key is None
         assert index.get_primary_key() is None
@@ -26,7 +27,7 @@ class TestIndex:
     def test_create_index_with_primary_key(self):
         """Tests creating an index with a primary key"""
         index = self.client.create_index(uid=self.index_uid2, options={'primaryKey': 'book_id'})
-        assert isinstance(index, object)
+        assert isinstance(index, Index)
         assert index.uid == self.index_uid2
         assert index.primary_key == 'book_id'
         assert index.get_primary_key() == 'book_id'
@@ -34,7 +35,7 @@ class TestIndex:
     def test_create_index_with_uid_in_options(self):
         """Tests creating an index with a primary key"""
         index = self.client.create_index(uid=self.index_uid3, options={'uid': 'wrong', 'primaryKey': 'book_id'})
-        assert isinstance(index, object)
+        assert isinstance(index, Index)
         assert index.uid == self.index_uid3
         assert index.primary_key == 'book_id'
         assert index.get_primary_key() == 'book_id'
@@ -51,7 +52,7 @@ class TestIndex:
 
     def test_index_with_any_uid(self):
         index = self.client.index('anyUID')
-        assert isinstance(index, object)
+        assert isinstance(index, Index)
         assert index.uid == 'anyUID'
         assert index.primary_key is None
         assert index.config is not None
@@ -64,7 +65,7 @@ class TestIndex:
     def test_get_index_with_valid_uid(self):
         """Tests getting one index with uid"""
         response = self.client.get_index(uid=self.index_uid)
-        assert isinstance(response, object)
+        assert isinstance(response, Index)
         assert response.uid == self.index_uid
 
     def test_get_index_with_none_uid(self):
@@ -109,7 +110,7 @@ class TestIndex:
         """Tests getting the index info"""
         index = self.client.index(uid=self.index_uid)
         response = index.fetch_info()
-        assert isinstance(response, object)
+        assert isinstance(response, Index)
         assert response.uid == self.index_uid
         assert response.primary_key is None
         assert response.primary_key == index.primary_key
@@ -119,7 +120,7 @@ class TestIndex:
         """Tests getting the index info"""
         index = self.client.index(uid=self.index_uid3)
         response = index.fetch_info()
-        assert isinstance(response, object)
+        assert isinstance(response, Index)
         assert response.uid == self.index_uid3
         assert response.primary_key == 'book_id'
         assert response.primary_key == index.primary_key
@@ -138,7 +139,7 @@ class TestIndex:
         """Tests updating an index"""
         index = self.client.index(uid=self.index_uid)
         response = index.update(primaryKey='objectID')
-        assert isinstance(response, object)
+        assert isinstance(response, Index)
         assert index.primary_key == 'objectID'
         assert index.get_primary_key() == 'objectID'
 


### PR DESCRIPTION
⚠️ Should be merged after the merge of #175

Breaking change:
- Make the internal method `Index.create(...)` a `@classmethod` instead of a `@staticmethod`. Why? Put the logic related to an index in the `Index` class instead of the `Client` class.
See the difference between static and class methods in Python: https://stackabuse.com/pythons-classmethod-and-staticmethod-explained/.
- Remove the internal method `Index.get_indexes()`. Since it's not related to only one index, this method should not be present in the `Index` class.
- Make the `update()` method returns an `Index` object instead of a `dict` because it's more convenient to manipulate object instead of dict. This is consitent with `client.index('movies').fetch_info()` and `client.create_index('movies)` and `client.index('movies')`

Changes:
- Check the type of the responses more accurately: `assert isinstance(response, Index)`