### PR TITLE
Make tests independent

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -177,7 +177,7 @@ name-group=
 include-naming-hint=no
 
 # Regular expression matching correct function names
-function-rgx=[a-z_][a-z0-9_]{2,70}$
+function-rgx=[a-z_][a-z0-9_]{2,30}$
 
 # Naming hint for function names
 function-name-hint=[a-z_][a-z0-9_]{2,30}$

--- a/.pylintrc
+++ b/.pylintrc
@@ -177,7 +177,7 @@ name-group=
 include-naming-hint=no
 
 # Regular expression matching correct function names
-function-rgx=[a-z_][a-z0-9_]{2,30}$
+function-rgx=[a-z_][a-z0-9_]{2,70}$
 
 # Naming hint for function names
 function-name-hint=[a-z_][a-z0-9_]{2,30}$

--- a/meilisearch/tests/__init__.py
+++ b/meilisearch/tests/__init__.py
@@ -2,12 +2,6 @@ from datetime import datetime
 from time import sleep
 from .common import MASTER_KEY, BASE_URL
 
-def clear_all_indexes(client):
-    indexes = client.get_indexes()
-    for index in indexes:
-        client.index(index['uid']).delete()
-
-
 # Waits until the end of the dump creation.
 # Raises a TimeoutError if the `timeout_in_ms` is reached.
 def wait_for_dump_creation(client, dump_uid, timeout_in_ms=10000, interval_in_ms=500):

--- a/meilisearch/tests/__init__.py
+++ b/meilisearch/tests/__init__.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 from time import sleep
-
-MASTER_KEY = 'masterKey'
-BASE_URL = 'http://127.0.0.1:7700'
+from .common import MASTER_KEY, BASE_URL
 
 def clear_all_indexes(client):
     indexes = client.get_indexes()

--- a/meilisearch/tests/__init__.py
+++ b/meilisearch/tests/__init__.py
@@ -1,17 +1,2 @@
-from datetime import datetime
-from time import sleep
 from .common import MASTER_KEY, BASE_URL
-
-# Waits until the end of the dump creation.
-# Raises a TimeoutError if the `timeout_in_ms` is reached.
-def wait_for_dump_creation(client, dump_uid, timeout_in_ms=10000, interval_in_ms=500):
-    start_time = datetime.now()
-    elapsed_time = 0
-    while elapsed_time < timeout_in_ms:
-        dump = client.get_dump_status(dump_uid)
-        if dump['status'] != 'in_progress':
-            return
-        sleep(interval_in_ms / 1000)
-        time_delta = datetime.now() - start_time
-        elapsed_time = time_delta.seconds * 1000 + time_delta.microseconds / 1000
-    raise TimeoutError
+from .helper import wait_for_dump_creation

--- a/meilisearch/tests/client/test_client.py
+++ b/meilisearch/tests/client/test_client.py
@@ -1,6 +1,6 @@
 import pytest
 import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY
+from meilisearch.tests.common import BASE_URL, MASTER_KEY
 
 class TestClient:
 

--- a/meilisearch/tests/client/test_client.py
+++ b/meilisearch/tests/client/test_client.py
@@ -1,29 +1,22 @@
 import pytest
 import meilisearch
-from meilisearch.tests.common import BASE_URL, MASTER_KEY
+from meilisearch.tests import BASE_URL, MASTER_KEY
 
-class TestClient:
+def test_get_client():
+    """Tests getting a client instance"""
+    client = meilisearch.Client(BASE_URL, MASTER_KEY)
+    assert client.config
+    response = client.health()
+    assert response.status_code >= 200 and response.status_code < 400
 
-    """ TESTS: Client class """
+def test_get_client_without_master_key():
+    """Tests getting a client instance without MASTER KEY"""
+    client = meilisearch.Client(BASE_URL)
+    with pytest.raises(Exception):
+        client.get_version()
 
-    @staticmethod
-    def test_get_client():
-        """Tests getting a client instance"""
-        client = meilisearch.Client(BASE_URL, MASTER_KEY)
-        assert client.config
-        response = client.health()
-        assert response.status_code >= 200 and response.status_code < 400
-
-    @staticmethod
-    def test_get_client_without_master_key():
-        """Tests getting a client instance without MASTER KEY"""
-        client = meilisearch.Client(BASE_URL)
-        with pytest.raises(Exception):
-            client.get_version()
-
-    @staticmethod
-    def test_get_client_with_wrong_master_key():
-        """Tests getting a client instance with an invalid MASTER KEY"""
-        client = meilisearch.Client(BASE_URL, MASTER_KEY + "123")
-        with pytest.raises(Exception):
-            client.get_version()
+def test_get_client_with_wrong_master_key():
+    """Tests getting a client instance with an invalid MASTER KEY"""
+    client = meilisearch.Client(BASE_URL, MASTER_KEY + "123")
+    with pytest.raises(Exception):
+        client.get_version()

--- a/meilisearch/tests/client/test_client.py
+++ b/meilisearch/tests/client/test_client.py
@@ -1,3 +1,5 @@
+# pylint: disable=invalid-name
+
 import pytest
 import meilisearch
 from meilisearch.tests import BASE_URL, MASTER_KEY

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -1,50 +1,27 @@
-import json
 import pytest
-import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY, wait_for_dump_creation
+from meilisearch.tests import wait_for_dump_creation
 from meilisearch.errors import MeiliSearchApiError
 
-class TestClientDumps:
+def test_dump_creation(client, custom_indexed_maker):
+    """Tests the creation of a MeiliSearch dump"""
+    custom_indexed_maker("dump-creation")
+    dump = client.create_dump()
+    assert dump['uid'] is not None
+    assert dump['status'] == 'in_progress'
+    wait_for_dump_creation(client, dump['uid'])
 
-    """ TESTS: Client dumps creation and status """
+def test_dump_status_route(client, custom_indexed_maker):
+    """Tests the route for getting a MeiliSearch dump status"""
+    custom_indexed_maker("dump-status")
+    dump = client.create_dump()
+    assert dump['uid'] is not None
+    assert dump['status'] == 'in_progress'
+    dump_status = client.get_dump_status(dump['uid'])
+    assert dump_status['uid'] is not None
+    assert dump_status['status'] is not None
+    wait_for_dump_creation(client, dump['uid'])
 
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    index = None
-    dataset_file = None
-    dataset_json = None
-
-    def setup_class(self):
-        self.dataset_file = open('./datasets/small_movies.json', 'r')
-        self.dataset_json = json.loads(self.dataset_file.read())
-        self.dataset_file.close()
-
-    def setup_method(self, method):
-        """Creates and populates an index before each test is run"""
-        self.index = self.client.create_index(uid='indexUID-' + method.__name__)
-        response = self.index.add_documents(self.dataset_json, primary_key='id')
-        self.index.wait_for_pending_update(response['updateId'])
-
-    def teardown_method(self, method):
-        self.client.index('indexUID-' + method.__name__).delete()
-
-    def test_dump_creation(self):
-        """Tests the creation of a MeiliSearch dump"""
-        dump = self.client.create_dump()
-        assert dump['uid'] is not None
-        assert dump['status'] == 'in_progress'
-        wait_for_dump_creation(self.client, dump['uid'])
-
-    def test_dump_status_route(self):
-        """Tests the route for getting a MeiliSearch dump status"""
-        dump = self.client.create_dump()
-        assert dump['uid'] is not None
-        assert dump['status'] == 'in_progress'
-        dump_status = self.client.get_dump_status(dump['uid'])
-        assert dump_status['uid'] is not None
-        assert dump_status['status'] is not None
-        wait_for_dump_creation(self.client, dump['uid'])
-
-    def test_dump_status_nonexistent_uid_raises_error(self):
-        """Tests the route for getting a nonexistent dump status"""
-        with pytest.raises(MeiliSearchApiError):
-            self.client.get_dump_status('uid_not_exists')
+def test_dump_status_nonexistent_uid_raises_error(client):
+    """Tests the route for getting a nonexistent dump status"""
+    with pytest.raises(MeiliSearchApiError):
+        client.get_dump_status('uid_not_exists')

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -4,17 +4,17 @@ import pytest
 from meilisearch.tests import wait_for_dump_creation
 from meilisearch.errors import MeiliSearchApiError
 
-def test_dump_creation(client, index_with_documents, small_movies):
+def test_dump_creation(client, index_with_documents):
     """Tests the creation of a MeiliSearch dump"""
-    index_with_documents("indexUID-dump-creation", small_movies)
+    index_with_documents("indexUID-dump-creation")
     dump = client.create_dump()
     assert dump['uid'] is not None
     assert dump['status'] == 'in_progress'
     wait_for_dump_creation(client, dump['uid'])
 
-def test_dump_status_route(client, index_with_documents, small_movies):
+def test_dump_status_route(client, index_with_documents):
     """Tests the route for getting a MeiliSearch dump status"""
-    index_with_documents("indexUID-dump-status", small_movies)
+    index_with_documents("indexUID-dump-status")
     dump = client.create_dump()
     assert dump['uid'] is not None
     assert dump['status'] == 'in_progress'

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -4,17 +4,17 @@ import pytest
 from meilisearch.tests import wait_for_dump_creation
 from meilisearch.errors import MeiliSearchApiError
 
-def test_dump_creation(client, custom_indexed_maker):
+def test_dump_creation(client, index_with_documents, small_movies):
     """Tests the creation of a MeiliSearch dump"""
-    custom_indexed_maker("dump-creation")
+    index_with_documents("indexUID-dump-creation", small_movies)
     dump = client.create_dump()
     assert dump['uid'] is not None
     assert dump['status'] == 'in_progress'
     wait_for_dump_creation(client, dump['uid'])
 
-def test_dump_status_route(client, custom_indexed_maker):
+def test_dump_status_route(client, index_with_documents, small_movies):
     """Tests the route for getting a MeiliSearch dump status"""
-    custom_indexed_maker("dump-status")
+    index_with_documents("indexUID-dump-status", small_movies)
     dump = client.create_dump()
     assert dump['uid'] is not None
     assert dump['status'] == 'in_progress'

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -1,3 +1,5 @@
+# pylint: disable=invalid-name
+
 import pytest
 from meilisearch.tests import wait_for_dump_creation
 from meilisearch.errors import MeiliSearchApiError

--- a/meilisearch/tests/client/test_client_dumps.py
+++ b/meilisearch/tests/client/test_client_dumps.py
@@ -1,7 +1,7 @@
 import json
 import pytest
 import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY, clear_all_indexes, wait_for_dump_creation
+from meilisearch.tests import BASE_URL, MASTER_KEY, wait_for_dump_creation
 from meilisearch.errors import MeiliSearchApiError
 
 class TestClientDumps:
@@ -14,7 +14,6 @@ class TestClientDumps:
     dataset_json = None
 
     def setup_class(self):
-        clear_all_indexes(self.client)
         self.dataset_file = open('./datasets/small_movies.json', 'r')
         self.dataset_json = json.loads(self.dataset_file.read())
         self.dataset_file.close()
@@ -27,10 +26,6 @@ class TestClientDumps:
 
     def teardown_method(self, method):
         self.client.index('indexUID-' + method.__name__).delete()
-
-    def teardown_class(self):
-        """Cleans all indexes in MEiliSearch when all the test are done"""
-        clear_all_indexes(self.client)
 
     def test_dump_creation(self):
         """Tests the creation of a MeiliSearch dump"""

--- a/meilisearch/tests/client/test_client_health_meilisearch.py
+++ b/meilisearch/tests/client/test_client_health_meilisearch.py
@@ -1,13 +1,5 @@
-import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY
 
-class TestHealth:
-
-    """ TESTS: health route """
-
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-
-    def test_health(self):
-        """Tests checking the health of MeiliSearch instance"""
-        response = self.client.health()
-        assert response.status_code >= 200 and response.status_code < 400
+def test_health(client):
+    """Tests checking the health of MeiliSearch instance"""
+    response = client.health()
+    assert response.status_code >= 200 and response.status_code < 400

--- a/meilisearch/tests/client/test_client_key_meilisearch.py
+++ b/meilisearch/tests/client/test_client_key_meilisearch.py
@@ -1,17 +1,9 @@
-import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY
 
-class TestKey:
-
-    """ TESTS: key route """
-
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-
-    def test_get_keys(self):
-        """Tests if public and private keys are generated and retrieved"""
-        response = self.client.get_keys()
-        assert isinstance(response, dict)
-        assert 'public' in response
-        assert 'private' in response
-        assert response['public'] is not None
-        assert response['private'] is not None
+def test_get_keys(client):
+    """Tests if public and private keys are generated and retrieved"""
+    response = client.get_keys()
+    assert isinstance(response, dict)
+    assert 'public' in response
+    assert 'private' in response
+    assert response['public'] is not None
+    assert response['private'] is not None

--- a/meilisearch/tests/client/test_client_stats_meilisearch.py
+++ b/meilisearch/tests/client/test_client_stats_meilisearch.py
@@ -1,29 +1,12 @@
-import meilisearch
 
-class TestStats:
 
-    """ TESTS: client stats route """
-
-    # client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    # index = None
-    # index2 = None
-
-    # def setup_class(self):
-    #     clear_all_indexes(self.client)
-    #     self.index = self.client.create_index(uid='indexUID')
-    #     self.index_2 = self.client.create_index(uid='indexUID2')
-
-    # def teardown_class(self):
-    #     self.index.delete()
-    #     self.index_2.delete()
-
-    def test_get_all_stats(self, client, sample_indexes):
-        """Tests getting all stats after creating two indexes"""
-        response = client.get_all_stats()
-        assert isinstance(response, object)
-        assert 'databaseSize' in response
-        assert isinstance(response['databaseSize'], int)
-        assert 'lastUpdate' in response
-        assert 'indexes' in response
-        assert 'indexUID' in response['indexes']
-        assert 'indexUID2' in response['indexes']
+def test_get_all_stats(client, sample_indexes):
+    """Tests getting all stats after creating two indexes"""
+    response = client.get_all_stats()
+    assert isinstance(response, object)
+    assert 'databaseSize' in response
+    assert isinstance(response['databaseSize'], int)
+    assert 'lastUpdate' in response
+    assert 'indexes' in response
+    assert 'indexUID' in response['indexes']
+    assert 'indexUID2' in response['indexes']

--- a/meilisearch/tests/client/test_client_stats_meilisearch.py
+++ b/meilisearch/tests/client/test_client_stats_meilisearch.py
@@ -1,6 +1,7 @@
+import pytest
 
-
-def test_get_all_stats(client, sample_indexes):
+@pytest.mark.usefixtures("sample_indexes")
+def test_get_all_stats(client):
     """Tests getting all stats after creating two indexes"""
     response = client.get_all_stats()
     assert isinstance(response, object)

--- a/meilisearch/tests/client/test_client_stats_meilisearch.py
+++ b/meilisearch/tests/client/test_client_stats_meilisearch.py
@@ -1,6 +1,6 @@
 import pytest
 
-@pytest.mark.usefixtures("sample_indexes")
+@pytest.mark.usefixtures("indexes_sample")
 def test_get_all_stats(client):
     """Tests getting all stats after creating two indexes"""
     response = client.get_all_stats()

--- a/meilisearch/tests/client/test_client_stats_meilisearch.py
+++ b/meilisearch/tests/client/test_client_stats_meilisearch.py
@@ -1,26 +1,25 @@
 import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY, clear_all_indexes
 
 class TestStats:
 
     """ TESTS: client stats route """
 
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    index = None
-    index2 = None
+    # client = meilisearch.Client(BASE_URL, MASTER_KEY)
+    # index = None
+    # index2 = None
 
-    def setup_class(self):
-        clear_all_indexes(self.client)
-        self.index = self.client.create_index(uid='indexUID')
-        self.index_2 = self.client.create_index(uid='indexUID2')
+    # def setup_class(self):
+    #     clear_all_indexes(self.client)
+    #     self.index = self.client.create_index(uid='indexUID')
+    #     self.index_2 = self.client.create_index(uid='indexUID2')
 
-    def teardown_class(self):
-        self.index.delete()
-        self.index_2.delete()
+    # def teardown_class(self):
+    #     self.index.delete()
+    #     self.index_2.delete()
 
-    def test_get_all_stats(self):
+    def test_get_all_stats(self, client, sample_indexes):
         """Tests getting all stats after creating two indexes"""
-        response = self.client.get_all_stats()
+        response = client.get_all_stats()
         assert isinstance(response, object)
         assert 'databaseSize' in response
         assert isinstance(response['databaseSize'], int)

--- a/meilisearch/tests/client/test_client_version_meilisearch.py
+++ b/meilisearch/tests/client/test_client_version_meilisearch.py
@@ -1,12 +1,7 @@
-import meilisearch
 
-
-class TestVersion:
-    """ TESTS: version route """
-
-    def test_get_version(self, client, sample_indexes):
-        """Tests getting the version of the MeiliSearch instance"""
-        response = client.get_version()
-        assert 'pkgVersion' in response
-        assert 'commitSha' in response
-        assert 'buildDate' in response
+def test_get_version(client):
+    """Tests getting the version of the MeiliSearch instance"""
+    response = client.get_version()
+    assert 'pkgVersion' in response
+    assert 'commitSha' in response
+    assert 'buildDate' in response

--- a/meilisearch/tests/client/test_client_version_meilisearch.py
+++ b/meilisearch/tests/client/test_client_version_meilisearch.py
@@ -1,22 +1,12 @@
 import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY, clear_all_indexes
+
 
 class TestVersion:
     """ TESTS: version route """
 
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    index = None
-
-    def setup_class(self):
-        clear_all_indexes(self.client)
-        self.index = self.client.create_index(uid='indexUID')
-
-    def teardown_class(self):
-        self.index.delete()
-
-    def test_get_version(self):
+    def test_get_version(self, client, sample_indexes):
         """Tests getting the version of the MeiliSearch instance"""
-        response = self.client.get_version()
+        response = client.get_version()
         assert 'pkgVersion' in response
         assert 'commitSha' in response
         assert 'buildDate' in response

--- a/meilisearch/tests/common.py
+++ b/meilisearch/tests/common.py
@@ -1,0 +1,27 @@
+import meilisearch
+
+MASTER_KEY = 'masterKey'
+BASE_URL = 'http://127.0.0.1:7700'
+
+client = meilisearch.Client(BASE_URL, MASTER_KEY)
+
+index_uid = 'indexUID'
+index_uid2 = 'indexUID2'
+index_uid3 = 'indexUID3'
+index_uid4 = 'indexUID4'
+
+
+# TODO: move this data
+index_fixture = [
+	{
+		"uid": index_uid
+	},
+	{
+		"uid": index_uid2,
+		"options": {'primaryKey': 'book_id'}
+	},
+	{
+		"uid": index_uid3,
+		"options": {'uid': 'wrong', 'primaryKey': 'book_id'}
+	}
+]

--- a/meilisearch/tests/common.py
+++ b/meilisearch/tests/common.py
@@ -1,5 +1,3 @@
-
-
 MASTER_KEY = 'masterKey'
 BASE_URL = 'http://127.0.0.1:7700'
 

--- a/meilisearch/tests/common.py
+++ b/meilisearch/tests/common.py
@@ -1,9 +1,7 @@
-import meilisearch
+
 
 MASTER_KEY = 'masterKey'
 BASE_URL = 'http://127.0.0.1:7700'
-
-client = meilisearch.Client(BASE_URL, MASTER_KEY)
 
 index_uid = 'indexUID'
 index_uid2 = 'indexUID2'

--- a/meilisearch/tests/common.py
+++ b/meilisearch/tests/common.py
@@ -6,7 +6,6 @@ INDEX_UID2 = 'indexUID2'
 INDEX_UID3 = 'indexUID3'
 INDEX_UID4 = 'indexUID4'
 
-
 INDEX_FIXTURE = [
 	{
 		"uid": INDEX_UID

--- a/meilisearch/tests/common.py
+++ b/meilisearch/tests/common.py
@@ -3,23 +3,22 @@
 MASTER_KEY = 'masterKey'
 BASE_URL = 'http://127.0.0.1:7700'
 
-index_uid = 'indexUID'
-index_uid2 = 'indexUID2'
-index_uid3 = 'indexUID3'
-index_uid4 = 'indexUID4'
+INDEX_UID = 'indexUID'
+INDEX_UID2 = 'indexUID2'
+INDEX_UID3 = 'indexUID3'
+INDEX_UID4 = 'indexUID4'
 
 
-# TODO: move this data
-index_fixture = [
+INDEX_FIXTURE = [
 	{
-		"uid": index_uid
+		"uid": INDEX_UID
 	},
 	{
-		"uid": index_uid2,
+		"uid": INDEX_UID2,
 		"options": {'primaryKey': 'book_id'}
 	},
 	{
-		"uid": index_uid3,
+		"uid": INDEX_UID3,
 		"options": {'uid': 'wrong', 'primaryKey': 'book_id'}
 	}
 ]

--- a/meilisearch/tests/common.py
+++ b/meilisearch/tests/common.py
@@ -7,15 +7,15 @@ INDEX_UID3 = 'indexUID3'
 INDEX_UID4 = 'indexUID4'
 
 INDEX_FIXTURE = [
-	{
-		"uid": INDEX_UID
-	},
-	{
-		"uid": INDEX_UID2,
-		"options": {'primaryKey': 'book_id'}
-	},
-	{
-		"uid": INDEX_UID3,
-		"options": {'uid': 'wrong', 'primaryKey': 'book_id'}
-	}
+    {
+        "uid": INDEX_UID
+    },
+    {
+        "uid": INDEX_UID2,
+        "options": {'primaryKey': 'book_id'}
+    },
+    {
+        "uid": INDEX_UID3,
+        "options": {'uid': 'wrong', 'primaryKey': 'book_id'}
+    }
 ]

--- a/meilisearch/tests/conftest.py
+++ b/meilisearch/tests/conftest.py
@@ -43,22 +43,12 @@ def small_movies():
 
 
 @fixture(scope='function')
-def index_with_documents(indexes_sample, small_movies):
-    """
-    Add small movies sample entries to the index(es)
-    """
-    response = indexes_sample[0].add_documents(small_movies)
-    indexes_sample[0].wait_for_pending_update(response['updateId'])
-    return indexes_sample[0]
-
-
-@fixture(scope='function')
-def custom_indexed_maker(client, small_movies):
-    def index_maker(index_suffix):
-        index = client.create_index(uid='indexUID-' + index_suffix)
-        response = index.add_documents(small_movies, primary_key='id')
+def index_with_documents(client, small_movies):
+    def index_maker(index_name=common.INDEX_UID, documents=small_movies):
+        index = client.create_index(uid=index_name)
+        response = index.add_documents(documents)
         index.wait_for_pending_update(response['updateId'])
-        yield
+        return index
         # cleanup
         index.delete()
     return index_maker

--- a/meilisearch/tests/conftest.py
+++ b/meilisearch/tests/conftest.py
@@ -30,13 +30,6 @@ def indexes_sample(client):
         indexes.append(client.create_index(**index_args))
     # yield the indexes to the test so it can use it
     yield indexes
-    # test finished, let's cleanup
-    for index in indexes:
-        try:
-            index.delete()
-        except meilisearch.errors.MeiliSearchApiError:
-            # test deleted index explicitly
-            pass
 
 
 @fixture(scope='session')

--- a/meilisearch/tests/conftest.py
+++ b/meilisearch/tests/conftest.py
@@ -1,0 +1,28 @@
+import json
+from pytest import fixture
+
+from meilisearch.tests import clear_all_indexes, common
+
+@fixture(autouse=True)
+def clear_indexes():
+	"""
+	Auto clear the indexes after each tetst function run.
+	helps with identifying tests that are not independent.
+	"""
+	# Yield back to the test function
+	yield
+	# test function has finished, let's cleanup
+	clear_all_indexes(common.client)
+
+
+@fixture(scope="function")
+def sample_indexes():
+	indexes = []
+	for index_args in common.index_fixture:
+		indexes.append(common.client.create_index(**index_args))
+	return indexes
+
+@fixture(scope="session")
+def small_movies():
+	with open('./datasets/small_movies.json', 'r') as movie_file:
+		yield json.loads(movie_file.read())

--- a/meilisearch/tests/conftest.py
+++ b/meilisearch/tests/conftest.py
@@ -49,6 +49,4 @@ def index_with_documents(client, small_movies):
         response = index.add_documents(documents)
         index.wait_for_pending_update(response['updateId'])
         return index
-        # cleanup
-        index.delete()
     return index_maker

--- a/meilisearch/tests/conftest.py
+++ b/meilisearch/tests/conftest.py
@@ -57,3 +57,15 @@ def indexed_small_movies(sample_indexes, small_movies):
     response = sample_indexes[0].add_documents(small_movies)
     sample_indexes[0].wait_for_pending_update(response['updateId'])
     return sample_indexes
+
+
+@fixture(scope="function")
+def custom_indexed_maker(client, small_movies):
+    def index_maker(index_suffix):
+        index = client.create_index(uid='indexUID-' + index_suffix)
+        response = index.add_documents(small_movies, primary_key='id')
+        index.wait_for_pending_update(response['updateId'])
+        yield
+        # cleanup
+        index.delete()
+    return index_maker

--- a/meilisearch/tests/conftest.py
+++ b/meilisearch/tests/conftest.py
@@ -1,3 +1,4 @@
+# pylint: disable=redefined-outer-name
 import json
 from pytest import fixture
 
@@ -25,7 +26,7 @@ def clear_indexes(client):
 @fixture(scope="function")
 def sample_indexes(client):
     indexes = []
-    for index_args in common.index_fixture:
+    for index_args in common.INDEX_FIXTURE:
         indexes.append(client.create_index(**index_args))
     # yield the indexes to the test so it can use it
     yield indexes

--- a/meilisearch/tests/conftest.py
+++ b/meilisearch/tests/conftest.py
@@ -43,9 +43,16 @@ def small_movies():
 
 
 @fixture(scope='function')
-def index_with_documents(client, small_movies):
+def empty_index(client):
+    def index_maker(index_name=common.INDEX_UID):
+        return client.create_index(uid=index_name)
+    return index_maker
+
+
+@fixture(scope='function')
+def index_with_documents(empty_index, small_movies):
     def index_maker(index_name=common.INDEX_UID, documents=small_movies):
-        index = client.create_index(uid=index_name)
+        index = empty_index(index_name)
         response = index.add_documents(documents)
         index.wait_for_pending_update(response['updateId'])
         return index

--- a/meilisearch/tests/conftest.py
+++ b/meilisearch/tests/conftest.py
@@ -5,7 +5,7 @@ from pytest import fixture
 from meilisearch.tests import common
 import meilisearch
 
-@fixture(scope="session")
+@fixture(scope='session')
 def client():
     return meilisearch.Client(common.BASE_URL, common.MASTER_KEY)
 
@@ -23,7 +23,7 @@ def clear_indexes(client):
         client.index(index['uid']).delete()
 
 
-@fixture(scope="function")
+@fixture(scope='function')
 def sample_indexes(client):
     indexes = []
     for index_args in common.INDEX_FIXTURE:
@@ -39,7 +39,7 @@ def sample_indexes(client):
             pass
 
 
-@fixture(scope="session")
+@fixture(scope='session')
 def small_movies():
     """
     Run once per session, provide the content of small_movies.json
@@ -49,17 +49,17 @@ def small_movies():
         yield json.loads(movie_file.read())
 
 
-@fixture(scope="function")
-def indexed_small_movies(sample_indexes, small_movies):
+@fixture(scope='function')
+def index_with_documents(sample_indexes, small_movies):
     """
     Add small movies sample entries to the index(es)
     """
     response = sample_indexes[0].add_documents(small_movies)
     sample_indexes[0].wait_for_pending_update(response['updateId'])
-    return sample_indexes
+    return sample_indexes[0]
 
 
-@fixture(scope="function")
+@fixture(scope='function')
 def custom_indexed_maker(client, small_movies):
     def index_maker(index_suffix):
         index = client.create_index(uid='indexUID-' + index_suffix)

--- a/meilisearch/tests/conftest.py
+++ b/meilisearch/tests/conftest.py
@@ -9,7 +9,6 @@ import meilisearch
 def client():
     return meilisearch.Client(common.BASE_URL, common.MASTER_KEY)
 
-# TODO: this will not be needed anymore?
 @fixture(autouse=True)
 def clear_indexes(client):
     """

--- a/meilisearch/tests/conftest.py
+++ b/meilisearch/tests/conftest.py
@@ -1,28 +1,54 @@
 import json
+from time import sleep
 from pytest import fixture
 
 from meilisearch.tests import clear_all_indexes, common
+import meilisearch
 
+@fixture(scope="session")
+def client():
+    return meilisearch.Client(common.BASE_URL, common.MASTER_KEY)
+
+# TODO: this will not be needed anymore?
 @fixture(autouse=True)
-def clear_indexes():
-	"""
-	Auto clear the indexes after each tetst function run.
-	helps with identifying tests that are not independent.
-	"""
-	# Yield back to the test function
-	yield
-	# test function has finished, let's cleanup
-	clear_all_indexes(common.client)
+def clear_indexes(client):
+    """
+    Auto clear the indexes after each tetst function run.
+    helps with identifying tests that are not independent.
+    """
+    # Yield back to the test function
+    yield
+    # test function has finished, let's cleanup
+    # TODO: don't call other function, jsut do it here
+    clear_all_indexes(client)
 
 
 @fixture(scope="function")
-def sample_indexes():
-	indexes = []
-	for index_args in common.index_fixture:
-		indexes.append(common.client.create_index(**index_args))
-	return indexes
+def sample_indexes(client):
+    indexes = []
+    for index_args in common.index_fixture:
+        indexes.append(client.create_index(**index_args))
+    # Give the indexes to the test so it can use it
+    yield indexes
+    # tests finished, let's cleanup
+    for index in indexes:
+        try:
+            index.delete()
+        except meilisearch.errors.MeiliSearchApiError:
+            # test deleted itself explicitly, pass
+            pass
+
 
 @fixture(scope="session")
 def small_movies():
-	with open('./datasets/small_movies.json', 'r') as movie_file:
-		yield json.loads(movie_file.read())
+    with open('./datasets/small_movies.json', 'r') as movie_file:
+        yield json.loads(movie_file.read())
+
+
+@fixture(scope="function")
+def indexed_small_movies(sample_indexes, small_movies):
+    response = sample_indexes[0].add_documents(small_movies)
+    sample_indexes[0].wait_for_pending_update(response['updateId'])
+    # wait a bit for the index to build?
+    # sleep(0.1)
+    return sample_indexes

--- a/meilisearch/tests/conftest.py
+++ b/meilisearch/tests/conftest.py
@@ -24,7 +24,7 @@ def clear_indexes(client):
 
 
 @fixture(scope='function')
-def sample_indexes(client):
+def indexes_sample(client):
     indexes = []
     for index_args in common.INDEX_FIXTURE:
         indexes.append(client.create_index(**index_args))
@@ -50,13 +50,13 @@ def small_movies():
 
 
 @fixture(scope='function')
-def index_with_documents(sample_indexes, small_movies):
+def index_with_documents(indexes_sample, small_movies):
     """
     Add small movies sample entries to the index(es)
     """
-    response = sample_indexes[0].add_documents(small_movies)
-    sample_indexes[0].wait_for_pending_update(response['updateId'])
-    return sample_indexes[0]
+    response = indexes_sample[0].add_documents(small_movies)
+    indexes_sample[0].wait_for_pending_update(response['updateId'])
+    return indexes_sample[0]
 
 
 @fixture(scope='function')

--- a/meilisearch/tests/errors/test_api_error_meilisearch.py
+++ b/meilisearch/tests/errors/test_api_error_meilisearch.py
@@ -1,3 +1,5 @@
+# pylint: disable=invalid-name
+
 import pytest
 import meilisearch
 from meilisearch.errors import MeiliSearchApiError

--- a/meilisearch/tests/errors/test_api_error_meilisearch.py
+++ b/meilisearch/tests/errors/test_api_error_meilisearch.py
@@ -3,18 +3,12 @@ import meilisearch
 from meilisearch.errors import MeiliSearchApiError
 from meilisearch.tests import BASE_URL, MASTER_KEY
 
-class TestMeiliSearchApiError:
+def test_meilisearch_api_error_no_master_key():
+    client = meilisearch.Client(BASE_URL)
+    with pytest.raises(MeiliSearchApiError):
+        client.create_index("some_index")
 
-    """ TESTS: MeiliSearchApiError class """
-
-    @staticmethod
-    def test_meilisearch_api_error_no_master_key():
-        client = meilisearch.Client(BASE_URL)
-        with pytest.raises(MeiliSearchApiError):
-            client.create_index("some_index")
-
-    @staticmethod
-    def test_meilisearch_api_error_wrong_master_key():
-        client = meilisearch.Client(BASE_URL, MASTER_KEY + '123')
-        with pytest.raises(MeiliSearchApiError):
-            client.create_index("some_index")
+def test_meilisearch_api_error_wrong_master_key():
+    client = meilisearch.Client(BASE_URL, MASTER_KEY + '123')
+    with pytest.raises(MeiliSearchApiError):
+        client.create_index("some_index")

--- a/meilisearch/tests/errors/test_communication_error_meilisearch.py
+++ b/meilisearch/tests/errors/test_communication_error_meilisearch.py
@@ -3,12 +3,7 @@ import meilisearch
 from meilisearch.errors import MeiliSearchCommunicationError
 from meilisearch.tests import MASTER_KEY
 
-class TestMeiliSearchCommunicationError:
-
-    """ TESTS: MeiliSearchCommunicationError class """
-
-    @staticmethod
-    def test_meilisearch_communication_error_host():
-        client = meilisearch.Client("http://wrongurl:1234", MASTER_KEY)
-        with pytest.raises(MeiliSearchCommunicationError):
-            client.create_index("some_index")
+def test_meilisearch_communication_error_host():
+    client = meilisearch.Client("http://wrongurl:1234", MASTER_KEY)
+    with pytest.raises(MeiliSearchCommunicationError):
+        client.create_index("some_index")

--- a/meilisearch/tests/errors/test_communication_error_meilisearch.py
+++ b/meilisearch/tests/errors/test_communication_error_meilisearch.py
@@ -1,3 +1,5 @@
+# pylint: disable=invalid-name
+
 import pytest
 import meilisearch
 from meilisearch.errors import MeiliSearchCommunicationError

--- a/meilisearch/tests/helper.py
+++ b/meilisearch/tests/helper.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+from time import sleep
+
+# Waits until the end of the dump creation.
+# Raises a TimeoutError if the `timeout_in_ms` is reached.
+def wait_for_dump_creation(client, dump_uid, timeout_in_ms=10000, interval_in_ms=500):
+    start_time = datetime.now()
+    elapsed_time = 0
+    while elapsed_time < timeout_in_ms:
+        dump = client.get_dump_status(dump_uid)
+        if dump['status'] != 'in_progress':
+            return
+        sleep(interval_in_ms / 1000)
+        time_delta = datetime.now() - start_time
+        elapsed_time = time_delta.seconds * 1000 + time_delta.microseconds / 1000
+    raise TimeoutError

--- a/meilisearch/tests/index/test_index.py
+++ b/meilisearch/tests/index/test_index.py
@@ -70,7 +70,6 @@ def test_get_index_with_wrong_uid(client):
 
 def test_get_or_create_index(client):
     """Test get_or_create_index method"""
-    # client.create_index(common.INDEX_UID3)
     index_1 = client.get_or_create_index(common.INDEX_UID4)
     index_2 = client.get_or_create_index(common.INDEX_UID4)
     index_3 = client.get_or_create_index(common.INDEX_UID4)

--- a/meilisearch/tests/index/test_index.py
+++ b/meilisearch/tests/index/test_index.py
@@ -1,3 +1,5 @@
+# pylint: disable=invalid-name
+
 import pytest
 from meilisearch.index import Index
 from meilisearch.tests import common

--- a/meilisearch/tests/index/test_index.py
+++ b/meilisearch/tests/index/test_index.py
@@ -3,148 +3,146 @@ from meilisearch.index import Index
 from meilisearch.tests import common
 
 
-class TestIndex:
 
+def test_create_index(client):
+    """Tests creating an index"""
+    index = client.create_index(uid=common.index_uid)
+    assert isinstance(index, Index)
+    assert index.uid == common.index_uid
+    assert index.primary_key is None
+    assert index.get_primary_key() is None
 
-    def test_create_index(self, client):
-        """Tests creating an index"""
-        index = client.create_index(uid=common.index_uid)
-        assert isinstance(index, Index)
-        assert index.uid == common.index_uid
-        assert index.primary_key is None
-        assert index.get_primary_key() is None
+def test_create_index_with_primary_key(client):
+    """Tests creating an index with a primary key"""
+    index = client.create_index(uid=common.index_uid2, options={'primaryKey': 'book_id'})
+    assert isinstance(index, Index)
+    assert index.uid == common.index_uid2
+    assert index.primary_key == 'book_id'
+    assert index.get_primary_key() == 'book_id'
 
-    def test_create_index_with_primary_key(self, client):
-        """Tests creating an index with a primary key"""
-        index = client.create_index(uid=common.index_uid2, options={'primaryKey': 'book_id'})
-        assert isinstance(index, Index)
-        assert index.uid == common.index_uid2
-        assert index.primary_key == 'book_id'
-        assert index.get_primary_key() == 'book_id'
+def test_create_index_with_uid_in_options(client):
+    """Tests creating an index with a primary key"""
+    index = client.create_index(uid=common.index_uid3, options={'uid': 'wrong', 'primaryKey': 'book_id'})
+    assert isinstance(index, Index)
+    assert index.uid == common.index_uid3
+    assert index.primary_key == 'book_id'
+    assert index.get_primary_key() == 'book_id'
 
-    def test_create_index_with_uid_in_options(self, client):
-        """Tests creating an index with a primary key"""
-        index = client.create_index(uid=common.index_uid3, options={'uid': 'wrong', 'primaryKey': 'book_id'})
-        assert isinstance(index, Index)
-        assert index.uid == common.index_uid3
-        assert index.primary_key == 'book_id'
-        assert index.get_primary_key() == 'book_id'
+def test_get_indexes(client, sample_indexes):
+    """Tests getting all indexes"""
+    response = client.get_indexes()
+    uids = [index['uid'] for index in response]
+    assert isinstance(response, list)
+    assert common.index_uid in uids
+    assert common.index_uid2 in uids
+    assert common.index_uid3 in uids
+    assert len(response) == 3
 
-    def test_get_indexes(self, client, sample_indexes):
-        """Tests getting all indexes"""
-        response = client.get_indexes()
-        uids = [index['uid'] for index in response]
-        assert isinstance(response, list)
-        assert common.index_uid in uids
-        assert common.index_uid2 in uids
-        assert common.index_uid3 in uids
-        assert len(response) == 3
+def test_index_with_any_uid(client):
+    index = client.index('anyUID')
+    assert isinstance(index, Index)
+    assert index.uid == 'anyUID'
+    assert index.primary_key is None
+    assert index.config is not None
+    assert index.http is not None
 
-    def test_index_with_any_uid(self, client):
-        index = client.index('anyUID')
-        assert isinstance(index, Index)
-        assert index.uid == 'anyUID'
-        assert index.primary_key is None
-        assert index.config is not None
-        assert index.http is not None
+def test_index_with_none_uid(client):
+    with pytest.raises(Exception):
+        client.index(None)
 
-    def test_index_with_none_uid(self, client):
-        with pytest.raises(Exception):
-            client.index(None)
+def test_get_index_with_valid_uid(client, sample_indexes):
+    """Tests getting one index with uid"""
+    response = client.get_index(uid=common.index_uid)
+    assert isinstance(response, Index)
+    assert response.uid == common.index_uid
 
-    def test_get_index_with_valid_uid(self, client, sample_indexes):
-        """Tests getting one index with uid"""
-        response = client.get_index(uid=common.index_uid)
-        assert isinstance(response, Index)
-        assert response.uid == common.index_uid
+def test_get_index_with_none_uid(client):
+    """Test raising an exception if the index UID is None"""
+    with pytest.raises(Exception):
+        client.get_index(uid=None)
 
-    def test_get_index_with_none_uid(self, client):
-        """Test raising an exception if the index UID is None"""
-        with pytest.raises(Exception):
-            client.get_index(uid=None)
+def test_get_index_with_wrong_uid(client):
+    """Tests get_index with an non-existing index"""
+    with pytest.raises(Exception):
+        client.get_index(uid='wrongUID')
 
-    def test_get_index_with_wrong_uid(self, client):
-        """Tests get_index with an non-existing index"""
-        with pytest.raises(Exception):
-            client.get_index(uid='wrongUID')
+def test_get_or_create_index(client):
+    """Test get_or_create_index method"""
+    # client.create_index(common.index_uid3)
+    index_1 = client.get_or_create_index(common.index_uid4)
+    index_2 = client.get_or_create_index(common.index_uid4)
+    index_3 = client.get_or_create_index(common.index_uid4)
+    assert index_1.uid == index_2.uid == index_3.uid == common.index_uid4
+    update = index_1.add_documents([{
+        'book_id': 1,
+        'name': "Some book"
+    }])
+    index_1.wait_for_pending_update(update['updateId'])
+    documents = index_2.get_documents()
+    assert len(documents) == 1
+    index_2.delete()
+    with pytest.raises(Exception):
+        client.get_index(index_3)
 
-    def test_get_or_create_index(self, client):
-        """Test get_or_create_index method"""
-        # client.create_index(common.index_uid3)
-        index_1 = client.get_or_create_index(common.index_uid4)
-        index_2 = client.get_or_create_index(common.index_uid4)
-        index_3 = client.get_or_create_index(common.index_uid4)
-        assert index_1.uid == index_2.uid == index_3.uid == common.index_uid4
-        update = index_1.add_documents([{
-            'book_id': 1,
-            'name': "Some book"
-        }])
-        index_1.wait_for_pending_update(update['updateId'])
-        documents = index_2.get_documents()
-        assert len(documents) == 1
-        index_2.delete()
-        with pytest.raises(Exception):
-            client.get_index(index_3)
+def test_get_or_create_index_with_primary_key(client):
+    """Test get_or_create_index method with primary key"""
+    index_1 = client.get_or_create_index('books', {'primaryKey': common.index_uid4})
+    index_2 = client.get_or_create_index('books', {'primaryKey': 'some_wrong_key'})
+    assert index_1.primary_key == common.index_uid4
+    assert index_1.get_primary_key() == common.index_uid4
+    assert index_2.primary_key == common.index_uid4
+    assert index_2.get_primary_key() == common.index_uid4
+    index_1.delete()
 
-    def test_get_or_create_index_with_primary_key(self, client):
-        """Test get_or_create_index method with primary key"""
-        index_1 = client.get_or_create_index('books', {'primaryKey': common.index_uid4})
-        index_2 = client.get_or_create_index('books', {'primaryKey': 'some_wrong_key'})
-        assert index_1.primary_key == common.index_uid4
-        assert index_1.get_primary_key() == common.index_uid4
-        assert index_2.primary_key == common.index_uid4
-        assert index_2.get_primary_key() == common.index_uid4
-        index_1.delete()
+def test_index_fetch_info(client, sample_indexes):
+    """Tests getting the index info"""
+    index = client.index(uid=common.index_uid)
+    response = index.fetch_info()
+    assert isinstance(response, Index)
+    assert response.uid == common.index_uid
+    assert response.primary_key is None
+    assert response.primary_key == index.primary_key
+    assert response.primary_key == index.get_primary_key()
 
-    def test_index_fetch_info(self, client, sample_indexes):
-        """Tests getting the index info"""
-        index = client.index(uid=common.index_uid)
-        response = index.fetch_info()
-        assert isinstance(response, Index)
-        assert response.uid == common.index_uid
-        assert response.primary_key is None
-        assert response.primary_key == index.primary_key
-        assert response.primary_key == index.get_primary_key()
+def test_index_fetch_info_containing_primary_key(client, sample_indexes):
+    """Tests getting the index info"""
+    index = client.index(uid=common.index_uid3)
+    response = index.fetch_info()
+    assert isinstance(response, Index)
+    assert response.uid == common.index_uid3
+    assert response.primary_key == 'book_id'
+    assert response.primary_key == index.primary_key
+    assert response.primary_key == index.get_primary_key()
 
-    def test_index_fetch_info_containing_primary_key(self, client, sample_indexes):
-        """Tests getting the index info"""
-        index = client.index(uid=common.index_uid3)
-        response = index.fetch_info()
-        assert isinstance(response, Index)
-        assert response.uid == common.index_uid3
-        assert response.primary_key == 'book_id'
-        assert response.primary_key == index.primary_key
-        assert response.primary_key == index.get_primary_key()
+def test_get_primary_key(client, sample_indexes):
+    """Tests getting the primary-key of an index"""
+    index = client.index(uid=common.index_uid3)
+    assert index.primary_key is None
+    response = index.get_primary_key()
+    assert response == 'book_id'
+    assert index.primary_key == 'book_id'
+    assert index.get_primary_key() == 'book_id'
 
-    def test_get_primary_key(self, client, sample_indexes):
-        """Tests getting the primary-key of an index"""
-        index = client.index(uid=common.index_uid3)
-        assert index.primary_key is None
-        response = index.get_primary_key()
-        assert response == 'book_id'
-        assert index.primary_key == 'book_id'
-        assert index.get_primary_key() == 'book_id'
+def test_update_index(client, sample_indexes):
+    """Tests updating an index"""
+    index = client.index(uid=common.index_uid)
+    response = index.update(primaryKey='objectID')
+    assert isinstance(response, Index)
+    assert index.primary_key == 'objectID'
+    assert index.get_primary_key() == 'objectID'
 
-    def test_update_index(self, client, sample_indexes):
-        """Tests updating an index"""
-        index = client.index(uid=common.index_uid)
-        response = index.update(primaryKey='objectID')
-        assert isinstance(response, Index)
-        assert index.primary_key == 'objectID'
-        assert index.get_primary_key() == 'objectID'
-
-    def test_delete_index(self, client, sample_indexes):
-        """Tests deleting an index"""
-        response = client.index(uid=common.index_uid).delete()
-        assert response.status_code == 204
-        with pytest.raises(Exception):
-            client.get_index(uid=common.index_uid)
-        response = client.index(uid=common.index_uid2).delete()
-        assert response.status_code == 204
-        with pytest.raises(Exception):
-            client.get_index(uid=common.index_uid2)
-        response = client.index(uid=common.index_uid3).delete()
-        assert response.status_code == 204
-        with pytest.raises(Exception):
-            client.get_index(uid=common.index_uid3)
-        assert len(client.get_indexes()) == 0
+def test_delete_index(client, sample_indexes):
+    """Tests deleting an index"""
+    response = client.index(uid=common.index_uid).delete()
+    assert response.status_code == 204
+    with pytest.raises(Exception):
+        client.get_index(uid=common.index_uid)
+    response = client.index(uid=common.index_uid2).delete()
+    assert response.status_code == 204
+    with pytest.raises(Exception):
+        client.get_index(uid=common.index_uid2)
+    response = client.index(uid=common.index_uid3).delete()
+    assert response.status_code == 204
+    with pytest.raises(Exception):
+        client.get_index(uid=common.index_uid3)
+    assert len(client.get_indexes()) == 0

--- a/meilisearch/tests/index/test_index.py
+++ b/meilisearch/tests/index/test_index.py
@@ -6,33 +6,33 @@ from meilisearch.tests import common
 class TestIndex:
 
 
-    def test_create_index(self):
+    def test_create_index(self, client):
         """Tests creating an index"""
-        index = common.client.create_index(uid=common.index_uid)
+        index = client.create_index(uid=common.index_uid)
         assert isinstance(index, Index)
         assert index.uid == common.index_uid
         assert index.primary_key is None
         assert index.get_primary_key() is None
 
-    def test_create_index_with_primary_key(self):
+    def test_create_index_with_primary_key(self, client):
         """Tests creating an index with a primary key"""
-        index = common.client.create_index(uid=common.index_uid2, options={'primaryKey': 'book_id'})
+        index = client.create_index(uid=common.index_uid2, options={'primaryKey': 'book_id'})
         assert isinstance(index, Index)
         assert index.uid == common.index_uid2
         assert index.primary_key == 'book_id'
         assert index.get_primary_key() == 'book_id'
 
-    def test_create_index_with_uid_in_options(self):
+    def test_create_index_with_uid_in_options(self, client):
         """Tests creating an index with a primary key"""
-        index = common.client.create_index(uid=common.index_uid3, options={'uid': 'wrong', 'primaryKey': 'book_id'})
+        index = client.create_index(uid=common.index_uid3, options={'uid': 'wrong', 'primaryKey': 'book_id'})
         assert isinstance(index, Index)
         assert index.uid == common.index_uid3
         assert index.primary_key == 'book_id'
         assert index.get_primary_key() == 'book_id'
 
-    def test_get_indexes(self, sample_indexes):
+    def test_get_indexes(self, client, sample_indexes):
         """Tests getting all indexes"""
-        response = common.client.get_indexes()
+        response = client.get_indexes()
         uids = [index['uid'] for index in response]
         assert isinstance(response, list)
         assert common.index_uid in uids
@@ -40,40 +40,40 @@ class TestIndex:
         assert common.index_uid3 in uids
         assert len(response) == 3
 
-    def test_index_with_any_uid(self):
-        index = common.client.index('anyUID')
+    def test_index_with_any_uid(self, client):
+        index = client.index('anyUID')
         assert isinstance(index, Index)
         assert index.uid == 'anyUID'
         assert index.primary_key is None
         assert index.config is not None
         assert index.http is not None
 
-    def test_index_with_none_uid(self):
+    def test_index_with_none_uid(self, client):
         with pytest.raises(Exception):
-            common.client.index(None)
+            client.index(None)
 
-    def test_get_index_with_valid_uid(self, sample_indexes):
+    def test_get_index_with_valid_uid(self, client, sample_indexes):
         """Tests getting one index with uid"""
-        response = common.client.get_index(uid=common.index_uid)
+        response = client.get_index(uid=common.index_uid)
         assert isinstance(response, Index)
         assert response.uid == common.index_uid
 
-    def test_get_index_with_none_uid(self):
+    def test_get_index_with_none_uid(self, client):
         """Test raising an exception if the index UID is None"""
         with pytest.raises(Exception):
-            common.client.get_index(uid=None)
+            client.get_index(uid=None)
 
-    def test_get_index_with_wrong_uid(self):
+    def test_get_index_with_wrong_uid(self, client):
         """Tests get_index with an non-existing index"""
         with pytest.raises(Exception):
-            common.client.get_index(uid='wrongUID')
+            client.get_index(uid='wrongUID')
 
-    def test_get_or_create_index(self):
+    def test_get_or_create_index(self, client):
         """Test get_or_create_index method"""
-        # common.client.create_index(common.index_uid3)
-        index_1 = common.client.get_or_create_index(common.index_uid4)
-        index_2 = common.client.get_or_create_index(common.index_uid4)
-        index_3 = common.client.get_or_create_index(common.index_uid4)
+        # client.create_index(common.index_uid3)
+        index_1 = client.get_or_create_index(common.index_uid4)
+        index_2 = client.get_or_create_index(common.index_uid4)
+        index_3 = client.get_or_create_index(common.index_uid4)
         assert index_1.uid == index_2.uid == index_3.uid == common.index_uid4
         update = index_1.add_documents([{
             'book_id': 1,
@@ -84,21 +84,21 @@ class TestIndex:
         assert len(documents) == 1
         index_2.delete()
         with pytest.raises(Exception):
-            common.client.get_index(index_3)
+            client.get_index(index_3)
 
-    def test_get_or_create_index_with_primary_key(self):
+    def test_get_or_create_index_with_primary_key(self, client):
         """Test get_or_create_index method with primary key"""
-        index_1 = common.client.get_or_create_index('books', {'primaryKey': common.index_uid4})
-        index_2 = common.client.get_or_create_index('books', {'primaryKey': 'some_wrong_key'})
+        index_1 = client.get_or_create_index('books', {'primaryKey': common.index_uid4})
+        index_2 = client.get_or_create_index('books', {'primaryKey': 'some_wrong_key'})
         assert index_1.primary_key == common.index_uid4
         assert index_1.get_primary_key() == common.index_uid4
         assert index_2.primary_key == common.index_uid4
         assert index_2.get_primary_key() == common.index_uid4
         index_1.delete()
 
-    def test_index_fetch_info(self, sample_indexes):
+    def test_index_fetch_info(self, client, sample_indexes):
         """Tests getting the index info"""
-        index = common.client.index(uid=common.index_uid)
+        index = client.index(uid=common.index_uid)
         response = index.fetch_info()
         assert isinstance(response, Index)
         assert response.uid == common.index_uid
@@ -106,9 +106,9 @@ class TestIndex:
         assert response.primary_key == index.primary_key
         assert response.primary_key == index.get_primary_key()
 
-    def test_index_fetch_info_containing_primary_key(self, sample_indexes):
+    def test_index_fetch_info_containing_primary_key(self, client, sample_indexes):
         """Tests getting the index info"""
-        index = common.client.index(uid=common.index_uid3)
+        index = client.index(uid=common.index_uid3)
         response = index.fetch_info()
         assert isinstance(response, Index)
         assert response.uid == common.index_uid3
@@ -116,35 +116,35 @@ class TestIndex:
         assert response.primary_key == index.primary_key
         assert response.primary_key == index.get_primary_key()
 
-    def test_get_primary_key(self, sample_indexes):
+    def test_get_primary_key(self, client, sample_indexes):
         """Tests getting the primary-key of an index"""
-        index = common.client.index(uid=common.index_uid3)
+        index = client.index(uid=common.index_uid3)
         assert index.primary_key is None
         response = index.get_primary_key()
         assert response == 'book_id'
         assert index.primary_key == 'book_id'
         assert index.get_primary_key() == 'book_id'
 
-    def test_update_index(self, sample_indexes):
+    def test_update_index(self, client, sample_indexes):
         """Tests updating an index"""
-        index = common.client.index(uid=common.index_uid)
+        index = client.index(uid=common.index_uid)
         response = index.update(primaryKey='objectID')
         assert isinstance(response, Index)
         assert index.primary_key == 'objectID'
         assert index.get_primary_key() == 'objectID'
 
-    def test_delete_index(self, sample_indexes):
+    def test_delete_index(self, client, sample_indexes):
         """Tests deleting an index"""
-        response = common.client.index(uid=common.index_uid).delete()
+        response = client.index(uid=common.index_uid).delete()
         assert response.status_code == 204
         with pytest.raises(Exception):
-            common.client.get_index(uid=common.index_uid)
-        response = common.client.index(uid=common.index_uid2).delete()
+            client.get_index(uid=common.index_uid)
+        response = client.index(uid=common.index_uid2).delete()
         assert response.status_code == 204
         with pytest.raises(Exception):
-            common.client.get_index(uid=common.index_uid2)
-        response = common.client.index(uid=common.index_uid3).delete()
+            client.get_index(uid=common.index_uid2)
+        response = client.index(uid=common.index_uid3).delete()
         assert response.status_code == 204
         with pytest.raises(Exception):
-            common.client.get_index(uid=common.index_uid3)
-        assert len(common.client.get_indexes()) == 0
+            client.get_index(uid=common.index_uid3)
+        assert len(client.get_indexes()) == 0

--- a/meilisearch/tests/index/test_index.py
+++ b/meilisearch/tests/index/test_index.py
@@ -6,36 +6,37 @@ from meilisearch.tests import common
 
 def test_create_index(client):
     """Tests creating an index"""
-    index = client.create_index(uid=common.index_uid)
+    index = client.create_index(uid=common.INDEX_UID)
     assert isinstance(index, Index)
-    assert index.uid == common.index_uid
+    assert index.uid == common.INDEX_UID
     assert index.primary_key is None
     assert index.get_primary_key() is None
 
 def test_create_index_with_primary_key(client):
     """Tests creating an index with a primary key"""
-    index = client.create_index(uid=common.index_uid2, options={'primaryKey': 'book_id'})
+    index = client.create_index(uid=common.INDEX_UID2, options={'primaryKey': 'book_id'})
     assert isinstance(index, Index)
-    assert index.uid == common.index_uid2
+    assert index.uid == common.INDEX_UID2
     assert index.primary_key == 'book_id'
     assert index.get_primary_key() == 'book_id'
 
 def test_create_index_with_uid_in_options(client):
     """Tests creating an index with a primary key"""
-    index = client.create_index(uid=common.index_uid3, options={'uid': 'wrong', 'primaryKey': 'book_id'})
+    index = client.create_index(uid=common.INDEX_UID3, options={'uid': 'wrong', 'primaryKey': 'book_id'})
     assert isinstance(index, Index)
-    assert index.uid == common.index_uid3
+    assert index.uid == common.INDEX_UID3
     assert index.primary_key == 'book_id'
     assert index.get_primary_key() == 'book_id'
 
-def test_get_indexes(client, sample_indexes):
+@pytest.mark.usefixtures("sample_indexes")
+def test_get_indexes(client):
     """Tests getting all indexes"""
     response = client.get_indexes()
     uids = [index['uid'] for index in response]
     assert isinstance(response, list)
-    assert common.index_uid in uids
-    assert common.index_uid2 in uids
-    assert common.index_uid3 in uids
+    assert common.INDEX_UID in uids
+    assert common.INDEX_UID2 in uids
+    assert common.INDEX_UID3 in uids
     assert len(response) == 3
 
 def test_index_with_any_uid(client):
@@ -50,11 +51,12 @@ def test_index_with_none_uid(client):
     with pytest.raises(Exception):
         client.index(None)
 
-def test_get_index_with_valid_uid(client, sample_indexes):
+@pytest.mark.usefixtures("sample_indexes")
+def test_get_index_with_valid_uid(client):
     """Tests getting one index with uid"""
-    response = client.get_index(uid=common.index_uid)
+    response = client.get_index(uid=common.INDEX_UID)
     assert isinstance(response, Index)
-    assert response.uid == common.index_uid
+    assert response.uid == common.INDEX_UID
 
 def test_get_index_with_none_uid(client):
     """Test raising an exception if the index UID is None"""
@@ -68,11 +70,11 @@ def test_get_index_with_wrong_uid(client):
 
 def test_get_or_create_index(client):
     """Test get_or_create_index method"""
-    # client.create_index(common.index_uid3)
-    index_1 = client.get_or_create_index(common.index_uid4)
-    index_2 = client.get_or_create_index(common.index_uid4)
-    index_3 = client.get_or_create_index(common.index_uid4)
-    assert index_1.uid == index_2.uid == index_3.uid == common.index_uid4
+    # client.create_index(common.INDEX_UID3)
+    index_1 = client.get_or_create_index(common.INDEX_UID4)
+    index_2 = client.get_or_create_index(common.INDEX_UID4)
+    index_3 = client.get_or_create_index(common.INDEX_UID4)
+    assert index_1.uid == index_2.uid == index_3.uid == common.INDEX_UID4
     update = index_1.add_documents([{
         'book_id': 1,
         'name': "Some book"
@@ -86,63 +88,68 @@ def test_get_or_create_index(client):
 
 def test_get_or_create_index_with_primary_key(client):
     """Test get_or_create_index method with primary key"""
-    index_1 = client.get_or_create_index('books', {'primaryKey': common.index_uid4})
+    index_1 = client.get_or_create_index('books', {'primaryKey': common.INDEX_UID4})
     index_2 = client.get_or_create_index('books', {'primaryKey': 'some_wrong_key'})
-    assert index_1.primary_key == common.index_uid4
-    assert index_1.get_primary_key() == common.index_uid4
-    assert index_2.primary_key == common.index_uid4
-    assert index_2.get_primary_key() == common.index_uid4
+    assert index_1.primary_key == common.INDEX_UID4
+    assert index_1.get_primary_key() == common.INDEX_UID4
+    assert index_2.primary_key == common.INDEX_UID4
+    assert index_2.get_primary_key() == common.INDEX_UID4
     index_1.delete()
 
-def test_index_fetch_info(client, sample_indexes):
+@pytest.mark.usefixtures("sample_indexes")
+def test_index_fetch_info(client):
     """Tests getting the index info"""
-    index = client.index(uid=common.index_uid)
+    index = client.index(uid=common.INDEX_UID)
     response = index.fetch_info()
     assert isinstance(response, Index)
-    assert response.uid == common.index_uid
+    assert response.uid == common.INDEX_UID
     assert response.primary_key is None
     assert response.primary_key == index.primary_key
     assert response.primary_key == index.get_primary_key()
 
-def test_index_fetch_info_containing_primary_key(client, sample_indexes):
+@pytest.mark.usefixtures("sample_indexes")
+def test_index_fetch_info_containing_primary_key(client):
     """Tests getting the index info"""
-    index = client.index(uid=common.index_uid3)
+    index = client.index(uid=common.INDEX_UID3)
     response = index.fetch_info()
     assert isinstance(response, Index)
-    assert response.uid == common.index_uid3
+    assert response.uid == common.INDEX_UID3
     assert response.primary_key == 'book_id'
     assert response.primary_key == index.primary_key
     assert response.primary_key == index.get_primary_key()
 
-def test_get_primary_key(client, sample_indexes):
+@pytest.mark.usefixtures("sample_indexes")
+def test_get_primary_key(client):
     """Tests getting the primary-key of an index"""
-    index = client.index(uid=common.index_uid3)
+    index = client.index(uid=common.INDEX_UID3)
     assert index.primary_key is None
     response = index.get_primary_key()
     assert response == 'book_id'
     assert index.primary_key == 'book_id'
     assert index.get_primary_key() == 'book_id'
 
-def test_update_index(client, sample_indexes):
+@pytest.mark.usefixtures("sample_indexes")
+def test_update_index(client):
     """Tests updating an index"""
-    index = client.index(uid=common.index_uid)
+    index = client.index(uid=common.INDEX_UID)
     response = index.update(primaryKey='objectID')
     assert isinstance(response, Index)
     assert index.primary_key == 'objectID'
     assert index.get_primary_key() == 'objectID'
 
-def test_delete_index(client, sample_indexes):
+@pytest.mark.usefixtures("sample_indexes")
+def test_delete_index(client):
     """Tests deleting an index"""
-    response = client.index(uid=common.index_uid).delete()
+    response = client.index(uid=common.INDEX_UID).delete()
     assert response.status_code == 204
     with pytest.raises(Exception):
-        client.get_index(uid=common.index_uid)
-    response = client.index(uid=common.index_uid2).delete()
+        client.get_index(uid=common.INDEX_UID)
+    response = client.index(uid=common.INDEX_UID2).delete()
     assert response.status_code == 204
     with pytest.raises(Exception):
-        client.get_index(uid=common.index_uid2)
-    response = client.index(uid=common.index_uid3).delete()
+        client.get_index(uid=common.INDEX_UID2)
+    response = client.index(uid=common.INDEX_UID3).delete()
     assert response.status_code == 204
     with pytest.raises(Exception):
-        client.get_index(uid=common.index_uid3)
+        client.get_index(uid=common.INDEX_UID3)
     assert len(client.get_indexes()) == 0

--- a/meilisearch/tests/index/test_index.py
+++ b/meilisearch/tests/index/test_index.py
@@ -2,8 +2,6 @@ import pytest
 from meilisearch.index import Index
 from meilisearch.tests import common
 
-
-
 def test_create_index(client):
     """Tests creating an index"""
     index = client.create_index(uid=common.INDEX_UID)

--- a/meilisearch/tests/index/test_index.py
+++ b/meilisearch/tests/index/test_index.py
@@ -26,7 +26,7 @@ def test_create_index_with_uid_in_options(client):
     assert index.primary_key == 'book_id'
     assert index.get_primary_key() == 'book_id'
 
-@pytest.mark.usefixtures("sample_indexes")
+@pytest.mark.usefixtures("indexes_sample")
 def test_get_indexes(client):
     """Tests getting all indexes"""
     response = client.get_indexes()
@@ -49,7 +49,7 @@ def test_index_with_none_uid(client):
     with pytest.raises(Exception):
         client.index(None)
 
-@pytest.mark.usefixtures("sample_indexes")
+@pytest.mark.usefixtures("indexes_sample")
 def test_get_index_with_valid_uid(client):
     """Tests getting one index with uid"""
     response = client.get_index(uid=common.INDEX_UID)
@@ -94,7 +94,7 @@ def test_get_or_create_index_with_primary_key(client):
     assert index_2.get_primary_key() == common.INDEX_UID4
     index_1.delete()
 
-@pytest.mark.usefixtures("sample_indexes")
+@pytest.mark.usefixtures("indexes_sample")
 def test_index_fetch_info(client):
     """Tests getting the index info"""
     index = client.index(uid=common.INDEX_UID)
@@ -105,7 +105,7 @@ def test_index_fetch_info(client):
     assert response.primary_key == index.primary_key
     assert response.primary_key == index.get_primary_key()
 
-@pytest.mark.usefixtures("sample_indexes")
+@pytest.mark.usefixtures("indexes_sample")
 def test_index_fetch_info_containing_primary_key(client):
     """Tests getting the index info"""
     index = client.index(uid=common.INDEX_UID3)
@@ -116,7 +116,7 @@ def test_index_fetch_info_containing_primary_key(client):
     assert response.primary_key == index.primary_key
     assert response.primary_key == index.get_primary_key()
 
-@pytest.mark.usefixtures("sample_indexes")
+@pytest.mark.usefixtures("indexes_sample")
 def test_get_primary_key(client):
     """Tests getting the primary-key of an index"""
     index = client.index(uid=common.INDEX_UID3)
@@ -126,7 +126,7 @@ def test_get_primary_key(client):
     assert index.primary_key == 'book_id'
     assert index.get_primary_key() == 'book_id'
 
-@pytest.mark.usefixtures("sample_indexes")
+@pytest.mark.usefixtures("indexes_sample")
 def test_update_index(client):
     """Tests updating an index"""
     index = client.index(uid=common.INDEX_UID)
@@ -135,7 +135,7 @@ def test_update_index(client):
     assert index.primary_key == 'objectID'
     assert index.get_primary_key() == 'objectID'
 
-@pytest.mark.usefixtures("sample_indexes")
+@pytest.mark.usefixtures("indexes_sample")
 def test_delete_index(client):
     """Tests deleting an index"""
     response = client.index(uid=common.INDEX_UID).delete()

--- a/meilisearch/tests/index/test_index.py
+++ b/meilisearch/tests/index/test_index.py
@@ -1,57 +1,47 @@
 import pytest
-import meilisearch
 from meilisearch.index import Index
-from meilisearch.tests import BASE_URL, MASTER_KEY, clear_all_indexes
+from meilisearch.tests import common
+
 
 class TestIndex:
 
-    """ TESTS: all index routes """
-
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    index_uid = 'indexUID'
-    index_uid2 = 'indexUID2'
-    index_uid3 = 'indexUID3'
-    index_uid4 = 'indexUID4'
-
-    def setup_class(self):
-        clear_all_indexes(self.client)
 
     def test_create_index(self):
         """Tests creating an index"""
-        index = self.client.create_index(uid=self.index_uid)
+        index = common.client.create_index(uid=common.index_uid)
         assert isinstance(index, Index)
-        assert index.uid == self.index_uid
+        assert index.uid == common.index_uid
         assert index.primary_key is None
         assert index.get_primary_key() is None
 
     def test_create_index_with_primary_key(self):
         """Tests creating an index with a primary key"""
-        index = self.client.create_index(uid=self.index_uid2, options={'primaryKey': 'book_id'})
+        index = common.client.create_index(uid=common.index_uid2, options={'primaryKey': 'book_id'})
         assert isinstance(index, Index)
-        assert index.uid == self.index_uid2
+        assert index.uid == common.index_uid2
         assert index.primary_key == 'book_id'
         assert index.get_primary_key() == 'book_id'
 
     def test_create_index_with_uid_in_options(self):
         """Tests creating an index with a primary key"""
-        index = self.client.create_index(uid=self.index_uid3, options={'uid': 'wrong', 'primaryKey': 'book_id'})
+        index = common.client.create_index(uid=common.index_uid3, options={'uid': 'wrong', 'primaryKey': 'book_id'})
         assert isinstance(index, Index)
-        assert index.uid == self.index_uid3
+        assert index.uid == common.index_uid3
         assert index.primary_key == 'book_id'
         assert index.get_primary_key() == 'book_id'
 
-    def test_get_indexes(self):
+    def test_get_indexes(self, sample_indexes):
         """Tests getting all indexes"""
-        response = self.client.get_indexes()
+        response = common.client.get_indexes()
         uids = [index['uid'] for index in response]
         assert isinstance(response, list)
-        assert self.index_uid in uids
-        assert self.index_uid2 in uids
-        assert self.index_uid3 in uids
+        assert common.index_uid in uids
+        assert common.index_uid2 in uids
+        assert common.index_uid3 in uids
         assert len(response) == 3
 
     def test_index_with_any_uid(self):
-        index = self.client.index('anyUID')
+        index = common.client.index('anyUID')
         assert isinstance(index, Index)
         assert index.uid == 'anyUID'
         assert index.primary_key is None
@@ -60,31 +50,31 @@ class TestIndex:
 
     def test_index_with_none_uid(self):
         with pytest.raises(Exception):
-            self.client.index(None)
+            common.client.index(None)
 
-    def test_get_index_with_valid_uid(self):
+    def test_get_index_with_valid_uid(self, sample_indexes):
         """Tests getting one index with uid"""
-        response = self.client.get_index(uid=self.index_uid)
+        response = common.client.get_index(uid=common.index_uid)
         assert isinstance(response, Index)
-        assert response.uid == self.index_uid
+        assert response.uid == common.index_uid
 
     def test_get_index_with_none_uid(self):
         """Test raising an exception if the index UID is None"""
         with pytest.raises(Exception):
-            self.client.get_index(uid=None)
+            common.client.get_index(uid=None)
 
     def test_get_index_with_wrong_uid(self):
         """Tests get_index with an non-existing index"""
         with pytest.raises(Exception):
-            self.client.get_index(uid='wrongUID')
+            common.client.get_index(uid='wrongUID')
 
     def test_get_or_create_index(self):
         """Test get_or_create_index method"""
-        # self.client.create_index(self.index_uid3)
-        index_1 = self.client.get_or_create_index(self.index_uid4)
-        index_2 = self.client.get_or_create_index(self.index_uid4)
-        index_3 = self.client.get_or_create_index(self.index_uid4)
-        assert index_1.uid == index_2.uid == index_3.uid == self.index_uid4
+        # common.client.create_index(common.index_uid3)
+        index_1 = common.client.get_or_create_index(common.index_uid4)
+        index_2 = common.client.get_or_create_index(common.index_uid4)
+        index_3 = common.client.get_or_create_index(common.index_uid4)
+        assert index_1.uid == index_2.uid == index_3.uid == common.index_uid4
         update = index_1.add_documents([{
             'book_id': 1,
             'name': "Some book"
@@ -94,67 +84,67 @@ class TestIndex:
         assert len(documents) == 1
         index_2.delete()
         with pytest.raises(Exception):
-            self.client.get_index(index_3)
+            common.client.get_index(index_3)
 
     def test_get_or_create_index_with_primary_key(self):
         """Test get_or_create_index method with primary key"""
-        index_1 = self.client.get_or_create_index('books', {'primaryKey': self.index_uid4})
-        index_2 = self.client.get_or_create_index('books', {'primaryKey': 'some_wrong_key'})
-        assert index_1.primary_key == self.index_uid4
-        assert index_1.get_primary_key() == self.index_uid4
-        assert index_2.primary_key == self.index_uid4
-        assert index_2.get_primary_key() == self.index_uid4
+        index_1 = common.client.get_or_create_index('books', {'primaryKey': common.index_uid4})
+        index_2 = common.client.get_or_create_index('books', {'primaryKey': 'some_wrong_key'})
+        assert index_1.primary_key == common.index_uid4
+        assert index_1.get_primary_key() == common.index_uid4
+        assert index_2.primary_key == common.index_uid4
+        assert index_2.get_primary_key() == common.index_uid4
         index_1.delete()
 
-    def test_index_fetch_info(self):
+    def test_index_fetch_info(self, sample_indexes):
         """Tests getting the index info"""
-        index = self.client.index(uid=self.index_uid)
+        index = common.client.index(uid=common.index_uid)
         response = index.fetch_info()
         assert isinstance(response, Index)
-        assert response.uid == self.index_uid
+        assert response.uid == common.index_uid
         assert response.primary_key is None
         assert response.primary_key == index.primary_key
         assert response.primary_key == index.get_primary_key()
 
-    def test_index_fetch_info_containing_primary_key(self):
+    def test_index_fetch_info_containing_primary_key(self, sample_indexes):
         """Tests getting the index info"""
-        index = self.client.index(uid=self.index_uid3)
+        index = common.client.index(uid=common.index_uid3)
         response = index.fetch_info()
         assert isinstance(response, Index)
-        assert response.uid == self.index_uid3
+        assert response.uid == common.index_uid3
         assert response.primary_key == 'book_id'
         assert response.primary_key == index.primary_key
         assert response.primary_key == index.get_primary_key()
 
-    def test_get_primary_key(self):
+    def test_get_primary_key(self, sample_indexes):
         """Tests getting the primary-key of an index"""
-        index = self.client.index(uid=self.index_uid3)
+        index = common.client.index(uid=common.index_uid3)
         assert index.primary_key is None
         response = index.get_primary_key()
         assert response == 'book_id'
         assert index.primary_key == 'book_id'
         assert index.get_primary_key() == 'book_id'
 
-    def test_update_index(self):
+    def test_update_index(self, sample_indexes):
         """Tests updating an index"""
-        index = self.client.index(uid=self.index_uid)
+        index = common.client.index(uid=common.index_uid)
         response = index.update(primaryKey='objectID')
         assert isinstance(response, Index)
         assert index.primary_key == 'objectID'
         assert index.get_primary_key() == 'objectID'
 
-    def test_delete_index(self):
+    def test_delete_index(self, sample_indexes):
         """Tests deleting an index"""
-        response = self.client.index(uid=self.index_uid).delete()
+        response = common.client.index(uid=common.index_uid).delete()
         assert response.status_code == 204
         with pytest.raises(Exception):
-            self.client.get_index(uid=self.index_uid)
-        response = self.client.index(uid=self.index_uid2).delete()
+            common.client.get_index(uid=common.index_uid)
+        response = common.client.index(uid=common.index_uid2).delete()
         assert response.status_code == 204
         with pytest.raises(Exception):
-            self.client.get_index(uid=self.index_uid2)
-        response = self.client.index(uid=self.index_uid3).delete()
+            common.client.get_index(uid=common.index_uid2)
+        response = common.client.index(uid=common.index_uid3).delete()
         assert response.status_code == 204
         with pytest.raises(Exception):
-            self.client.get_index(uid=self.index_uid3)
-        assert len(self.client.get_indexes()) == 0
+            common.client.get_index(uid=common.index_uid3)
+        assert len(common.client.get_indexes()) == 0

--- a/meilisearch/tests/index/test_index_document_meilisearch.py
+++ b/meilisearch/tests/index/test_index_document_meilisearch.py
@@ -1,18 +1,18 @@
 import pytest
 
-def test_get_documents_default(sample_indexes):
+def test_get_documents_default(indexes_sample):
     """Tests getting documents on a clean index"""
-    response = sample_indexes[0].get_documents()
+    response = indexes_sample[0].get_documents()
     assert isinstance(response, list)
     assert response == []
 
-def test_add_documents(sample_indexes, small_movies):
+def test_add_documents(indexes_sample, small_movies):
     """Tests adding new documents to a clean index"""
-    response = sample_indexes[0].add_documents(small_movies)
+    response = indexes_sample[0].add_documents(small_movies)
     assert isinstance(response, object)
     assert 'updateId' in response
-    assert sample_indexes[0].get_primary_key() == 'id'
-    update = sample_indexes[0].wait_for_pending_update(response['updateId'])
+    assert indexes_sample[0].get_primary_key() == 'id'
+    update = indexes_sample[0].wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
 
 def test_get_document(index_with_documents):
@@ -22,10 +22,10 @@ def test_get_document(index_with_documents):
     assert 'title' in response
     assert response['title'] == 'The Highwaymen'
 
-def test_get_document_inexistent(sample_indexes):
+def test_get_document_inexistent(indexes_sample):
     """Tests getting one INEXISTENT document on a populated index"""
     with pytest.raises(Exception):
-        sample_indexes[0].get_document('123')
+        indexes_sample[0].get_document('123')
 
 def test_get_documents_populated(index_with_documents):
     """Tests getting documents on a populated index"""

--- a/meilisearch/tests/index/test_index_document_meilisearch.py
+++ b/meilisearch/tests/index/test_index_document_meilisearch.py
@@ -1,66 +1,52 @@
-import json
 import pytest
-import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY, clear_all_indexes
 
 class TestDocument:
 
     """ TESTS: all documents routes and optional params """
 
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    index = None
-    dataset_file = None
-    dataset_json = None
-
-    def setup_class(self):
-        clear_all_indexes(self.client)
-        self.index = self.client.create_index(uid='indexUID')
-        self.dataset_file = open('./datasets/small_movies.json', 'r')
-        self.dataset_json = json.loads(self.dataset_file.read())
-        self.dataset_file.close()
-
-    def teardown_class(self):
-        self.index.delete()
-
-    def test_get_documents_default(self):
+    def test_get_documents_default(self, sample_indexes):
         """Tests getting documents on a clean index"""
-        response = self.index.get_documents()
+        response = sample_indexes[0].get_documents()
         assert isinstance(response, list)
         assert response == []
 
-    def test_add_documents(self):
+    def test_add_documents(self, sample_indexes, small_movies):
         """Tests adding new documents to a clean index"""
-        response = self.index.add_documents(self.dataset_json)
+        response = sample_indexes[0].add_documents(small_movies)
         assert isinstance(response, object)
         assert 'updateId' in response
-        assert self.index.get_primary_key() == 'id'
-        update = self.index.wait_for_pending_update(response['updateId'])
+        assert sample_indexes[0].get_primary_key() == 'id'
+        update = sample_indexes[0].wait_for_pending_update(response['updateId'])
         assert update['status'] == 'processed'
 
-    def test_get_document(self):
+    def test_get_document(self, indexed_small_movies):
         """Tests getting one document on a populated index"""
-        response = self.index.get_document('500682')
+        response = indexed_small_movies[0].get_document('500682')
         assert isinstance(response, object)
         assert 'title' in response
         assert response['title'] == 'The Highwaymen'
 
-    def test_get_document_inexistent(self):
+    def test_get_document_inexistent(self, sample_indexes):
         """Tests getting one INEXISTENT document on a populated index"""
         with pytest.raises(Exception):
-            self.index.get_document('123')
+            sample_indexes[0].get_document('123')
 
-    def test_get_documents_populated(self):
+    def test_get_documents_populated(self, indexed_small_movies):
         """Tests getting documents on a populated index"""
-        response = self.index.get_documents()
+
+        response = indexed_small_movies[0].get_documents()
         assert isinstance(response, list)
         assert len(response) == 20
 
-    def test_get_documents_offset_optional_params(self):
+    def test_get_documents_offset_optional_params(self, indexed_small_movies, small_movies):
         """Tests getting documents on a populated index with optional parameters"""
-        response = self.index.get_documents()
+        # Add movies to the index
+        indexed_small_movies[0].add_documents(small_movies)
+
+        response = indexed_small_movies[0].get_documents()
         assert isinstance(response, list)
         assert len(response) == 20
-        response_offset_limit = self.index.get_documents({
+        response_offset_limit = indexed_small_movies[0].get_documents({
             'limit': 3,
             'offset': 1,
             'attributesToRetrieve': 'title'
@@ -68,47 +54,47 @@ class TestDocument:
         assert len(response_offset_limit) == 3
         assert response_offset_limit[0]['title'] == response[1]['title']
 
-    def test_update_documents(self):
+    def test_update_documents(self, indexed_small_movies, small_movies):
         """Tests updating a single document and a set of documents """
-        response = self.index.get_documents()
+        response = indexed_small_movies[0].get_documents()
         response[0]['title'] = 'Some title'
-        update = self.index.update_documents([response[0]])
+        update = indexed_small_movies[0].update_documents([response[0]])
         assert isinstance(update, object)
         assert 'updateId' in update
-        self.index.wait_for_pending_update(update['updateId'])
-        response = self.index.get_documents()
+        indexed_small_movies[0].wait_for_pending_update(update['updateId'])
+        response = indexed_small_movies[0].get_documents()
         assert response[0]['title'] == 'Some title'
-        update = self.index.update_documents(self.dataset_json)
-        self.index.wait_for_pending_update(update['updateId'])
-        response = self.index.get_documents()
+        update = indexed_small_movies[0].update_documents(small_movies)
+        indexed_small_movies[0].wait_for_pending_update(update['updateId'])
+        response = indexed_small_movies[0].get_documents()
         assert response[0]['title'] != 'Some title'
 
-    def test_delete_document(self):
+    def test_delete_document(self, indexed_small_movies):
         """Tests deleting a single document"""
-        response = self.index.delete_document('500682')
+        response = indexed_small_movies[0].delete_document('500682')
         assert isinstance(response, object)
         assert 'updateId' in response
-        self.index.wait_for_pending_update(response['updateId'])
+        indexed_small_movies[0].wait_for_pending_update(response['updateId'])
         with pytest.raises(Exception):
-            self.index.get_document('500682')
+            indexed_small_movies[0].get_document('500682')
 
-    def test_delete_documents(self):
+    def test_delete_documents(self, indexed_small_movies):
         """Tests deleting a set of documents """
         to_delete = ['522681', '450465', '329996']
-        response = self.index.delete_documents(to_delete)
+        response = indexed_small_movies[0].delete_documents(to_delete)
         assert isinstance(response, object)
         assert 'updateId' in response
-        self.index.wait_for_pending_update(response['updateId'])
+        indexed_small_movies[0].wait_for_pending_update(response['updateId'])
         for document in to_delete:
             with pytest.raises(Exception):
-                self.index.get_document(document)
+                indexed_small_movies[0].get_document(document)
 
-    def test_delete_all_documents(self):
+    def test_delete_all_documents(self, indexed_small_movies):
         """Tests updating all the documents in the index"""
-        response = self.index.delete_all_documents()
+        response = indexed_small_movies[0].delete_all_documents()
         assert isinstance(response, object)
         assert 'updateId' in response
-        self.index.wait_for_pending_update(response['updateId'])
-        response = self.index.get_documents()
+        indexed_small_movies[0].wait_for_pending_update(response['updateId'])
+        response = indexed_small_movies[0].get_documents()
         assert isinstance(response, list)
         assert response == []

--- a/meilisearch/tests/index/test_index_document_meilisearch.py
+++ b/meilisearch/tests/index/test_index_document_meilisearch.py
@@ -15,9 +15,9 @@ def test_add_documents(sample_indexes, small_movies):
     update = sample_indexes[0].wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
 
-def test_get_document(indexed_small_movies):
+def test_get_document(index_with_documents):
     """Tests getting one document on a populated index"""
-    response = indexed_small_movies[0].get_document('500682')
+    response = index_with_documents.get_document('500682')
     assert isinstance(response, object)
     assert 'title' in response
     assert response['title'] == 'The Highwaymen'
@@ -27,22 +27,22 @@ def test_get_document_inexistent(sample_indexes):
     with pytest.raises(Exception):
         sample_indexes[0].get_document('123')
 
-def test_get_documents_populated(indexed_small_movies):
+def test_get_documents_populated(index_with_documents):
     """Tests getting documents on a populated index"""
 
-    response = indexed_small_movies[0].get_documents()
+    response = index_with_documents.get_documents()
     assert isinstance(response, list)
     assert len(response) == 20
 
-def test_get_documents_offset_optional_params(indexed_small_movies, small_movies):
+def test_get_documents_offset_optional_params(index_with_documents, small_movies):
     """Tests getting documents on a populated index with optional parameters"""
     # Add movies to the index
-    indexed_small_movies[0].add_documents(small_movies)
+    index_with_documents.add_documents(small_movies)
 
-    response = indexed_small_movies[0].get_documents()
+    response = index_with_documents.get_documents()
     assert isinstance(response, list)
     assert len(response) == 20
-    response_offset_limit = indexed_small_movies[0].get_documents({
+    response_offset_limit = index_with_documents.get_documents({
         'limit': 3,
         'offset': 1,
         'attributesToRetrieve': 'title'
@@ -50,47 +50,47 @@ def test_get_documents_offset_optional_params(indexed_small_movies, small_movies
     assert len(response_offset_limit) == 3
     assert response_offset_limit[0]['title'] == response[1]['title']
 
-def test_update_documents(indexed_small_movies, small_movies):
+def test_update_documents(index_with_documents, small_movies):
     """Tests updating a single document and a set of documents """
-    response = indexed_small_movies[0].get_documents()
+    response = index_with_documents.get_documents()
     response[0]['title'] = 'Some title'
-    update = indexed_small_movies[0].update_documents([response[0]])
+    update = index_with_documents.update_documents([response[0]])
     assert isinstance(update, object)
     assert 'updateId' in update
-    indexed_small_movies[0].wait_for_pending_update(update['updateId'])
-    response = indexed_small_movies[0].get_documents()
+    index_with_documents.wait_for_pending_update(update['updateId'])
+    response = index_with_documents.get_documents()
     assert response[0]['title'] == 'Some title'
-    update = indexed_small_movies[0].update_documents(small_movies)
-    indexed_small_movies[0].wait_for_pending_update(update['updateId'])
-    response = indexed_small_movies[0].get_documents()
+    update = index_with_documents.update_documents(small_movies)
+    index_with_documents.wait_for_pending_update(update['updateId'])
+    response = index_with_documents.get_documents()
     assert response[0]['title'] != 'Some title'
 
-def test_delete_document(indexed_small_movies):
+def test_delete_document(index_with_documents):
     """Tests deleting a single document"""
-    response = indexed_small_movies[0].delete_document('500682')
+    response = index_with_documents.delete_document('500682')
     assert isinstance(response, object)
     assert 'updateId' in response
-    indexed_small_movies[0].wait_for_pending_update(response['updateId'])
+    index_with_documents.wait_for_pending_update(response['updateId'])
     with pytest.raises(Exception):
-        indexed_small_movies[0].get_document('500682')
+        index_with_documents.get_document('500682')
 
-def test_delete_documents(indexed_small_movies):
+def test_delete_documents(index_with_documents):
     """Tests deleting a set of documents """
     to_delete = ['522681', '450465', '329996']
-    response = indexed_small_movies[0].delete_documents(to_delete)
+    response = index_with_documents.delete_documents(to_delete)
     assert isinstance(response, object)
     assert 'updateId' in response
-    indexed_small_movies[0].wait_for_pending_update(response['updateId'])
+    index_with_documents.wait_for_pending_update(response['updateId'])
     for document in to_delete:
         with pytest.raises(Exception):
-            indexed_small_movies[0].get_document(document)
+            index_with_documents.get_document(document)
 
-def test_delete_all_documents(indexed_small_movies):
+def test_delete_all_documents(index_with_documents):
     """Tests updating all the documents in the index"""
-    response = indexed_small_movies[0].delete_all_documents()
+    response = index_with_documents.delete_all_documents()
     assert isinstance(response, object)
     assert 'updateId' in response
-    indexed_small_movies[0].wait_for_pending_update(response['updateId'])
-    response = indexed_small_movies[0].get_documents()
+    index_with_documents.wait_for_pending_update(response['updateId'])
+    response = index_with_documents.get_documents()
     assert isinstance(response, list)
     assert response == []

--- a/meilisearch/tests/index/test_index_document_meilisearch.py
+++ b/meilisearch/tests/index/test_index_document_meilisearch.py
@@ -1,3 +1,5 @@
+# pylint: disable=invalid-name
+
 import pytest
 
 def test_get_documents_default(indexes_sample):

--- a/meilisearch/tests/index/test_index_document_meilisearch.py
+++ b/meilisearch/tests/index/test_index_document_meilisearch.py
@@ -2,19 +2,20 @@
 
 import pytest
 
-def test_get_documents_default(indexes_sample):
+def test_get_documents_default(empty_index):
     """Tests getting documents on a clean index"""
-    response = indexes_sample[0].get_documents()
+    response = empty_index().get_documents()
     assert isinstance(response, list)
     assert response == []
 
-def test_add_documents(indexes_sample, small_movies):
+def test_add_documents(empty_index, small_movies):
     """Tests adding new documents to a clean index"""
-    response = indexes_sample[0].add_documents(small_movies)
+    index = empty_index()
+    response = index.add_documents(small_movies)
     assert isinstance(response, object)
     assert 'updateId' in response
-    assert indexes_sample[0].get_primary_key() == 'id'
-    update = indexes_sample[0].wait_for_pending_update(response['updateId'])
+    assert index.get_primary_key() == 'id'
+    update = index.wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
 
 def test_get_document(index_with_documents):
@@ -24,10 +25,10 @@ def test_get_document(index_with_documents):
     assert 'title' in response
     assert response['title'] == 'The Highwaymen'
 
-def test_get_document_inexistent(indexes_sample):
+def test_get_document_inexistent(empty_index):
     """Tests getting one INEXISTENT document on a populated index"""
     with pytest.raises(Exception):
-        indexes_sample[0].get_document('123')
+        empty_index().get_document('123')
 
 def test_get_documents_populated(index_with_documents):
     """Tests getting documents on a populated index"""

--- a/meilisearch/tests/index/test_index_document_meilisearch.py
+++ b/meilisearch/tests/index/test_index_document_meilisearch.py
@@ -19,7 +19,7 @@ def test_add_documents(indexes_sample, small_movies):
 
 def test_get_document(index_with_documents):
     """Tests getting one document on a populated index"""
-    response = index_with_documents.get_document('500682')
+    response = index_with_documents().get_document('500682')
     assert isinstance(response, object)
     assert 'title' in response
     assert response['title'] == 'The Highwaymen'
@@ -32,19 +32,19 @@ def test_get_document_inexistent(indexes_sample):
 def test_get_documents_populated(index_with_documents):
     """Tests getting documents on a populated index"""
 
-    response = index_with_documents.get_documents()
+    response = index_with_documents().get_documents()
     assert isinstance(response, list)
     assert len(response) == 20
 
 def test_get_documents_offset_optional_params(index_with_documents, small_movies):
     """Tests getting documents on a populated index with optional parameters"""
     # Add movies to the index
-    index_with_documents.add_documents(small_movies)
-
-    response = index_with_documents.get_documents()
+    index = index_with_documents()
+    index.add_documents(small_movies)
+    response = index.get_documents()
     assert isinstance(response, list)
     assert len(response) == 20
-    response_offset_limit = index_with_documents.get_documents({
+    response_offset_limit = index.get_documents({
         'limit': 3,
         'offset': 1,
         'attributesToRetrieve': 'title'
@@ -54,45 +54,49 @@ def test_get_documents_offset_optional_params(index_with_documents, small_movies
 
 def test_update_documents(index_with_documents, small_movies):
     """Tests updating a single document and a set of documents """
-    response = index_with_documents.get_documents()
+    index = index_with_documents()
+    response = index.get_documents()
     response[0]['title'] = 'Some title'
-    update = index_with_documents.update_documents([response[0]])
+    update = index.update_documents([response[0]])
     assert isinstance(update, object)
     assert 'updateId' in update
-    index_with_documents.wait_for_pending_update(update['updateId'])
-    response = index_with_documents.get_documents()
+    index.wait_for_pending_update(update['updateId'])
+    response = index.get_documents()
     assert response[0]['title'] == 'Some title'
-    update = index_with_documents.update_documents(small_movies)
-    index_with_documents.wait_for_pending_update(update['updateId'])
-    response = index_with_documents.get_documents()
+    update = index.update_documents(small_movies)
+    index.wait_for_pending_update(update['updateId'])
+    response = index.get_documents()
     assert response[0]['title'] != 'Some title'
 
 def test_delete_document(index_with_documents):
     """Tests deleting a single document"""
-    response = index_with_documents.delete_document('500682')
+    index = index_with_documents()
+    response = index.delete_document('500682')
     assert isinstance(response, object)
     assert 'updateId' in response
-    index_with_documents.wait_for_pending_update(response['updateId'])
+    index.wait_for_pending_update(response['updateId'])
     with pytest.raises(Exception):
-        index_with_documents.get_document('500682')
+        index.get_document('500682')
 
 def test_delete_documents(index_with_documents):
     """Tests deleting a set of documents """
     to_delete = ['522681', '450465', '329996']
-    response = index_with_documents.delete_documents(to_delete)
+    index = index_with_documents()
+    response = index.delete_documents(to_delete)
     assert isinstance(response, object)
     assert 'updateId' in response
-    index_with_documents.wait_for_pending_update(response['updateId'])
+    index.wait_for_pending_update(response['updateId'])
     for document in to_delete:
         with pytest.raises(Exception):
-            index_with_documents.get_document(document)
+            index.get_document(document)
 
 def test_delete_all_documents(index_with_documents):
     """Tests updating all the documents in the index"""
-    response = index_with_documents.delete_all_documents()
+    index = index_with_documents()
+    response = index.delete_all_documents()
     assert isinstance(response, object)
     assert 'updateId' in response
-    index_with_documents.wait_for_pending_update(response['updateId'])
-    response = index_with_documents.get_documents()
+    index.wait_for_pending_update(response['updateId'])
+    response = index.get_documents()
     assert isinstance(response, list)
     assert response == []

--- a/meilisearch/tests/index/test_index_document_meilisearch.py
+++ b/meilisearch/tests/index/test_index_document_meilisearch.py
@@ -1,100 +1,96 @@
 import pytest
 
-class TestDocument:
+def test_get_documents_default(sample_indexes):
+    """Tests getting documents on a clean index"""
+    response = sample_indexes[0].get_documents()
+    assert isinstance(response, list)
+    assert response == []
 
-    """ TESTS: all documents routes and optional params """
+def test_add_documents(sample_indexes, small_movies):
+    """Tests adding new documents to a clean index"""
+    response = sample_indexes[0].add_documents(small_movies)
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    assert sample_indexes[0].get_primary_key() == 'id'
+    update = sample_indexes[0].wait_for_pending_update(response['updateId'])
+    assert update['status'] == 'processed'
 
-    def test_get_documents_default(self, sample_indexes):
-        """Tests getting documents on a clean index"""
-        response = sample_indexes[0].get_documents()
-        assert isinstance(response, list)
-        assert response == []
+def test_get_document(indexed_small_movies):
+    """Tests getting one document on a populated index"""
+    response = indexed_small_movies[0].get_document('500682')
+    assert isinstance(response, object)
+    assert 'title' in response
+    assert response['title'] == 'The Highwaymen'
 
-    def test_add_documents(self, sample_indexes, small_movies):
-        """Tests adding new documents to a clean index"""
-        response = sample_indexes[0].add_documents(small_movies)
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        assert sample_indexes[0].get_primary_key() == 'id'
-        update = sample_indexes[0].wait_for_pending_update(response['updateId'])
-        assert update['status'] == 'processed'
+def test_get_document_inexistent(sample_indexes):
+    """Tests getting one INEXISTENT document on a populated index"""
+    with pytest.raises(Exception):
+        sample_indexes[0].get_document('123')
 
-    def test_get_document(self, indexed_small_movies):
-        """Tests getting one document on a populated index"""
-        response = indexed_small_movies[0].get_document('500682')
-        assert isinstance(response, object)
-        assert 'title' in response
-        assert response['title'] == 'The Highwaymen'
+def test_get_documents_populated(indexed_small_movies):
+    """Tests getting documents on a populated index"""
 
-    def test_get_document_inexistent(self, sample_indexes):
-        """Tests getting one INEXISTENT document on a populated index"""
+    response = indexed_small_movies[0].get_documents()
+    assert isinstance(response, list)
+    assert len(response) == 20
+
+def test_get_documents_offset_optional_params(indexed_small_movies, small_movies):
+    """Tests getting documents on a populated index with optional parameters"""
+    # Add movies to the index
+    indexed_small_movies[0].add_documents(small_movies)
+
+    response = indexed_small_movies[0].get_documents()
+    assert isinstance(response, list)
+    assert len(response) == 20
+    response_offset_limit = indexed_small_movies[0].get_documents({
+        'limit': 3,
+        'offset': 1,
+        'attributesToRetrieve': 'title'
+    })
+    assert len(response_offset_limit) == 3
+    assert response_offset_limit[0]['title'] == response[1]['title']
+
+def test_update_documents(indexed_small_movies, small_movies):
+    """Tests updating a single document and a set of documents """
+    response = indexed_small_movies[0].get_documents()
+    response[0]['title'] = 'Some title'
+    update = indexed_small_movies[0].update_documents([response[0]])
+    assert isinstance(update, object)
+    assert 'updateId' in update
+    indexed_small_movies[0].wait_for_pending_update(update['updateId'])
+    response = indexed_small_movies[0].get_documents()
+    assert response[0]['title'] == 'Some title'
+    update = indexed_small_movies[0].update_documents(small_movies)
+    indexed_small_movies[0].wait_for_pending_update(update['updateId'])
+    response = indexed_small_movies[0].get_documents()
+    assert response[0]['title'] != 'Some title'
+
+def test_delete_document(indexed_small_movies):
+    """Tests deleting a single document"""
+    response = indexed_small_movies[0].delete_document('500682')
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    indexed_small_movies[0].wait_for_pending_update(response['updateId'])
+    with pytest.raises(Exception):
+        indexed_small_movies[0].get_document('500682')
+
+def test_delete_documents(indexed_small_movies):
+    """Tests deleting a set of documents """
+    to_delete = ['522681', '450465', '329996']
+    response = indexed_small_movies[0].delete_documents(to_delete)
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    indexed_small_movies[0].wait_for_pending_update(response['updateId'])
+    for document in to_delete:
         with pytest.raises(Exception):
-            sample_indexes[0].get_document('123')
+            indexed_small_movies[0].get_document(document)
 
-    def test_get_documents_populated(self, indexed_small_movies):
-        """Tests getting documents on a populated index"""
-
-        response = indexed_small_movies[0].get_documents()
-        assert isinstance(response, list)
-        assert len(response) == 20
-
-    def test_get_documents_offset_optional_params(self, indexed_small_movies, small_movies):
-        """Tests getting documents on a populated index with optional parameters"""
-        # Add movies to the index
-        indexed_small_movies[0].add_documents(small_movies)
-
-        response = indexed_small_movies[0].get_documents()
-        assert isinstance(response, list)
-        assert len(response) == 20
-        response_offset_limit = indexed_small_movies[0].get_documents({
-            'limit': 3,
-            'offset': 1,
-            'attributesToRetrieve': 'title'
-        })
-        assert len(response_offset_limit) == 3
-        assert response_offset_limit[0]['title'] == response[1]['title']
-
-    def test_update_documents(self, indexed_small_movies, small_movies):
-        """Tests updating a single document and a set of documents """
-        response = indexed_small_movies[0].get_documents()
-        response[0]['title'] = 'Some title'
-        update = indexed_small_movies[0].update_documents([response[0]])
-        assert isinstance(update, object)
-        assert 'updateId' in update
-        indexed_small_movies[0].wait_for_pending_update(update['updateId'])
-        response = indexed_small_movies[0].get_documents()
-        assert response[0]['title'] == 'Some title'
-        update = indexed_small_movies[0].update_documents(small_movies)
-        indexed_small_movies[0].wait_for_pending_update(update['updateId'])
-        response = indexed_small_movies[0].get_documents()
-        assert response[0]['title'] != 'Some title'
-
-    def test_delete_document(self, indexed_small_movies):
-        """Tests deleting a single document"""
-        response = indexed_small_movies[0].delete_document('500682')
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        indexed_small_movies[0].wait_for_pending_update(response['updateId'])
-        with pytest.raises(Exception):
-            indexed_small_movies[0].get_document('500682')
-
-    def test_delete_documents(self, indexed_small_movies):
-        """Tests deleting a set of documents """
-        to_delete = ['522681', '450465', '329996']
-        response = indexed_small_movies[0].delete_documents(to_delete)
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        indexed_small_movies[0].wait_for_pending_update(response['updateId'])
-        for document in to_delete:
-            with pytest.raises(Exception):
-                indexed_small_movies[0].get_document(document)
-
-    def test_delete_all_documents(self, indexed_small_movies):
-        """Tests updating all the documents in the index"""
-        response = indexed_small_movies[0].delete_all_documents()
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        indexed_small_movies[0].wait_for_pending_update(response['updateId'])
-        response = indexed_small_movies[0].get_documents()
-        assert isinstance(response, list)
-        assert response == []
+def test_delete_all_documents(indexed_small_movies):
+    """Tests updating all the documents in the index"""
+    response = indexed_small_movies[0].delete_all_documents()
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    indexed_small_movies[0].wait_for_pending_update(response['updateId'])
+    response = indexed_small_movies[0].get_documents()
+    assert isinstance(response, list)
+    assert response == []

--- a/meilisearch/tests/index/test_index_search_meilisearch.py
+++ b/meilisearch/tests/index/test_index_search_meilisearch.py
@@ -1,3 +1,4 @@
+# pylint: disable=invalid-name
 
 def test_basic_search(index_with_documents):
     """Tests search with an simple query"""

--- a/meilisearch/tests/index/test_index_search_meilisearch.py
+++ b/meilisearch/tests/index/test_index_search_meilisearch.py
@@ -1,33 +1,33 @@
 
-def test_basic_search(indexed_small_movies):
+def test_basic_search(index_with_documents):
     """Tests search with an simple query"""
-    response = indexed_small_movies[0].search('How to Train Your Dragon')
+    response = index_with_documents.search('How to Train Your Dragon')
     assert isinstance(response, object)
     assert response['hits'][0]['id'] == '166428'
 
-def test_basic_search_with_empty_params(indexed_small_movies):
+def test_basic_search_with_empty_params(index_with_documents):
     """Tests search with an simple query and empty params"""
-    response = indexed_small_movies[0].search('How to Train Your Dragon', {})
+    response = index_with_documents.search('How to Train Your Dragon', {})
     assert isinstance(response, object)
     assert response['hits'][0]['id'] == '166428'
     assert '_formatted' not in response['hits'][0]
 
-def test_basic_search_with_empty_query(indexed_small_movies):
+def test_basic_search_with_empty_query(index_with_documents):
     """Tests search with empty query and empty params"""
-    response = indexed_small_movies[0].search('')
+    response = index_with_documents.search('')
     assert isinstance(response, object)
     assert len(response['hits']) == 20
     assert response['query'] == ''
 
-def test_basic_search_with_placeholder(indexed_small_movies):
+def test_basic_search_with_placeholder(index_with_documents):
     """Tests search with no query [None] and empty params"""
-    response = indexed_small_movies[0].search(None, {})
+    response = index_with_documents.search(None, {})
     assert isinstance(response, object)
     assert len(response['hits']) == 20
 
-def test_custom_search(indexed_small_movies):
+def test_custom_search(index_with_documents):
     """Tests search with an simple query and custom parameter (attributesToHighlight)"""
-    response = indexed_small_movies[0].search(
+    response = index_with_documents.search(
         'Dragon',
         {
             'attributesToHighlight': ['title']
@@ -38,9 +38,9 @@ def test_custom_search(indexed_small_movies):
     assert '_formatted' in response['hits'][0]
     assert 'dragon' in response['hits'][0]['_formatted']['title'].lower()
 
-def test_custom_search_with_empty_query(indexed_small_movies):
+def test_custom_search_with_empty_query(index_with_documents):
     """Tests search with empty query and custom parameter (attributesToHighlight)"""
-    response = indexed_small_movies[0].search(
+    response = index_with_documents.search(
         '',
         {
             'attributesToHighlight': ['title']
@@ -50,9 +50,9 @@ def test_custom_search_with_empty_query(indexed_small_movies):
     assert len(response['hits']) == 20
     assert response['query'] == ''
 
-def test_custom_search_with_placeholder(indexed_small_movies):
+def test_custom_search_with_placeholder(index_with_documents):
     """Tests search with no query [None] and custom parameter (limit)"""
-    response = indexed_small_movies[0].search(
+    response = index_with_documents.search(
         None,
         {
             'limit': 5
@@ -61,9 +61,9 @@ def test_custom_search_with_placeholder(indexed_small_movies):
     assert isinstance(response, object)
     assert len(response['hits']) == 5
 
-def test_custom_search_params_with_wildcard(indexed_small_movies):
+def test_custom_search_params_with_wildcard(index_with_documents):
     """Tests search with '*' in query params"""
-    response = indexed_small_movies[0].search(
+    response = index_with_documents.search(
         'a',
         {
             'limit': 5,
@@ -77,9 +77,9 @@ def test_custom_search_params_with_wildcard(indexed_small_movies):
     assert '_formatted' in response['hits'][0]
     assert "title" in response['hits'][0]['_formatted']
 
-def test_custom_search_params_with_simple_string(indexed_small_movies):
+def test_custom_search_params_with_simple_string(index_with_documents):
     """Tests search with simple string in query params"""
-    response = indexed_small_movies[0].search(
+    response = index_with_documents.search(
         'a',
         {
             'limit': 5,
@@ -94,9 +94,9 @@ def test_custom_search_params_with_simple_string(indexed_small_movies):
     assert 'title' in response['hits'][0]['_formatted']
     assert not 'release_date' in response['hits'][0]['_formatted']
 
-def test_custom_search_params_with_string_list(indexed_small_movies):
+def test_custom_search_params_with_string_list(index_with_documents):
     """Tests search with string list in query params"""
-    response = indexed_small_movies[0].search(
+    response = index_with_documents.search(
         'a',
         {
             'limit': 5,
@@ -112,10 +112,10 @@ def test_custom_search_params_with_string_list(indexed_small_movies):
     assert 'title' in response['hits'][0]['_formatted']
     assert not 'overview' in response['hits'][0]['_formatted']
 
-def test_custom_search_params_with_facets_distribution(indexed_small_movies):
-    update = indexed_small_movies[0].update_attributes_for_faceting(['genre'])
-    indexed_small_movies[0].wait_for_pending_update(update['updateId'])
-    response = indexed_small_movies[0].search(
+def test_custom_search_params_with_facets_distribution(index_with_documents):
+    update = index_with_documents.update_attributes_for_faceting(['genre'])
+    index_with_documents.wait_for_pending_update(update['updateId'])
+    response = index_with_documents.search(
         'world',
         {
             'facetsDistribution': ['genre']
@@ -131,10 +131,10 @@ def test_custom_search_params_with_facets_distribution(indexed_small_movies):
     assert response['facetsDistribution']['genre']['action'] == 3
     assert response['facetsDistribution']['genre']['fantasy'] == 1
 
-def test_custom_search_params_with_facet_filters(indexed_small_movies):
-    update = indexed_small_movies[0].update_attributes_for_faceting(['genre'])
-    indexed_small_movies[0].wait_for_pending_update(update['updateId'])
-    response = indexed_small_movies[0].search(
+def test_custom_search_params_with_facet_filters(index_with_documents):
+    update = index_with_documents.update_attributes_for_faceting(['genre'])
+    index_with_documents.wait_for_pending_update(update['updateId'])
+    response = index_with_documents.search(
         'world',
         {
             'facetFilters': [['genre:action']]
@@ -145,10 +145,10 @@ def test_custom_search_params_with_facet_filters(indexed_small_movies):
     assert 'facetsDistribution' not in response
     assert 'exhaustiveFacetsCount' not in response
 
-def test_custom_search_params_with_multiple_facet_filters(indexed_small_movies):
-    update = indexed_small_movies[0].update_attributes_for_faceting(['genre'])
-    indexed_small_movies[0].wait_for_pending_update(update['updateId'])
-    response = indexed_small_movies[0].search(
+def test_custom_search_params_with_multiple_facet_filters(index_with_documents):
+    update = index_with_documents.update_attributes_for_faceting(['genre'])
+    index_with_documents.wait_for_pending_update(update['updateId'])
+    response = index_with_documents.search(
         'world',
         {
             'facetFilters': ['genre:action', ['genre:action', 'genre:action']]
@@ -159,10 +159,10 @@ def test_custom_search_params_with_multiple_facet_filters(indexed_small_movies):
     assert 'facetsDistribution' not in response
     assert 'exhaustiveFacetsCount' not in response
 
-def test_custom_search_params_with_many_params(indexed_small_movies):
-    update = indexed_small_movies[0].update_attributes_for_faceting(['genre'])
-    indexed_small_movies[0].wait_for_pending_update(update['updateId'])
-    response = indexed_small_movies[0].search(
+def test_custom_search_params_with_many_params(index_with_documents):
+    update = index_with_documents.update_attributes_for_faceting(['genre'])
+    index_with_documents.wait_for_pending_update(update['updateId'])
+    response = index_with_documents.search(
         'world',
         {
             'facetFilters': [['genre:action']],

--- a/meilisearch/tests/index/test_index_search_meilisearch.py
+++ b/meilisearch/tests/index/test_index_search_meilisearch.py
@@ -1,184 +1,180 @@
 
-class TestSearch:
+def test_basic_search(indexed_small_movies):
+    """Tests search with an simple query"""
+    response = indexed_small_movies[0].search('How to Train Your Dragon')
+    assert isinstance(response, object)
+    assert response['hits'][0]['id'] == '166428'
 
-    """ TESTS: search route """
+def test_basic_search_with_empty_params(indexed_small_movies):
+    """Tests search with an simple query and empty params"""
+    response = indexed_small_movies[0].search('How to Train Your Dragon', {})
+    assert isinstance(response, object)
+    assert response['hits'][0]['id'] == '166428'
+    assert '_formatted' not in response['hits'][0]
 
-    def test_basic_search(self, indexed_small_movies):
-        """Tests search with an simple query"""
-        response = indexed_small_movies[0].search('How to Train Your Dragon')
-        assert isinstance(response, object)
-        assert response['hits'][0]['id'] == '166428'
+def test_basic_search_with_empty_query(indexed_small_movies):
+    """Tests search with empty query and empty params"""
+    response = indexed_small_movies[0].search('')
+    assert isinstance(response, object)
+    assert len(response['hits']) == 20
+    assert response['query'] == ''
 
-    def test_basic_search_with_empty_params(self, indexed_small_movies):
-        """Tests search with an simple query and empty params"""
-        response = indexed_small_movies[0].search('How to Train Your Dragon', {})
-        assert isinstance(response, object)
-        assert response['hits'][0]['id'] == '166428'
-        assert '_formatted' not in response['hits'][0]
+def test_basic_search_with_placeholder(indexed_small_movies):
+    """Tests search with no query [None] and empty params"""
+    response = indexed_small_movies[0].search(None, {})
+    assert isinstance(response, object)
+    assert len(response['hits']) == 20
 
-    def test_basic_search_with_empty_query(self, indexed_small_movies):
-        """Tests search with empty query and empty params"""
-        response = indexed_small_movies[0].search('')
-        assert isinstance(response, object)
-        assert len(response['hits']) == 20
-        assert response['query'] == ''
+def test_custom_search(indexed_small_movies):
+    """Tests search with an simple query and custom parameter (attributesToHighlight)"""
+    response = indexed_small_movies[0].search(
+        'Dragon',
+        {
+            'attributesToHighlight': ['title']
+        }
+    )
+    assert isinstance(response, object)
+    assert response['hits'][0]['id'] == '166428'
+    assert '_formatted' in response['hits'][0]
+    assert 'dragon' in response['hits'][0]['_formatted']['title'].lower()
 
-    def test_basic_search_with_placeholder(self, indexed_small_movies):
-        """Tests search with no query [None] and empty params"""
-        response = indexed_small_movies[0].search(None, {})
-        assert isinstance(response, object)
-        assert len(response['hits']) == 20
+def test_custom_search_with_empty_query(indexed_small_movies):
+    """Tests search with empty query and custom parameter (attributesToHighlight)"""
+    response = indexed_small_movies[0].search(
+        '',
+        {
+            'attributesToHighlight': ['title']
+        }
+    )
+    assert isinstance(response, object)
+    assert len(response['hits']) == 20
+    assert response['query'] == ''
 
-    def test_custom_search(self, indexed_small_movies):
-        """Tests search with an simple query and custom parameter (attributesToHighlight)"""
-        response = indexed_small_movies[0].search(
-            'Dragon',
-            {
-                'attributesToHighlight': ['title']
-            }
-        )
-        assert isinstance(response, object)
-        assert response['hits'][0]['id'] == '166428'
-        assert '_formatted' in response['hits'][0]
-        assert 'dragon' in response['hits'][0]['_formatted']['title'].lower()
+def test_custom_search_with_placeholder(indexed_small_movies):
+    """Tests search with no query [None] and custom parameter (limit)"""
+    response = indexed_small_movies[0].search(
+        None,
+        {
+            'limit': 5
+        }
+    )
+    assert isinstance(response, object)
+    assert len(response['hits']) == 5
 
-    def test_custom_search_with_empty_query(self, indexed_small_movies):
-        """Tests search with empty query and custom parameter (attributesToHighlight)"""
-        response = indexed_small_movies[0].search(
-            '',
-            {
-                'attributesToHighlight': ['title']
-            }
-        )
-        assert isinstance(response, object)
-        assert len(response['hits']) == 20
-        assert response['query'] == ''
+def test_custom_search_params_with_wildcard(indexed_small_movies):
+    """Tests search with '*' in query params"""
+    response = indexed_small_movies[0].search(
+        'a',
+        {
+            'limit': 5,
+            'attributesToHighlight': ['*'],
+            'attributesToRetrieve': ['*'],
+            'attributesToCrop': ['*'],
+        }
+    )
+    assert isinstance(response, object)
+    assert len(response['hits']) == 5
+    assert '_formatted' in response['hits'][0]
+    assert "title" in response['hits'][0]['_formatted']
 
-    def test_custom_search_with_placeholder(self, indexed_small_movies):
-        """Tests search with no query [None] and custom parameter (limit)"""
-        response = indexed_small_movies[0].search(
-            None,
-            {
-                'limit': 5
-            }
-        )
-        assert isinstance(response, object)
-        assert len(response['hits']) == 5
+def test_custom_search_params_with_simple_string(indexed_small_movies):
+    """Tests search with simple string in query params"""
+    response = indexed_small_movies[0].search(
+        'a',
+        {
+            'limit': 5,
+            'attributesToHighlight': ['title'],
+            'attributesToRetrieve': ['title'],
+            'attributesToCrop': ['title'],
+        }
+    )
+    assert isinstance(response, object)
+    assert len(response['hits']) == 5
+    assert '_formatted' in response['hits'][0]
+    assert 'title' in response['hits'][0]['_formatted']
+    assert not 'release_date' in response['hits'][0]['_formatted']
 
-    def test_custom_search_params_with_wildcard(self, indexed_small_movies):
-        """Tests search with '*' in query params"""
-        response = indexed_small_movies[0].search(
-            'a',
-            {
-                'limit': 5,
-                'attributesToHighlight': ['*'],
-                'attributesToRetrieve': ['*'],
-                'attributesToCrop': ['*'],
-            }
-        )
-        assert isinstance(response, object)
-        assert len(response['hits']) == 5
-        assert '_formatted' in response['hits'][0]
-        assert "title" in response['hits'][0]['_formatted']
+def test_custom_search_params_with_string_list(indexed_small_movies):
+    """Tests search with string list in query params"""
+    response = indexed_small_movies[0].search(
+        'a',
+        {
+            'limit': 5,
+            'attributesToRetrieve': ['title', 'overview'],
+            'attributesToHighlight': ['title'],
+        }
+    )
+    assert isinstance(response, object)
+    assert len(response['hits']) == 5
+    assert 'title' in response['hits'][0]
+    assert 'overview' in response['hits'][0]
+    assert not 'release_date' in response['hits'][0]
+    assert 'title' in response['hits'][0]['_formatted']
+    assert not 'overview' in response['hits'][0]['_formatted']
 
-    def test_custom_search_params_with_simple_string(self, indexed_small_movies):
-        """Tests search with simple string in query params"""
-        response = indexed_small_movies[0].search(
-            'a',
-            {
-                'limit': 5,
-                'attributesToHighlight': ['title'],
-                'attributesToRetrieve': ['title'],
-                'attributesToCrop': ['title'],
-            }
-        )
-        assert isinstance(response, object)
-        assert len(response['hits']) == 5
-        assert '_formatted' in response['hits'][0]
-        assert 'title' in response['hits'][0]['_formatted']
-        assert not 'release_date' in response['hits'][0]['_formatted']
+def test_custom_search_params_with_facets_distribution(indexed_small_movies):
+    update = indexed_small_movies[0].update_attributes_for_faceting(['genre'])
+    indexed_small_movies[0].wait_for_pending_update(update['updateId'])
+    response = indexed_small_movies[0].search(
+        'world',
+        {
+            'facetsDistribution': ['genre']
+        }
+    )
+    assert isinstance(response, object)
+    assert len(response['hits']) == 12
+    assert 'facetsDistribution' in response
+    assert 'exhaustiveFacetsCount' in response
+    assert response['exhaustiveFacetsCount']
+    assert 'genre' in response['facetsDistribution']
+    assert response['facetsDistribution']['genre']['cartoon'] == 1
+    assert response['facetsDistribution']['genre']['action'] == 3
+    assert response['facetsDistribution']['genre']['fantasy'] == 1
 
-    def test_custom_search_params_with_string_list(self, indexed_small_movies):
-        """Tests search with string list in query params"""
-        response = indexed_small_movies[0].search(
-            'a',
-            {
-                'limit': 5,
-                'attributesToRetrieve': ['title', 'overview'],
-                'attributesToHighlight': ['title'],
-            }
-        )
-        assert isinstance(response, object)
-        assert len(response['hits']) == 5
-        assert 'title' in response['hits'][0]
-        assert 'overview' in response['hits'][0]
-        assert not 'release_date' in response['hits'][0]
-        assert 'title' in response['hits'][0]['_formatted']
-        assert not 'overview' in response['hits'][0]['_formatted']
+def test_custom_search_params_with_facet_filters(indexed_small_movies):
+    update = indexed_small_movies[0].update_attributes_for_faceting(['genre'])
+    indexed_small_movies[0].wait_for_pending_update(update['updateId'])
+    response = indexed_small_movies[0].search(
+        'world',
+        {
+            'facetFilters': [['genre:action']]
+        }
+    )
+    assert isinstance(response, object)
+    assert len(response['hits']) == 3
+    assert 'facetsDistribution' not in response
+    assert 'exhaustiveFacetsCount' not in response
 
-    def test_custom_search_params_with_facets_distribution(self, indexed_small_movies):
-        update = indexed_small_movies[0].update_attributes_for_faceting(['genre'])
-        indexed_small_movies[0].wait_for_pending_update(update['updateId'])
-        response = indexed_small_movies[0].search(
-            'world',
-            {
-                'facetsDistribution': ['genre']
-            }
-        )
-        assert isinstance(response, object)
-        assert len(response['hits']) == 12
-        assert 'facetsDistribution' in response
-        assert 'exhaustiveFacetsCount' in response
-        assert response['exhaustiveFacetsCount']
-        assert 'genre' in response['facetsDistribution']
-        assert response['facetsDistribution']['genre']['cartoon'] == 1
-        assert response['facetsDistribution']['genre']['action'] == 3
-        assert response['facetsDistribution']['genre']['fantasy'] == 1
+def test_custom_search_params_with_multiple_facet_filters(indexed_small_movies):
+    update = indexed_small_movies[0].update_attributes_for_faceting(['genre'])
+    indexed_small_movies[0].wait_for_pending_update(update['updateId'])
+    response = indexed_small_movies[0].search(
+        'world',
+        {
+            'facetFilters': ['genre:action', ['genre:action', 'genre:action']]
+        }
+    )
+    assert isinstance(response, object)
+    assert len(response['hits']) == 3
+    assert 'facetsDistribution' not in response
+    assert 'exhaustiveFacetsCount' not in response
 
-    def test_custom_search_params_with_facet_filters(self, indexed_small_movies):
-        update = indexed_small_movies[0].update_attributes_for_faceting(['genre'])
-        indexed_small_movies[0].wait_for_pending_update(update['updateId'])
-        response = indexed_small_movies[0].search(
-            'world',
-            {
-                'facetFilters': [['genre:action']]
-            }
-        )
-        assert isinstance(response, object)
-        assert len(response['hits']) == 3
-        assert 'facetsDistribution' not in response
-        assert 'exhaustiveFacetsCount' not in response
-
-    def test_custom_search_params_with_multiple_facet_filters(self, indexed_small_movies):
-        update = indexed_small_movies[0].update_attributes_for_faceting(['genre'])
-        indexed_small_movies[0].wait_for_pending_update(update['updateId'])
-        response = indexed_small_movies[0].search(
-            'world',
-            {
-                'facetFilters': ['genre:action', ['genre:action', 'genre:action']]
-            }
-        )
-        assert isinstance(response, object)
-        assert len(response['hits']) == 3
-        assert 'facetsDistribution' not in response
-        assert 'exhaustiveFacetsCount' not in response
-
-    def test_custom_search_params_with_many_params(self, indexed_small_movies):
-        update = indexed_small_movies[0].update_attributes_for_faceting(['genre'])
-        indexed_small_movies[0].wait_for_pending_update(update['updateId'])
-        response = indexed_small_movies[0].search(
-            'world',
-            {
-                'facetFilters': [['genre:action']],
-                'attributesToRetrieve': ['title', 'poster']
-            }
-        )
-        assert isinstance(response, object)
-        assert len(response['hits']) == 3
-        assert 'facetsDistribution' not in response
-        assert 'exhaustiveFacetsCount' not in response
-        assert 'title' in response['hits'][0]
-        assert 'poster' in response['hits'][0]
-        assert 'overview' not in response['hits'][0]
-        assert 'release_date' not in response['hits'][0]
-        assert response['hits'][0]['title'] == 'Avengers: Infinity War'
+def test_custom_search_params_with_many_params(indexed_small_movies):
+    update = indexed_small_movies[0].update_attributes_for_faceting(['genre'])
+    indexed_small_movies[0].wait_for_pending_update(update['updateId'])
+    response = indexed_small_movies[0].search(
+        'world',
+        {
+            'facetFilters': [['genre:action']],
+            'attributesToRetrieve': ['title', 'poster']
+        }
+    )
+    assert isinstance(response, object)
+    assert len(response['hits']) == 3
+    assert 'facetsDistribution' not in response
+    assert 'exhaustiveFacetsCount' not in response
+    assert 'title' in response['hits'][0]
+    assert 'poster' in response['hits'][0]
+    assert 'overview' not in response['hits'][0]
+    assert 'release_date' not in response['hits'][0]
+    assert response['hits'][0]['title'] == 'Avengers: Infinity War'

--- a/meilisearch/tests/index/test_index_search_meilisearch.py
+++ b/meilisearch/tests/index/test_index_search_meilisearch.py
@@ -2,33 +2,33 @@
 
 def test_basic_search(index_with_documents):
     """Tests search with an simple query"""
-    response = index_with_documents.search('How to Train Your Dragon')
+    response = index_with_documents().search('How to Train Your Dragon')
     assert isinstance(response, object)
     assert response['hits'][0]['id'] == '166428'
 
 def test_basic_search_with_empty_params(index_with_documents):
     """Tests search with an simple query and empty params"""
-    response = index_with_documents.search('How to Train Your Dragon', {})
+    response = index_with_documents().search('How to Train Your Dragon', {})
     assert isinstance(response, object)
     assert response['hits'][0]['id'] == '166428'
     assert '_formatted' not in response['hits'][0]
 
 def test_basic_search_with_empty_query(index_with_documents):
     """Tests search with empty query and empty params"""
-    response = index_with_documents.search('')
+    response = index_with_documents().search('')
     assert isinstance(response, object)
     assert len(response['hits']) == 20
     assert response['query'] == ''
 
 def test_basic_search_with_placeholder(index_with_documents):
     """Tests search with no query [None] and empty params"""
-    response = index_with_documents.search(None, {})
+    response = index_with_documents().search(None, {})
     assert isinstance(response, object)
     assert len(response['hits']) == 20
 
 def test_custom_search(index_with_documents):
     """Tests search with an simple query and custom parameter (attributesToHighlight)"""
-    response = index_with_documents.search(
+    response = index_with_documents().search(
         'Dragon',
         {
             'attributesToHighlight': ['title']
@@ -41,7 +41,7 @@ def test_custom_search(index_with_documents):
 
 def test_custom_search_with_empty_query(index_with_documents):
     """Tests search with empty query and custom parameter (attributesToHighlight)"""
-    response = index_with_documents.search(
+    response = index_with_documents().search(
         '',
         {
             'attributesToHighlight': ['title']
@@ -53,7 +53,7 @@ def test_custom_search_with_empty_query(index_with_documents):
 
 def test_custom_search_with_placeholder(index_with_documents):
     """Tests search with no query [None] and custom parameter (limit)"""
-    response = index_with_documents.search(
+    response = index_with_documents().search(
         None,
         {
             'limit': 5
@@ -64,7 +64,7 @@ def test_custom_search_with_placeholder(index_with_documents):
 
 def test_custom_search_params_with_wildcard(index_with_documents):
     """Tests search with '*' in query params"""
-    response = index_with_documents.search(
+    response = index_with_documents().search(
         'a',
         {
             'limit': 5,
@@ -80,7 +80,7 @@ def test_custom_search_params_with_wildcard(index_with_documents):
 
 def test_custom_search_params_with_simple_string(index_with_documents):
     """Tests search with simple string in query params"""
-    response = index_with_documents.search(
+    response = index_with_documents().search(
         'a',
         {
             'limit': 5,
@@ -97,7 +97,7 @@ def test_custom_search_params_with_simple_string(index_with_documents):
 
 def test_custom_search_params_with_string_list(index_with_documents):
     """Tests search with string list in query params"""
-    response = index_with_documents.search(
+    response = index_with_documents().search(
         'a',
         {
             'limit': 5,
@@ -114,9 +114,10 @@ def test_custom_search_params_with_string_list(index_with_documents):
     assert not 'overview' in response['hits'][0]['_formatted']
 
 def test_custom_search_params_with_facets_distribution(index_with_documents):
-    update = index_with_documents.update_attributes_for_faceting(['genre'])
-    index_with_documents.wait_for_pending_update(update['updateId'])
-    response = index_with_documents.search(
+    index = index_with_documents()
+    update = index.update_attributes_for_faceting(['genre'])
+    index.wait_for_pending_update(update['updateId'])
+    response = index.search(
         'world',
         {
             'facetsDistribution': ['genre']
@@ -133,9 +134,10 @@ def test_custom_search_params_with_facets_distribution(index_with_documents):
     assert response['facetsDistribution']['genre']['fantasy'] == 1
 
 def test_custom_search_params_with_facet_filters(index_with_documents):
-    update = index_with_documents.update_attributes_for_faceting(['genre'])
-    index_with_documents.wait_for_pending_update(update['updateId'])
-    response = index_with_documents.search(
+    index = index_with_documents()
+    update = index.update_attributes_for_faceting(['genre'])
+    index.wait_for_pending_update(update['updateId'])
+    response = index.search(
         'world',
         {
             'facetFilters': [['genre:action']]
@@ -147,9 +149,10 @@ def test_custom_search_params_with_facet_filters(index_with_documents):
     assert 'exhaustiveFacetsCount' not in response
 
 def test_custom_search_params_with_multiple_facet_filters(index_with_documents):
-    update = index_with_documents.update_attributes_for_faceting(['genre'])
-    index_with_documents.wait_for_pending_update(update['updateId'])
-    response = index_with_documents.search(
+    index = index_with_documents()
+    update = index.update_attributes_for_faceting(['genre'])
+    index.wait_for_pending_update(update['updateId'])
+    response = index.search(
         'world',
         {
             'facetFilters': ['genre:action', ['genre:action', 'genre:action']]
@@ -161,9 +164,10 @@ def test_custom_search_params_with_multiple_facet_filters(index_with_documents):
     assert 'exhaustiveFacetsCount' not in response
 
 def test_custom_search_params_with_many_params(index_with_documents):
-    update = index_with_documents.update_attributes_for_faceting(['genre'])
-    index_with_documents.wait_for_pending_update(update['updateId'])
-    response = index_with_documents.search(
+    index = index_with_documents()
+    update = index.update_attributes_for_faceting(['genre'])
+    index.wait_for_pending_update(update['updateId'])
+    response = index.search(
         'world',
         {
             'facetFilters': [['genre:action']],

--- a/meilisearch/tests/index/test_index_stats_meilisearch.py
+++ b/meilisearch/tests/index/test_index_stats_meilisearch.py
@@ -1,4 +1,4 @@
-from meilisearch.tests.common import BASE_URL, MASTER_KEY
+
 
 class TestStats:
 

--- a/meilisearch/tests/index/test_index_stats_meilisearch.py
+++ b/meilisearch/tests/index/test_index_stats_meilisearch.py
@@ -1,23 +1,12 @@
-import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY, clear_all_indexes
+from meilisearch.tests.common import BASE_URL, MASTER_KEY
 
 class TestStats:
 
     """ TESTS: stats route """
 
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    index = None
-
-    def setup_class(self):
-        clear_all_indexes(self.client)
-        self.index = self.client.create_index(uid='indexUID')
-
-    def teardown_class(self):
-        self.index.delete()
-
-    def test_get_stats(self):
+    def test_get_stats(self, sample_indexes):
         """Tests getting stats of a single index"""
-        response = self.index.get_stats()
+        response = sample_indexes[0].get_stats()
         assert isinstance(response, object)
         assert 'numberOfDocuments' in response
         assert response['numberOfDocuments'] == 0

--- a/meilisearch/tests/index/test_index_stats_meilisearch.py
+++ b/meilisearch/tests/index/test_index_stats_meilisearch.py
@@ -1,8 +1,8 @@
 
 
-def test_get_stats(sample_indexes):
+def test_get_stats(indexes_sample):
     """Tests getting stats of a single index"""
-    response = sample_indexes[0].get_stats()
+    response = indexes_sample[0].get_stats()
     assert isinstance(response, object)
     assert 'numberOfDocuments' in response
     assert response['numberOfDocuments'] == 0

--- a/meilisearch/tests/index/test_index_stats_meilisearch.py
+++ b/meilisearch/tests/index/test_index_stats_meilisearch.py
@@ -1,8 +1,8 @@
 
 
-def test_get_stats(indexes_sample):
+def test_get_stats(empty_index):
     """Tests getting stats of a single index"""
-    response = indexes_sample[0].get_stats()
+    response = empty_index().get_stats()
     assert isinstance(response, object)
     assert 'numberOfDocuments' in response
     assert response['numberOfDocuments'] == 0

--- a/meilisearch/tests/index/test_index_stats_meilisearch.py
+++ b/meilisearch/tests/index/test_index_stats_meilisearch.py
@@ -1,13 +1,9 @@
 
 
-class TestStats:
-
-    """ TESTS: stats route """
-
-    def test_get_stats(self, sample_indexes):
-        """Tests getting stats of a single index"""
-        response = sample_indexes[0].get_stats()
-        assert isinstance(response, object)
-        assert 'numberOfDocuments' in response
-        assert response['numberOfDocuments'] == 0
-        assert 'isIndexing' in response
+def test_get_stats(sample_indexes):
+    """Tests getting stats of a single index"""
+    response = sample_indexes[0].get_stats()
+    assert isinstance(response, object)
+    assert 'numberOfDocuments' in response
+    assert response['numberOfDocuments'] == 0
+    assert 'isIndexing' in response

--- a/meilisearch/tests/index/test_index_update_meilisearch.py
+++ b/meilisearch/tests/index/test_index_update_meilisearch.py
@@ -2,35 +2,37 @@
 
 import pytest
 
-def test_get_all_update_status_default(indexes_sample):
+def test_get_all_update_status_default(empty_index):
     """Tests getting the updates list of an empty index"""
-    response = indexes_sample[0].get_all_update_status()
+    response = empty_index().get_all_update_status()
     assert isinstance(response, list)
     assert response == []
 
-def test_get_all_update_status(indexes_sample, small_movies):
+def test_get_all_update_status(empty_index, small_movies):
     """Tests getting the updates list of a populated index"""
-    response = indexes_sample[0].add_documents(small_movies)
+    index = empty_index()
+    response = index.add_documents(small_movies)
     assert 'updateId' in response
-    response = indexes_sample[0].add_documents(small_movies)
+    response = index.add_documents(small_movies)
     assert 'updateId' in response
-    response = indexes_sample[0].get_all_update_status()
+    response = index.get_all_update_status()
     assert len(response) == 2
 
-def test_get_update(indexes_sample, small_movies):
+def test_get_update(empty_index, small_movies):
     """Tests getting an update of a given operation"""
-    response = indexes_sample[0].add_documents(small_movies)
+    index = empty_index()
+    response = index.add_documents(small_movies)
     assert 'updateId' in response
-    update = indexes_sample[0].wait_for_pending_update(response['updateId'])
+    update = index.wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
-    response = indexes_sample[0].get_update_status(response['updateId'])
+    response = index.get_update_status(response['updateId'])
     assert 'updateId' in response
     assert 'type' in response
     assert 'duration' in response
     assert 'enqueuedAt' in response
     assert 'processedAt' in response
 
-def test_get_update_inexistent(indexes_sample):
+def test_get_update_inexistent(empty_index):
     """Tests getting an update of an INEXISTENT operation"""
     with pytest.raises(Exception):
-        indexes_sample[0].get_update_status('999')
+        empty_index().get_update_status('999')

--- a/meilisearch/tests/index/test_index_update_meilisearch.py
+++ b/meilisearch/tests/index/test_index_update_meilisearch.py
@@ -1,56 +1,41 @@
 import json
 import pytest
 import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY, clear_all_indexes
+from meilisearch.tests.common import BASE_URL, MASTER_KEY
 
 class TestUpdate:
 
     """ TESTS: all update routes """
 
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    index = None
-    dataset_file = None
-    dataset_json = None
-
-    def setup_class(self):
-        clear_all_indexes(self.client)
-        self.index = self.client.create_index(uid='indexUID')
-        self.dataset_file = open('./datasets/small_movies.json', 'r')
-        self.dataset_json = json.loads(self.dataset_file.read())
-        self.dataset_file.close()
-
-    def teardown_class(self):
-        self.index.delete()
-
-    def test_get_all_update_status_default(self):
+    def test_get_all_update_status_default(self, sample_indexes):
         """Tests getting the updates list of an empty index"""
-        response = self.index.get_all_update_status()
+        response = sample_indexes[0].get_all_update_status()
         assert isinstance(response, list)
         assert response == []
 
-    def test_get_all_update_status(self):
+    def test_get_all_update_status(self, sample_indexes, small_movies):
         """Tests getting the updates list of a populated index"""
-        response = self.index.add_documents(self.dataset_json)
+        response = sample_indexes[0].add_documents(small_movies)
         assert 'updateId' in response
-        response = self.index.add_documents(self.dataset_json)
+        response = sample_indexes[0].add_documents(small_movies)
         assert 'updateId' in response
-        response = self.index.get_all_update_status()
+        response = sample_indexes[0].get_all_update_status()
         assert len(response) == 2
 
-    def test_get_update(self):
+    def test_get_update(self, sample_indexes, small_movies):
         """Tests getting an update of a given operation"""
-        response = self.index.add_documents(self.dataset_json)
+        response = sample_indexes[0].add_documents(small_movies)
         assert 'updateId' in response
-        update = self.index.wait_for_pending_update(response['updateId'])
+        update = sample_indexes[0].wait_for_pending_update(response['updateId'])
         assert update['status'] == 'processed'
-        response = self.index.get_update_status(response['updateId'])
+        response = sample_indexes[0].get_update_status(response['updateId'])
         assert 'updateId' in response
         assert 'type' in response
         assert 'duration' in response
         assert 'enqueuedAt' in response
         assert 'processedAt' in response
 
-    def test_get_update_inexistent(self):
+    def test_get_update_inexistent(self, sample_indexes):
         """Tests getting an update of an INEXISTENT operation"""
         with pytest.raises(Exception):
-            self.index.get_update_status('999')
+            sample_indexes[0].get_update_status('999')

--- a/meilisearch/tests/index/test_index_update_meilisearch.py
+++ b/meilisearch/tests/index/test_index_update_meilisearch.py
@@ -1,38 +1,34 @@
 import pytest
 
-class TestUpdate:
+def test_get_all_update_status_default(sample_indexes):
+    """Tests getting the updates list of an empty index"""
+    response = sample_indexes[0].get_all_update_status()
+    assert isinstance(response, list)
+    assert response == []
 
-    """ TESTS: all update routes """
+def test_get_all_update_status(sample_indexes, small_movies):
+    """Tests getting the updates list of a populated index"""
+    response = sample_indexes[0].add_documents(small_movies)
+    assert 'updateId' in response
+    response = sample_indexes[0].add_documents(small_movies)
+    assert 'updateId' in response
+    response = sample_indexes[0].get_all_update_status()
+    assert len(response) == 2
 
-    def test_get_all_update_status_default(self, sample_indexes):
-        """Tests getting the updates list of an empty index"""
-        response = sample_indexes[0].get_all_update_status()
-        assert isinstance(response, list)
-        assert response == []
+def test_get_update(sample_indexes, small_movies):
+    """Tests getting an update of a given operation"""
+    response = sample_indexes[0].add_documents(small_movies)
+    assert 'updateId' in response
+    update = sample_indexes[0].wait_for_pending_update(response['updateId'])
+    assert update['status'] == 'processed'
+    response = sample_indexes[0].get_update_status(response['updateId'])
+    assert 'updateId' in response
+    assert 'type' in response
+    assert 'duration' in response
+    assert 'enqueuedAt' in response
+    assert 'processedAt' in response
 
-    def test_get_all_update_status(self, sample_indexes, small_movies):
-        """Tests getting the updates list of a populated index"""
-        response = sample_indexes[0].add_documents(small_movies)
-        assert 'updateId' in response
-        response = sample_indexes[0].add_documents(small_movies)
-        assert 'updateId' in response
-        response = sample_indexes[0].get_all_update_status()
-        assert len(response) == 2
-
-    def test_get_update(self, sample_indexes, small_movies):
-        """Tests getting an update of a given operation"""
-        response = sample_indexes[0].add_documents(small_movies)
-        assert 'updateId' in response
-        update = sample_indexes[0].wait_for_pending_update(response['updateId'])
-        assert update['status'] == 'processed'
-        response = sample_indexes[0].get_update_status(response['updateId'])
-        assert 'updateId' in response
-        assert 'type' in response
-        assert 'duration' in response
-        assert 'enqueuedAt' in response
-        assert 'processedAt' in response
-
-    def test_get_update_inexistent(self, sample_indexes):
-        """Tests getting an update of an INEXISTENT operation"""
-        with pytest.raises(Exception):
-            sample_indexes[0].get_update_status('999')
+def test_get_update_inexistent(sample_indexes):
+    """Tests getting an update of an INEXISTENT operation"""
+    with pytest.raises(Exception):
+        sample_indexes[0].get_update_status('999')

--- a/meilisearch/tests/index/test_index_update_meilisearch.py
+++ b/meilisearch/tests/index/test_index_update_meilisearch.py
@@ -1,7 +1,4 @@
-import json
 import pytest
-import meilisearch
-from meilisearch.tests.common import BASE_URL, MASTER_KEY
 
 class TestUpdate:
 

--- a/meilisearch/tests/index/test_index_update_meilisearch.py
+++ b/meilisearch/tests/index/test_index_update_meilisearch.py
@@ -1,3 +1,5 @@
+# pylint: disable=invalid-name
+
 import pytest
 
 def test_get_all_update_status_default(indexes_sample):

--- a/meilisearch/tests/index/test_index_update_meilisearch.py
+++ b/meilisearch/tests/index/test_index_update_meilisearch.py
@@ -1,34 +1,34 @@
 import pytest
 
-def test_get_all_update_status_default(sample_indexes):
+def test_get_all_update_status_default(indexes_sample):
     """Tests getting the updates list of an empty index"""
-    response = sample_indexes[0].get_all_update_status()
+    response = indexes_sample[0].get_all_update_status()
     assert isinstance(response, list)
     assert response == []
 
-def test_get_all_update_status(sample_indexes, small_movies):
+def test_get_all_update_status(indexes_sample, small_movies):
     """Tests getting the updates list of a populated index"""
-    response = sample_indexes[0].add_documents(small_movies)
+    response = indexes_sample[0].add_documents(small_movies)
     assert 'updateId' in response
-    response = sample_indexes[0].add_documents(small_movies)
+    response = indexes_sample[0].add_documents(small_movies)
     assert 'updateId' in response
-    response = sample_indexes[0].get_all_update_status()
+    response = indexes_sample[0].get_all_update_status()
     assert len(response) == 2
 
-def test_get_update(sample_indexes, small_movies):
+def test_get_update(indexes_sample, small_movies):
     """Tests getting an update of a given operation"""
-    response = sample_indexes[0].add_documents(small_movies)
+    response = indexes_sample[0].add_documents(small_movies)
     assert 'updateId' in response
-    update = sample_indexes[0].wait_for_pending_update(response['updateId'])
+    update = indexes_sample[0].wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
-    response = sample_indexes[0].get_update_status(response['updateId'])
+    response = indexes_sample[0].get_update_status(response['updateId'])
     assert 'updateId' in response
     assert 'type' in response
     assert 'duration' in response
     assert 'enqueuedAt' in response
     assert 'processedAt' in response
 
-def test_get_update_inexistent(sample_indexes):
+def test_get_update_inexistent(indexes_sample):
     """Tests getting an update of an INEXISTENT operation"""
     with pytest.raises(Exception):
-        sample_indexes[0].get_update_status('999')
+        indexes_sample[0].get_update_status('999')

--- a/meilisearch/tests/index/test_index_wait_for_pending_update.py
+++ b/meilisearch/tests/index/test_index_wait_for_pending_update.py
@@ -10,7 +10,7 @@ def test_wait_for_pending_update_default(indexed_small_movies):
     assert 'status' in update
     assert update['status'] != 'enqueued'
 
-def test_wait_for_pending_update_timeout(indexed_small_movies, small_movies):
+def test_wait_for_pending_update_timeout(indexed_small_movies):
     """Tests timeout risen by waiting for an update"""
     with pytest.raises(TimeoutError):
         indexed_small_movies[0].wait_for_pending_update(2, timeout_in_ms=0)

--- a/meilisearch/tests/index/test_index_wait_for_pending_update.py
+++ b/meilisearch/tests/index/test_index_wait_for_pending_update.py
@@ -1,3 +1,5 @@
+# pylint: disable=invalid-name
+
 from datetime import datetime
 import pytest
 

--- a/meilisearch/tests/index/test_index_wait_for_pending_update.py
+++ b/meilisearch/tests/index/test_index_wait_for_pending_update.py
@@ -1,48 +1,30 @@
 from datetime import datetime
-import json
 import pytest
-import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY, clear_all_indexes
 
 class TestUpdate:
 
     """ TESTS: wait_for_pending_update method """
 
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    index = None
-    dataset_file = None
-    dataset_json = None
-
-    def setup_class(self):
-        clear_all_indexes(self.client)
-        self.index = self.client.create_index(uid='indexUID')
-        self.dataset_file = open('./datasets/small_movies.json', 'r')
-        self.dataset_json = json.loads(self.dataset_file.read())
-        self.dataset_file.close()
-
-    def teardown_class(self):
-        self.index.delete()
-
-    def test_wait_for_pending_update_default(self):
+    def test_wait_for_pending_update_default(self, indexed_small_movies):
         """Tests waiting for an update with default parameters"""
-        response = self.index.add_documents([{'id': 1, 'title': 'Le Petit Prince'}])
+        response = indexed_small_movies[0].add_documents([{'id': 1, 'title': 'Le Petit Prince'}])
         assert 'updateId' in response
-        update = self.index.wait_for_pending_update(response['updateId'])
+        update = indexed_small_movies[0].wait_for_pending_update(response['updateId'])
         assert isinstance(update, object)
         assert 'status' in update
         assert update['status'] != 'enqueued'
 
-    def test_wait_for_pending_update_timeout(self):
+    def test_wait_for_pending_update_timeout(self, indexed_small_movies, small_movies):
         """Tests timeout risen by waiting for an update"""
         with pytest.raises(TimeoutError):
-            self.index.wait_for_pending_update(2, timeout_in_ms=0)
+            indexed_small_movies[0].wait_for_pending_update(2, timeout_in_ms=0)
 
-    def test_wait_for_pending_update_interval_custom(self):
+    def test_wait_for_pending_update_interval_custom(self, indexed_small_movies, small_movies):
         """Tests call to wait for an update with custom interval"""
-        response = self.index.add_documents(self.dataset_json)
+        response = indexed_small_movies[0].add_documents(small_movies)
         assert 'updateId' in response
         start_time = datetime.now()
-        wait_update = self.index.wait_for_pending_update(
+        wait_update = indexed_small_movies[0].wait_for_pending_update(
             response['updateId'],
             interval_in_ms=1000,
             timeout_in_ms=6000
@@ -53,11 +35,11 @@ class TestUpdate:
         assert wait_update['status'] != 'enqueued'
         assert time_delta.seconds >= 1
 
-    def test_wait_for_pending_update_interval_zero(self):
+    def test_wait_for_pending_update_interval_zero(self, indexed_small_movies, small_movies):
         """Tests call to wait for an update with custom interval"""
-        response = self.index.add_documents(self.dataset_json)
+        response = indexed_small_movies[0].add_documents(small_movies)
         assert 'updateId' in response
-        wait_update = self.index.wait_for_pending_update(
+        wait_update = indexed_small_movies[0].wait_for_pending_update(
             response['updateId'],
             interval_in_ms=0,
             timeout_in_ms=6000

--- a/meilisearch/tests/index/test_index_wait_for_pending_update.py
+++ b/meilisearch/tests/index/test_index_wait_for_pending_update.py
@@ -5,9 +5,10 @@ import pytest
 
 def test_wait_for_pending_update_default(index_with_documents):
     """Tests waiting for an update with default parameters"""
-    response = index_with_documents.add_documents([{'id': 1, 'title': 'Le Petit Prince'}])
+    index = index_with_documents()
+    response = index.add_documents([{'id': 1, 'title': 'Le Petit Prince'}])
     assert 'updateId' in response
-    update = index_with_documents.wait_for_pending_update(response['updateId'])
+    update = index.wait_for_pending_update(response['updateId'])
     assert isinstance(update, object)
     assert 'status' in update
     assert update['status'] != 'enqueued'
@@ -15,14 +16,15 @@ def test_wait_for_pending_update_default(index_with_documents):
 def test_wait_for_pending_update_timeout(index_with_documents):
     """Tests timeout risen by waiting for an update"""
     with pytest.raises(TimeoutError):
-        index_with_documents.wait_for_pending_update(2, timeout_in_ms=0)
+        index_with_documents().wait_for_pending_update(2, timeout_in_ms=0)
 
 def test_wait_for_pending_update_interval_custom(index_with_documents, small_movies):
     """Tests call to wait for an update with custom interval"""
-    response = index_with_documents.add_documents(small_movies)
+    index = index_with_documents()
+    response = index.add_documents(small_movies)
     assert 'updateId' in response
     start_time = datetime.now()
-    wait_update = index_with_documents.wait_for_pending_update(
+    wait_update = index.wait_for_pending_update(
         response['updateId'],
         interval_in_ms=1000,
         timeout_in_ms=6000
@@ -35,9 +37,10 @@ def test_wait_for_pending_update_interval_custom(index_with_documents, small_mov
 
 def test_wait_for_pending_update_interval_zero(index_with_documents, small_movies):
     """Tests call to wait for an update with custom interval"""
-    response = index_with_documents.add_documents(small_movies)
+    index = index_with_documents()
+    response = index.add_documents(small_movies)
     assert 'updateId' in response
-    wait_update = index_with_documents.wait_for_pending_update(
+    wait_update = index.wait_for_pending_update(
         response['updateId'],
         interval_in_ms=0,
         timeout_in_ms=6000

--- a/meilisearch/tests/index/test_index_wait_for_pending_update.py
+++ b/meilisearch/tests/index/test_index_wait_for_pending_update.py
@@ -1,26 +1,26 @@
 from datetime import datetime
 import pytest
 
-def test_wait_for_pending_update_default(indexed_small_movies):
+def test_wait_for_pending_update_default(index_with_documents):
     """Tests waiting for an update with default parameters"""
-    response = indexed_small_movies[0].add_documents([{'id': 1, 'title': 'Le Petit Prince'}])
+    response = index_with_documents.add_documents([{'id': 1, 'title': 'Le Petit Prince'}])
     assert 'updateId' in response
-    update = indexed_small_movies[0].wait_for_pending_update(response['updateId'])
+    update = index_with_documents.wait_for_pending_update(response['updateId'])
     assert isinstance(update, object)
     assert 'status' in update
     assert update['status'] != 'enqueued'
 
-def test_wait_for_pending_update_timeout(indexed_small_movies):
+def test_wait_for_pending_update_timeout(index_with_documents):
     """Tests timeout risen by waiting for an update"""
     with pytest.raises(TimeoutError):
-        indexed_small_movies[0].wait_for_pending_update(2, timeout_in_ms=0)
+        index_with_documents.wait_for_pending_update(2, timeout_in_ms=0)
 
-def test_wait_for_pending_update_interval_custom(indexed_small_movies, small_movies):
+def test_wait_for_pending_update_interval_custom(index_with_documents, small_movies):
     """Tests call to wait for an update with custom interval"""
-    response = indexed_small_movies[0].add_documents(small_movies)
+    response = index_with_documents.add_documents(small_movies)
     assert 'updateId' in response
     start_time = datetime.now()
-    wait_update = indexed_small_movies[0].wait_for_pending_update(
+    wait_update = index_with_documents.wait_for_pending_update(
         response['updateId'],
         interval_in_ms=1000,
         timeout_in_ms=6000
@@ -31,11 +31,11 @@ def test_wait_for_pending_update_interval_custom(indexed_small_movies, small_mov
     assert wait_update['status'] != 'enqueued'
     assert time_delta.seconds >= 1
 
-def test_wait_for_pending_update_interval_zero(indexed_small_movies, small_movies):
+def test_wait_for_pending_update_interval_zero(index_with_documents, small_movies):
     """Tests call to wait for an update with custom interval"""
-    response = indexed_small_movies[0].add_documents(small_movies)
+    response = index_with_documents.add_documents(small_movies)
     assert 'updateId' in response
-    wait_update = indexed_small_movies[0].wait_for_pending_update(
+    wait_update = index_with_documents.wait_for_pending_update(
         response['updateId'],
         interval_in_ms=0,
         timeout_in_ms=6000

--- a/meilisearch/tests/index/test_index_wait_for_pending_update.py
+++ b/meilisearch/tests/index/test_index_wait_for_pending_update.py
@@ -1,49 +1,45 @@
 from datetime import datetime
 import pytest
 
-class TestUpdate:
+def test_wait_for_pending_update_default(indexed_small_movies):
+    """Tests waiting for an update with default parameters"""
+    response = indexed_small_movies[0].add_documents([{'id': 1, 'title': 'Le Petit Prince'}])
+    assert 'updateId' in response
+    update = indexed_small_movies[0].wait_for_pending_update(response['updateId'])
+    assert isinstance(update, object)
+    assert 'status' in update
+    assert update['status'] != 'enqueued'
 
-    """ TESTS: wait_for_pending_update method """
+def test_wait_for_pending_update_timeout(indexed_small_movies, small_movies):
+    """Tests timeout risen by waiting for an update"""
+    with pytest.raises(TimeoutError):
+        indexed_small_movies[0].wait_for_pending_update(2, timeout_in_ms=0)
 
-    def test_wait_for_pending_update_default(self, indexed_small_movies):
-        """Tests waiting for an update with default parameters"""
-        response = indexed_small_movies[0].add_documents([{'id': 1, 'title': 'Le Petit Prince'}])
-        assert 'updateId' in response
-        update = indexed_small_movies[0].wait_for_pending_update(response['updateId'])
-        assert isinstance(update, object)
-        assert 'status' in update
-        assert update['status'] != 'enqueued'
+def test_wait_for_pending_update_interval_custom(indexed_small_movies, small_movies):
+    """Tests call to wait for an update with custom interval"""
+    response = indexed_small_movies[0].add_documents(small_movies)
+    assert 'updateId' in response
+    start_time = datetime.now()
+    wait_update = indexed_small_movies[0].wait_for_pending_update(
+        response['updateId'],
+        interval_in_ms=1000,
+        timeout_in_ms=6000
+    )
+    time_delta = datetime.now() - start_time
+    assert isinstance(wait_update, object)
+    assert 'status' in wait_update
+    assert wait_update['status'] != 'enqueued'
+    assert time_delta.seconds >= 1
 
-    def test_wait_for_pending_update_timeout(self, indexed_small_movies, small_movies):
-        """Tests timeout risen by waiting for an update"""
-        with pytest.raises(TimeoutError):
-            indexed_small_movies[0].wait_for_pending_update(2, timeout_in_ms=0)
-
-    def test_wait_for_pending_update_interval_custom(self, indexed_small_movies, small_movies):
-        """Tests call to wait for an update with custom interval"""
-        response = indexed_small_movies[0].add_documents(small_movies)
-        assert 'updateId' in response
-        start_time = datetime.now()
-        wait_update = indexed_small_movies[0].wait_for_pending_update(
-            response['updateId'],
-            interval_in_ms=1000,
-            timeout_in_ms=6000
-        )
-        time_delta = datetime.now() - start_time
-        assert isinstance(wait_update, object)
-        assert 'status' in wait_update
-        assert wait_update['status'] != 'enqueued'
-        assert time_delta.seconds >= 1
-
-    def test_wait_for_pending_update_interval_zero(self, indexed_small_movies, small_movies):
-        """Tests call to wait for an update with custom interval"""
-        response = indexed_small_movies[0].add_documents(small_movies)
-        assert 'updateId' in response
-        wait_update = indexed_small_movies[0].wait_for_pending_update(
-            response['updateId'],
-            interval_in_ms=0,
-            timeout_in_ms=6000
-        )
-        assert isinstance(wait_update, object)
-        assert 'status' in wait_update
-        assert wait_update['status'] != 'enqueued'
+def test_wait_for_pending_update_interval_zero(indexed_small_movies, small_movies):
+    """Tests call to wait for an update with custom interval"""
+    response = indexed_small_movies[0].add_documents(small_movies)
+    assert 'updateId' in response
+    wait_update = indexed_small_movies[0].wait_for_pending_update(
+        response['updateId'],
+        interval_in_ms=0,
+        timeout_in_ms=6000
+    )
+    assert isinstance(wait_update, object)
+    assert 'status' in wait_update
+    assert wait_update['status'] != 'enqueued'

--- a/meilisearch/tests/settings/test_settings.py
+++ b/meilisearch/tests/settings/test_settings.py
@@ -13,9 +13,9 @@ DEFAULT_RANKING_RULES = [
     'exactness'
 ]
 
-def test_get_settings_default(indexes_sample):
+def test_get_settings_default(empty_index):
     """Tests getting all settings by default"""
-    response = indexes_sample[0].get_settings()
+    response = empty_index().get_settings()
     assert isinstance(response, object)
     for rule in DEFAULT_RANKING_RULES:
         assert rule in response['rankingRules']
@@ -25,14 +25,15 @@ def test_get_settings_default(indexes_sample):
     assert response['stopWords'] == []
     assert response['synonyms'] == {}
 
-def test_update_settings(indexes_sample):
+def test_update_settings(empty_index):
     """Tests updating some settings"""
-    response = indexes_sample[0].update_settings(NEW_SETTINGS)
+    index = empty_index()
+    response = index.update_settings(NEW_SETTINGS)
     assert isinstance(response, object)
     assert 'updateId' in response
-    update = indexes_sample[0].wait_for_pending_update(response['updateId'])
+    update = index.wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
-    response = indexes_sample[0].get_settings()
+    response = index.get_settings()
     for rule in NEW_SETTINGS['rankingRules']:
         assert rule in response['rankingRules']
     assert response['distinctAttribute'] is None
@@ -42,14 +43,15 @@ def test_update_settings(indexes_sample):
     assert response['stopWords'] == []
     assert response['synonyms'] == {}
 
-def test_reset_settings(indexes_sample):
+def test_reset_settings(empty_index):
     """Tests resetting default settings"""
-    response = indexes_sample[0].reset_settings()
+    index = empty_index()
+    response = index.reset_settings()
     assert isinstance(response, object)
     assert 'updateId' in response
-    update = indexes_sample[0].wait_for_pending_update(response['updateId'])
+    update = index.wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
-    response = indexes_sample[0].get_settings()
+    response = index.get_settings()
     for rule in DEFAULT_RANKING_RULES:
         assert rule in response['rankingRules']
     assert response['distinctAttribute'] is None

--- a/meilisearch/tests/settings/test_settings.py
+++ b/meilisearch/tests/settings/test_settings.py
@@ -46,6 +46,21 @@ def test_update_settings(empty_index):
 def test_reset_settings(empty_index):
     """Tests resetting default settings"""
     index = empty_index()
+    # Update settings first
+    response = index.update_settings(NEW_SETTINGS)
+    update = index.wait_for_pending_update(response['updateId'])
+    assert update['status'] == 'processed'
+    # Check the settings have been correctly updated
+    response = index.get_settings()
+    for rule in NEW_SETTINGS['rankingRules']:
+        assert rule in response['rankingRules']
+    assert response['distinctAttribute'] is None
+    for attribute in NEW_SETTINGS['searchableAttributes']:
+        assert attribute in response['searchableAttributes']
+    assert response['displayedAttributes'] == ['*']
+    assert response['stopWords'] == []
+    assert response['synonyms'] == {}
+    # Check the reset of the settings
     response = index.reset_settings()
     assert isinstance(response, object)
     assert 'updateId' in response

--- a/meilisearch/tests/settings/test_settings.py
+++ b/meilisearch/tests/settings/test_settings.py
@@ -1,12 +1,8 @@
-import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY
 
 class TestSetting:
 
     """ TESTS: all settings route """
 
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    index = None
     new_settings = {
         'rankingRules': ['typo', 'words'],
         'searchableAttributes': ['title', 'overview']
@@ -20,15 +16,9 @@ class TestSetting:
         'exactness'
     ]
 
-    def setup_class(self):
-        self.index = self.client.create_index(uid='indexUID')
-
-    def teardown_class(self):
-        self.index.delete()
-
-    def test_get_settings_default(self):
+    def test_get_settings_default(self, sample_indexes):
         """Tests getting all settings by default"""
-        response = self.index.get_settings()
+        response = sample_indexes[0].get_settings()
         assert isinstance(response, object)
         for rule in self.default_ranking_rules:
             assert rule in response['rankingRules']
@@ -38,14 +28,14 @@ class TestSetting:
         assert response['stopWords'] == []
         assert response['synonyms'] == {}
 
-    def test_update_settings(self):
+    def test_update_settings(self, sample_indexes):
         """Tests updating some settings"""
-        response = self.index.update_settings(self.new_settings)
+        response = sample_indexes[0].update_settings(self.new_settings)
         assert isinstance(response, object)
         assert 'updateId' in response
-        update = self.index.wait_for_pending_update(response['updateId'])
+        update = sample_indexes[0].wait_for_pending_update(response['updateId'])
         assert update['status'] == 'processed'
-        response = self.index.get_settings()
+        response = sample_indexes[0].get_settings()
         for rule in self.new_settings['rankingRules']:
             assert rule in response['rankingRules']
         assert response['distinctAttribute'] is None
@@ -55,14 +45,14 @@ class TestSetting:
         assert response['stopWords'] == []
         assert response['synonyms'] == {}
 
-    def test_reset_settings(self):
+    def test_reset_settings(self, sample_indexes):
         """Tests resetting default settings"""
-        response = self.index.reset_settings()
+        response = sample_indexes[0].reset_settings()
         assert isinstance(response, object)
         assert 'updateId' in response
-        update = self.index.wait_for_pending_update(response['updateId'])
+        update = sample_indexes[0].wait_for_pending_update(response['updateId'])
         assert update['status'] == 'processed'
-        response = self.index.get_settings()
+        response = sample_indexes[0].get_settings()
         for rule in self.default_ranking_rules:
             assert rule in response['rankingRules']
         assert response['distinctAttribute'] is None

--- a/meilisearch/tests/settings/test_settings.py
+++ b/meilisearch/tests/settings/test_settings.py
@@ -1,62 +1,59 @@
 
-class TestSetting:
+NEW_SETTINGS = {
+    'rankingRules': ['typo', 'words'],
+    'searchableAttributes': ['title', 'overview']
+}
 
-    """ TESTS: all settings route """
+DEFAULT_RANKING_RULES = [
+    'typo',
+    'words',
+    'proximity',
+    'attribute',
+    'wordsPosition',
+    'exactness'
+]
 
-    new_settings = {
-        'rankingRules': ['typo', 'words'],
-        'searchableAttributes': ['title', 'overview']
-    }
-    default_ranking_rules = [
-        'typo',
-        'words',
-        'proximity',
-        'attribute',
-        'wordsPosition',
-        'exactness'
-    ]
+def test_get_settings_default(sample_indexes):
+    """Tests getting all settings by default"""
+    response = sample_indexes[0].get_settings()
+    assert isinstance(response, object)
+    for rule in DEFAULT_RANKING_RULES:
+        assert rule in response['rankingRules']
+    assert response['distinctAttribute'] is None
+    assert response['searchableAttributes'] == ['*']
+    assert response['displayedAttributes'] == ['*']
+    assert response['stopWords'] == []
+    assert response['synonyms'] == {}
 
-    def test_get_settings_default(self, sample_indexes):
-        """Tests getting all settings by default"""
-        response = sample_indexes[0].get_settings()
-        assert isinstance(response, object)
-        for rule in self.default_ranking_rules:
-            assert rule in response['rankingRules']
-        assert response['distinctAttribute'] is None
-        assert response['searchableAttributes'] == ['*']
-        assert response['displayedAttributes'] == ['*']
-        assert response['stopWords'] == []
-        assert response['synonyms'] == {}
+def test_update_settings(sample_indexes):
+    """Tests updating some settings"""
+    response = sample_indexes[0].update_settings(NEW_SETTINGS)
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    update = sample_indexes[0].wait_for_pending_update(response['updateId'])
+    assert update['status'] == 'processed'
+    response = sample_indexes[0].get_settings()
+    for rule in NEW_SETTINGS['rankingRules']:
+        assert rule in response['rankingRules']
+    assert response['distinctAttribute'] is None
+    for attribute in NEW_SETTINGS['searchableAttributes']:
+        assert attribute in response['searchableAttributes']
+    assert response['displayedAttributes'] == ['*']
+    assert response['stopWords'] == []
+    assert response['synonyms'] == {}
 
-    def test_update_settings(self, sample_indexes):
-        """Tests updating some settings"""
-        response = sample_indexes[0].update_settings(self.new_settings)
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        update = sample_indexes[0].wait_for_pending_update(response['updateId'])
-        assert update['status'] == 'processed'
-        response = sample_indexes[0].get_settings()
-        for rule in self.new_settings['rankingRules']:
-            assert rule in response['rankingRules']
-        assert response['distinctAttribute'] is None
-        for attribute in self.new_settings['searchableAttributes']:
-            assert attribute in response['searchableAttributes']
-        assert response['displayedAttributes'] == ['*']
-        assert response['stopWords'] == []
-        assert response['synonyms'] == {}
-
-    def test_reset_settings(self, sample_indexes):
-        """Tests resetting default settings"""
-        response = sample_indexes[0].reset_settings()
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        update = sample_indexes[0].wait_for_pending_update(response['updateId'])
-        assert update['status'] == 'processed'
-        response = sample_indexes[0].get_settings()
-        for rule in self.default_ranking_rules:
-            assert rule in response['rankingRules']
-        assert response['distinctAttribute'] is None
-        assert response['displayedAttributes'] == ['*']
-        assert response['searchableAttributes'] == ['*']
-        assert response['stopWords'] == []
-        assert response['synonyms'] == {}
+def test_reset_settings(sample_indexes):
+    """Tests resetting default settings"""
+    response = sample_indexes[0].reset_settings()
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    update = sample_indexes[0].wait_for_pending_update(response['updateId'])
+    assert update['status'] == 'processed'
+    response = sample_indexes[0].get_settings()
+    for rule in DEFAULT_RANKING_RULES:
+        assert rule in response['rankingRules']
+    assert response['distinctAttribute'] is None
+    assert response['displayedAttributes'] == ['*']
+    assert response['searchableAttributes'] == ['*']
+    assert response['stopWords'] == []
+    assert response['synonyms'] == {}

--- a/meilisearch/tests/settings/test_settings.py
+++ b/meilisearch/tests/settings/test_settings.py
@@ -13,9 +13,9 @@ DEFAULT_RANKING_RULES = [
     'exactness'
 ]
 
-def test_get_settings_default(sample_indexes):
+def test_get_settings_default(indexes_sample):
     """Tests getting all settings by default"""
-    response = sample_indexes[0].get_settings()
+    response = indexes_sample[0].get_settings()
     assert isinstance(response, object)
     for rule in DEFAULT_RANKING_RULES:
         assert rule in response['rankingRules']
@@ -25,14 +25,14 @@ def test_get_settings_default(sample_indexes):
     assert response['stopWords'] == []
     assert response['synonyms'] == {}
 
-def test_update_settings(sample_indexes):
+def test_update_settings(indexes_sample):
     """Tests updating some settings"""
-    response = sample_indexes[0].update_settings(NEW_SETTINGS)
+    response = indexes_sample[0].update_settings(NEW_SETTINGS)
     assert isinstance(response, object)
     assert 'updateId' in response
-    update = sample_indexes[0].wait_for_pending_update(response['updateId'])
+    update = indexes_sample[0].wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
-    response = sample_indexes[0].get_settings()
+    response = indexes_sample[0].get_settings()
     for rule in NEW_SETTINGS['rankingRules']:
         assert rule in response['rankingRules']
     assert response['distinctAttribute'] is None
@@ -42,14 +42,14 @@ def test_update_settings(sample_indexes):
     assert response['stopWords'] == []
     assert response['synonyms'] == {}
 
-def test_reset_settings(sample_indexes):
+def test_reset_settings(indexes_sample):
     """Tests resetting default settings"""
-    response = sample_indexes[0].reset_settings()
+    response = indexes_sample[0].reset_settings()
     assert isinstance(response, object)
     assert 'updateId' in response
-    update = sample_indexes[0].wait_for_pending_update(response['updateId'])
+    update = indexes_sample[0].wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
-    response = sample_indexes[0].get_settings()
+    response = indexes_sample[0].get_settings()
     for rule in DEFAULT_RANKING_RULES:
         assert rule in response['rankingRules']
     assert response['distinctAttribute'] is None

--- a/meilisearch/tests/settings/test_settings_attributes_for_faceting_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_attributes_for_faceting_meilisearch.py
@@ -1,4 +1,4 @@
-
+# pylint: disable=invalid-name
 
 def test_get_attributes_for_faceting(indexes_sample):
     """ Tests getting the attributes for faceting """

--- a/meilisearch/tests/settings/test_settings_attributes_for_faceting_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_attributes_for_faceting_meilisearch.py
@@ -1,48 +1,29 @@
-import json
-import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY
 
-class TestAttributesForFaceting:
 
-    """ TESTS: attributesForFaceting setting """
+def test_get_attributes_for_faceting(sample_indexes):
+    """ Tests getting the attributes for faceting """
+    response = sample_indexes[0].get_attributes_for_faceting()
+    assert isinstance(response, object)
+    assert response == []
 
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    index = None
+def test_update_attributes_for_faceting(sample_indexes):
+    """Tests updating the attributes for faceting"""
     attributes_for_faceting = ['title', 'release_date']
-    dataset_file = None
-    dataset_json = None
 
-    def setup_class(self):
-        self.index = self.client.create_index(uid='indexUID')
-        self.dataset_file = open('./datasets/small_movies.json', 'r')
-        self.dataset_json = json.loads(self.dataset_file.read())
-        self.dataset_file.close()
+    response = sample_indexes[0].update_attributes_for_faceting(attributes_for_faceting)
+    sample_indexes[0].wait_for_pending_update(response['updateId'])
+    get_attributes_new = sample_indexes[0].get_attributes_for_faceting()
+    assert len(get_attributes_new) == len(attributes_for_faceting)
+    get_attributes = sample_indexes[0].get_attributes_for_faceting()
+    for attribute in attributes_for_faceting:
+        assert attribute in get_attributes
 
-    def teardown_class(self):
-        self.index.delete()
-
-    def test_get_attributes_for_faceting(self):
-        """ Tests getting the attributes for faceting """
-        response = self.index.get_attributes_for_faceting()
-        assert isinstance(response, object)
-        assert response == []
-
-    def test_update_attributes_for_faceting(self):
-        """Tests updating the attributes for faceting"""
-        response = self.index.update_attributes_for_faceting(self.attributes_for_faceting)
-        self.index.wait_for_pending_update(response['updateId'])
-        get_attributes_new = self.index.get_attributes_for_faceting()
-        assert len(get_attributes_new) == len(self.attributes_for_faceting)
-        get_attributes = self.index.get_attributes_for_faceting()
-        for attribute in self.attributes_for_faceting:
-            assert attribute in get_attributes
-
-    def test_reset_attributes_for_faceting(self):
-        """Tests the reset of attributes for faceting to default values (in dataset)"""
-        response = self.index.reset_attributes_for_faceting()
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        self.index.wait_for_pending_update(response['updateId'])
-        response = self.index.get_attributes_for_faceting()
-        assert isinstance(response, object)
-        assert response == []
+def test_reset_attributes_for_faceting(sample_indexes):
+    """Tests the reset of attributes for faceting to default values (in dataset)"""
+    response = sample_indexes[0].reset_attributes_for_faceting()
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    sample_indexes[0].wait_for_pending_update(response['updateId'])
+    response = sample_indexes[0].get_attributes_for_faceting()
+    assert isinstance(response, object)
+    assert response == []

--- a/meilisearch/tests/settings/test_settings_attributes_for_faceting_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_attributes_for_faceting_meilisearch.py
@@ -1,29 +1,29 @@
 
 
-def test_get_attributes_for_faceting(sample_indexes):
+def test_get_attributes_for_faceting(indexes_sample):
     """ Tests getting the attributes for faceting """
-    response = sample_indexes[0].get_attributes_for_faceting()
+    response = indexes_sample[0].get_attributes_for_faceting()
     assert isinstance(response, object)
     assert response == []
 
-def test_update_attributes_for_faceting(sample_indexes):
+def test_update_attributes_for_faceting(indexes_sample):
     """Tests updating the attributes for faceting"""
     attributes_for_faceting = ['title', 'release_date']
 
-    response = sample_indexes[0].update_attributes_for_faceting(attributes_for_faceting)
-    sample_indexes[0].wait_for_pending_update(response['updateId'])
-    get_attributes_new = sample_indexes[0].get_attributes_for_faceting()
+    response = indexes_sample[0].update_attributes_for_faceting(attributes_for_faceting)
+    indexes_sample[0].wait_for_pending_update(response['updateId'])
+    get_attributes_new = indexes_sample[0].get_attributes_for_faceting()
     assert len(get_attributes_new) == len(attributes_for_faceting)
-    get_attributes = sample_indexes[0].get_attributes_for_faceting()
+    get_attributes = indexes_sample[0].get_attributes_for_faceting()
     for attribute in attributes_for_faceting:
         assert attribute in get_attributes
 
-def test_reset_attributes_for_faceting(sample_indexes):
+def test_reset_attributes_for_faceting(indexes_sample):
     """Tests the reset of attributes for faceting to default values (in dataset)"""
-    response = sample_indexes[0].reset_attributes_for_faceting()
+    response = indexes_sample[0].reset_attributes_for_faceting()
     assert isinstance(response, object)
     assert 'updateId' in response
-    sample_indexes[0].wait_for_pending_update(response['updateId'])
-    response = sample_indexes[0].get_attributes_for_faceting()
+    indexes_sample[0].wait_for_pending_update(response['updateId'])
+    response = indexes_sample[0].get_attributes_for_faceting()
     assert isinstance(response, object)
     assert response == []

--- a/meilisearch/tests/settings/test_settings_attributes_for_faceting_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_attributes_for_faceting_meilisearch.py
@@ -1,29 +1,30 @@
 # pylint: disable=invalid-name
 
-def test_get_attributes_for_faceting(indexes_sample):
+def test_get_attributes_for_faceting(empty_index):
     """ Tests getting the attributes for faceting """
-    response = indexes_sample[0].get_attributes_for_faceting()
+    response = empty_index().get_attributes_for_faceting()
     assert isinstance(response, object)
     assert response == []
 
-def test_update_attributes_for_faceting(indexes_sample):
+def test_update_attributes_for_faceting(empty_index):
     """Tests updating the attributes for faceting"""
     attributes_for_faceting = ['title', 'release_date']
-
-    response = indexes_sample[0].update_attributes_for_faceting(attributes_for_faceting)
-    indexes_sample[0].wait_for_pending_update(response['updateId'])
-    get_attributes_new = indexes_sample[0].get_attributes_for_faceting()
+    index = empty_index()
+    response = index.update_attributes_for_faceting(attributes_for_faceting)
+    index.wait_for_pending_update(response['updateId'])
+    get_attributes_new = index.get_attributes_for_faceting()
     assert len(get_attributes_new) == len(attributes_for_faceting)
-    get_attributes = indexes_sample[0].get_attributes_for_faceting()
+    get_attributes = index.get_attributes_for_faceting()
     for attribute in attributes_for_faceting:
         assert attribute in get_attributes
 
-def test_reset_attributes_for_faceting(indexes_sample):
+def test_reset_attributes_for_faceting(empty_index):
     """Tests the reset of attributes for faceting to default values (in dataset)"""
-    response = indexes_sample[0].reset_attributes_for_faceting()
+    index = empty_index()
+    response = index.reset_attributes_for_faceting()
     assert isinstance(response, object)
     assert 'updateId' in response
-    indexes_sample[0].wait_for_pending_update(response['updateId'])
-    response = indexes_sample[0].get_attributes_for_faceting()
+    index.wait_for_pending_update(response['updateId'])
+    response = index.get_attributes_for_faceting()
     assert isinstance(response, object)
     assert response == []

--- a/meilisearch/tests/settings/test_settings_displayed_attributes_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_displayed_attributes_meilisearch.py
@@ -1,34 +1,31 @@
 
-class TestDisplayedAttributes:
+DISPLAYED_ATTRIBUTES = ['id', 'release_date', 'title', 'poster', 'overview', 'genre']
 
-    """ TESTS: displayedAttributes setting """
 
-    displayed_attributes = ['id', 'release_date', 'title', 'poster', 'overview', 'genre']
+def test_get_displayed_attributes(sample_indexes, small_movies):
+    """ Tests getting the displayed attributes before and after indexing a dataset """
+    response = sample_indexes[0].get_displayed_attributes()
+    assert isinstance(response, object)
+    assert response == ['*']
+    response = sample_indexes[0].add_documents(small_movies, primary_key='id')
+    sample_indexes[0].wait_for_pending_update(response['updateId'])
+    get_attributes = sample_indexes[0].get_displayed_attributes()
+    assert get_attributes == ['*']
 
-    def test_get_displayed_attributes(self, sample_indexes, small_movies):
-        """ Tests getting the displayed attributes before and after indexing a dataset """
-        response = sample_indexes[0].get_displayed_attributes()
-        assert isinstance(response, object)
-        assert response == ['*']
-        response = sample_indexes[0].add_documents(small_movies, primary_key='id')
-        sample_indexes[0].wait_for_pending_update(response['updateId'])
-        get_attributes = sample_indexes[0].get_displayed_attributes()
-        assert get_attributes == ['*']
+def test_update_displayed_attributes(sample_indexes):
+    """Tests updating the displayed attributes"""
+    response = sample_indexes[0].update_displayed_attributes(DISPLAYED_ATTRIBUTES)
+    sample_indexes[0].wait_for_pending_update(response['updateId'])
+    get_attributes_new = sample_indexes[0].get_displayed_attributes()
+    assert len(get_attributes_new) == len(DISPLAYED_ATTRIBUTES)
+    for attribute in DISPLAYED_ATTRIBUTES:
+        assert attribute in get_attributes_new
 
-    def test_update_displayed_attributes(self, sample_indexes):
-        """Tests updating the displayed attributes"""
-        response = sample_indexes[0].update_displayed_attributes(self.displayed_attributes)
-        sample_indexes[0].wait_for_pending_update(response['updateId'])
-        get_attributes_new = sample_indexes[0].get_displayed_attributes()
-        assert len(get_attributes_new) == len(self.displayed_attributes)
-        for attribute in self.displayed_attributes:
-            assert attribute in get_attributes_new
-
-    def test_reset_displayed_attributes(self, sample_indexes):
-        """Tests the reset of displayedAttributes to default values (in dataset)"""
-        response = sample_indexes[0].reset_displayed_attributes()
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        sample_indexes[0].wait_for_pending_update(response['updateId'])
-        get_attributes = sample_indexes[0].get_displayed_attributes()
-        assert get_attributes == ['*']
+def test_reset_displayed_attributes(sample_indexes):
+    """Tests the reset of displayedAttributes to default values (in dataset)"""
+    response = sample_indexes[0].reset_displayed_attributes()
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    sample_indexes[0].wait_for_pending_update(response['updateId'])
+    get_attributes = sample_indexes[0].get_displayed_attributes()
+    assert get_attributes == ['*']

--- a/meilisearch/tests/settings/test_settings_displayed_attributes_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_displayed_attributes_meilisearch.py
@@ -3,30 +3,33 @@
 DISPLAYED_ATTRIBUTES = ['id', 'release_date', 'title', 'poster', 'overview', 'genre']
 
 
-def test_get_displayed_attributes(indexes_sample, small_movies):
+def test_get_displayed_attributes(empty_index, small_movies):
     """ Tests getting the displayed attributes before and after indexing a dataset """
-    response = indexes_sample[0].get_displayed_attributes()
+    index =  empty_index()
+    response = index.get_displayed_attributes()
     assert isinstance(response, object)
     assert response == ['*']
-    response = indexes_sample[0].add_documents(small_movies, primary_key='id')
-    indexes_sample[0].wait_for_pending_update(response['updateId'])
-    get_attributes = indexes_sample[0].get_displayed_attributes()
+    response = index.add_documents(small_movies)
+    index.wait_for_pending_update(response['updateId'])
+    get_attributes = index.get_displayed_attributes()
     assert get_attributes == ['*']
 
-def test_update_displayed_attributes(indexes_sample):
+def test_update_displayed_attributes(empty_index):
     """Tests updating the displayed attributes"""
-    response = indexes_sample[0].update_displayed_attributes(DISPLAYED_ATTRIBUTES)
-    indexes_sample[0].wait_for_pending_update(response['updateId'])
-    get_attributes_new = indexes_sample[0].get_displayed_attributes()
+    index = empty_index()
+    response = index.update_displayed_attributes(DISPLAYED_ATTRIBUTES)
+    index.wait_for_pending_update(response['updateId'])
+    get_attributes_new = index.get_displayed_attributes()
     assert len(get_attributes_new) == len(DISPLAYED_ATTRIBUTES)
     for attribute in DISPLAYED_ATTRIBUTES:
         assert attribute in get_attributes_new
 
-def test_reset_displayed_attributes(indexes_sample):
+def test_reset_displayed_attributes(empty_index):
     """Tests the reset of displayedAttributes to default values (in dataset)"""
-    response = indexes_sample[0].reset_displayed_attributes()
+    index = empty_index()
+    response = index.reset_displayed_attributes()
     assert isinstance(response, object)
     assert 'updateId' in response
-    indexes_sample[0].wait_for_pending_update(response['updateId'])
-    get_attributes = indexes_sample[0].get_displayed_attributes()
+    index.wait_for_pending_update(response['updateId'])
+    get_attributes = index.get_displayed_attributes()
     assert get_attributes == ['*']

--- a/meilisearch/tests/settings/test_settings_displayed_attributes_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_displayed_attributes_meilisearch.py
@@ -2,30 +2,30 @@
 DISPLAYED_ATTRIBUTES = ['id', 'release_date', 'title', 'poster', 'overview', 'genre']
 
 
-def test_get_displayed_attributes(sample_indexes, small_movies):
+def test_get_displayed_attributes(indexes_sample, small_movies):
     """ Tests getting the displayed attributes before and after indexing a dataset """
-    response = sample_indexes[0].get_displayed_attributes()
+    response = indexes_sample[0].get_displayed_attributes()
     assert isinstance(response, object)
     assert response == ['*']
-    response = sample_indexes[0].add_documents(small_movies, primary_key='id')
-    sample_indexes[0].wait_for_pending_update(response['updateId'])
-    get_attributes = sample_indexes[0].get_displayed_attributes()
+    response = indexes_sample[0].add_documents(small_movies, primary_key='id')
+    indexes_sample[0].wait_for_pending_update(response['updateId'])
+    get_attributes = indexes_sample[0].get_displayed_attributes()
     assert get_attributes == ['*']
 
-def test_update_displayed_attributes(sample_indexes):
+def test_update_displayed_attributes(indexes_sample):
     """Tests updating the displayed attributes"""
-    response = sample_indexes[0].update_displayed_attributes(DISPLAYED_ATTRIBUTES)
-    sample_indexes[0].wait_for_pending_update(response['updateId'])
-    get_attributes_new = sample_indexes[0].get_displayed_attributes()
+    response = indexes_sample[0].update_displayed_attributes(DISPLAYED_ATTRIBUTES)
+    indexes_sample[0].wait_for_pending_update(response['updateId'])
+    get_attributes_new = indexes_sample[0].get_displayed_attributes()
     assert len(get_attributes_new) == len(DISPLAYED_ATTRIBUTES)
     for attribute in DISPLAYED_ATTRIBUTES:
         assert attribute in get_attributes_new
 
-def test_reset_displayed_attributes(sample_indexes):
+def test_reset_displayed_attributes(indexes_sample):
     """Tests the reset of displayedAttributes to default values (in dataset)"""
-    response = sample_indexes[0].reset_displayed_attributes()
+    response = indexes_sample[0].reset_displayed_attributes()
     assert isinstance(response, object)
     assert 'updateId' in response
-    sample_indexes[0].wait_for_pending_update(response['updateId'])
-    get_attributes = sample_indexes[0].get_displayed_attributes()
+    indexes_sample[0].wait_for_pending_update(response['updateId'])
+    get_attributes = indexes_sample[0].get_displayed_attributes()
     assert get_attributes == ['*']

--- a/meilisearch/tests/settings/test_settings_displayed_attributes_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_displayed_attributes_meilisearch.py
@@ -1,3 +1,4 @@
+# pylint: disable=invalid-name
 
 DISPLAYED_ATTRIBUTES = ['id', 'release_date', 'title', 'poster', 'overview', 'genre']
 

--- a/meilisearch/tests/settings/test_settings_displayed_attributes_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_displayed_attributes_meilisearch.py
@@ -1,50 +1,34 @@
-import json
-import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY
 
 class TestDisplayedAttributes:
 
     """ TESTS: displayedAttributes setting """
 
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    index = None
     displayed_attributes = ['id', 'release_date', 'title', 'poster', 'overview', 'genre']
-    dataset_file = None
-    dataset_json = None
 
-    def setup_class(self):
-        self.index = self.client.create_index(uid='indexUID')
-        self.dataset_file = open('./datasets/small_movies.json', 'r')
-        self.dataset_json = json.loads(self.dataset_file.read())
-        self.dataset_file.close()
-
-    def teardown_class(self):
-        self.index.delete()
-
-    def test_get_displayed_attributes(self):
+    def test_get_displayed_attributes(self, sample_indexes, small_movies):
         """ Tests getting the displayed attributes before and after indexing a dataset """
-        response = self.index.get_displayed_attributes()
+        response = sample_indexes[0].get_displayed_attributes()
         assert isinstance(response, object)
         assert response == ['*']
-        response = self.index.add_documents(self.dataset_json, primary_key='id')
-        self.index.wait_for_pending_update(response['updateId'])
-        get_attributes = self.index.get_displayed_attributes()
+        response = sample_indexes[0].add_documents(small_movies, primary_key='id')
+        sample_indexes[0].wait_for_pending_update(response['updateId'])
+        get_attributes = sample_indexes[0].get_displayed_attributes()
         assert get_attributes == ['*']
 
-    def test_update_displayed_attributes(self):
+    def test_update_displayed_attributes(self, sample_indexes):
         """Tests updating the displayed attributes"""
-        response = self.index.update_displayed_attributes(self.displayed_attributes)
-        self.index.wait_for_pending_update(response['updateId'])
-        get_attributes_new = self.index.get_displayed_attributes()
+        response = sample_indexes[0].update_displayed_attributes(self.displayed_attributes)
+        sample_indexes[0].wait_for_pending_update(response['updateId'])
+        get_attributes_new = sample_indexes[0].get_displayed_attributes()
         assert len(get_attributes_new) == len(self.displayed_attributes)
         for attribute in self.displayed_attributes:
             assert attribute in get_attributes_new
 
-    def test_reset_displayed_attributes(self):
+    def test_reset_displayed_attributes(self, sample_indexes):
         """Tests the reset of displayedAttributes to default values (in dataset)"""
-        response = self.index.reset_displayed_attributes()
+        response = sample_indexes[0].reset_displayed_attributes()
         assert isinstance(response, object)
         assert 'updateId' in response
-        self.index.wait_for_pending_update(response['updateId'])
-        get_attributes = self.index.get_displayed_attributes()
+        sample_indexes[0].wait_for_pending_update(response['updateId'])
+        get_attributes = sample_indexes[0].get_displayed_attributes()
         assert get_attributes == ['*']

--- a/meilisearch/tests/settings/test_settings_distinct_attribute_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_distinct_attribute_meilisearch.py
@@ -1,42 +1,32 @@
-import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY
 
 class TestDistinctAttribute:
 
     """ TESTS: distinctAttribute setting """
 
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    index = None
     new_distinct_attribute = 'title'
     default_distinct_attribute = None
 
-    def setup_class(self):
-        self.index = self.client.create_index(uid='indexUID')
-
-    def teardown_class(self):
-        self.index.delete()
-
-    def test_get_distinct_attribute(self):
+    def test_get_distinct_attribute(self, sample_indexes):
         """Tests geting the distinct attributes"""
-        response = self.index.get_distinct_attribute()
+        response = sample_indexes[0].get_distinct_attribute()
         assert isinstance(response, object)
         assert response == self.default_distinct_attribute
 
-    def test_update_distinct_attribute(self):
+    def test_update_distinct_attribute(self, sample_indexes):
         """Tests creating a custom distinct attribute and checks it has been set correctly"""
-        response = self.index.update_distinct_attribute(self.new_distinct_attribute)
+        response = sample_indexes[0].update_distinct_attribute(self.new_distinct_attribute)
         assert isinstance(response, object)
         assert 'updateId' in response
-        self.index.wait_for_pending_update(response['updateId'])
-        response = self.index.get_distinct_attribute()
+        sample_indexes[0].wait_for_pending_update(response['updateId'])
+        response = sample_indexes[0].get_distinct_attribute()
         assert isinstance(response, object)
         assert response == self.new_distinct_attribute
 
-    def test_reset_distinct_attribute(self):
+    def test_reset_distinct_attribute(self, sample_indexes):
         """Tests resetting distinct attribute"""
-        response = self.index.reset_distinct_attribute()
+        response = sample_indexes[0].reset_distinct_attribute()
         assert isinstance(response, object)
         assert 'updateId' in response
-        self.index.wait_for_pending_update(response['updateId'])
-        response = self.index.get_distinct_attribute()
+        sample_indexes[0].wait_for_pending_update(response['updateId'])
+        response = sample_indexes[0].get_distinct_attribute()
         assert response == self.default_distinct_attribute

--- a/meilisearch/tests/settings/test_settings_distinct_attribute_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_distinct_attribute_meilisearch.py
@@ -3,27 +3,27 @@
 NEW_DISTINCT_ATTRIBUTE = 'title'
 DEFAULT_DISTINCT_ATTRIBUTE = None
 
-def test_get_distinct_attribute(sample_indexes):
+def test_get_distinct_attribute(indexes_sample):
     """Tests geting the distinct attributes"""
-    response = sample_indexes[0].get_distinct_attribute()
+    response = indexes_sample[0].get_distinct_attribute()
     assert isinstance(response, object)
     assert response == DEFAULT_DISTINCT_ATTRIBUTE
 
-def test_update_distinct_attribute(sample_indexes):
+def test_update_distinct_attribute(indexes_sample):
     """Tests creating a custom distinct attribute and checks it has been set correctly"""
-    response = sample_indexes[0].update_distinct_attribute(NEW_DISTINCT_ATTRIBUTE)
+    response = indexes_sample[0].update_distinct_attribute(NEW_DISTINCT_ATTRIBUTE)
     assert isinstance(response, object)
     assert 'updateId' in response
-    sample_indexes[0].wait_for_pending_update(response['updateId'])
-    response = sample_indexes[0].get_distinct_attribute()
+    indexes_sample[0].wait_for_pending_update(response['updateId'])
+    response = indexes_sample[0].get_distinct_attribute()
     assert isinstance(response, object)
     assert response == NEW_DISTINCT_ATTRIBUTE
 
-def test_reset_distinct_attribute(sample_indexes):
+def test_reset_distinct_attribute(indexes_sample):
     """Tests resetting distinct attribute"""
-    response = sample_indexes[0].reset_distinct_attribute()
+    response = indexes_sample[0].reset_distinct_attribute()
     assert isinstance(response, object)
     assert 'updateId' in response
-    sample_indexes[0].wait_for_pending_update(response['updateId'])
-    response = sample_indexes[0].get_distinct_attribute()
+    indexes_sample[0].wait_for_pending_update(response['updateId'])
+    response = indexes_sample[0].get_distinct_attribute()
     assert response == DEFAULT_DISTINCT_ATTRIBUTE

--- a/meilisearch/tests/settings/test_settings_distinct_attribute_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_distinct_attribute_meilisearch.py
@@ -3,27 +3,29 @@
 NEW_DISTINCT_ATTRIBUTE = 'title'
 DEFAULT_DISTINCT_ATTRIBUTE = None
 
-def test_get_distinct_attribute(indexes_sample):
+def test_get_distinct_attribute(empty_index):
     """Tests geting the distinct attributes"""
-    response = indexes_sample[0].get_distinct_attribute()
+    response = empty_index().get_distinct_attribute()
     assert isinstance(response, object)
     assert response == DEFAULT_DISTINCT_ATTRIBUTE
 
-def test_update_distinct_attribute(indexes_sample):
+def test_update_distinct_attribute(empty_index):
     """Tests creating a custom distinct attribute and checks it has been set correctly"""
-    response = indexes_sample[0].update_distinct_attribute(NEW_DISTINCT_ATTRIBUTE)
+    index = empty_index()
+    response = index.update_distinct_attribute(NEW_DISTINCT_ATTRIBUTE)
     assert isinstance(response, object)
     assert 'updateId' in response
-    indexes_sample[0].wait_for_pending_update(response['updateId'])
-    response = indexes_sample[0].get_distinct_attribute()
+    index.wait_for_pending_update(response['updateId'])
+    response = index.get_distinct_attribute()
     assert isinstance(response, object)
     assert response == NEW_DISTINCT_ATTRIBUTE
 
-def test_reset_distinct_attribute(indexes_sample):
+def test_reset_distinct_attribute(empty_index):
     """Tests resetting distinct attribute"""
-    response = indexes_sample[0].reset_distinct_attribute()
+    index = empty_index()
+    response = index.reset_distinct_attribute()
     assert isinstance(response, object)
     assert 'updateId' in response
-    indexes_sample[0].wait_for_pending_update(response['updateId'])
-    response = indexes_sample[0].get_distinct_attribute()
+    index.wait_for_pending_update(response['updateId'])
+    response = index.get_distinct_attribute()
     assert response == DEFAULT_DISTINCT_ATTRIBUTE

--- a/meilisearch/tests/settings/test_settings_distinct_attribute_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_distinct_attribute_meilisearch.py
@@ -1,32 +1,29 @@
 
-class TestDistinctAttribute:
 
-    """ TESTS: distinctAttribute setting """
+NEW_DISTINCT_ATTRIBUTE = 'title'
+DEFAULT_DISTINCT_ATTRIBUTE = None
 
-    new_distinct_attribute = 'title'
-    default_distinct_attribute = None
+def test_get_distinct_attribute(sample_indexes):
+    """Tests geting the distinct attributes"""
+    response = sample_indexes[0].get_distinct_attribute()
+    assert isinstance(response, object)
+    assert response == DEFAULT_DISTINCT_ATTRIBUTE
 
-    def test_get_distinct_attribute(self, sample_indexes):
-        """Tests geting the distinct attributes"""
-        response = sample_indexes[0].get_distinct_attribute()
-        assert isinstance(response, object)
-        assert response == self.default_distinct_attribute
+def test_update_distinct_attribute(sample_indexes):
+    """Tests creating a custom distinct attribute and checks it has been set correctly"""
+    response = sample_indexes[0].update_distinct_attribute(NEW_DISTINCT_ATTRIBUTE)
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    sample_indexes[0].wait_for_pending_update(response['updateId'])
+    response = sample_indexes[0].get_distinct_attribute()
+    assert isinstance(response, object)
+    assert response == NEW_DISTINCT_ATTRIBUTE
 
-    def test_update_distinct_attribute(self, sample_indexes):
-        """Tests creating a custom distinct attribute and checks it has been set correctly"""
-        response = sample_indexes[0].update_distinct_attribute(self.new_distinct_attribute)
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        sample_indexes[0].wait_for_pending_update(response['updateId'])
-        response = sample_indexes[0].get_distinct_attribute()
-        assert isinstance(response, object)
-        assert response == self.new_distinct_attribute
-
-    def test_reset_distinct_attribute(self, sample_indexes):
-        """Tests resetting distinct attribute"""
-        response = sample_indexes[0].reset_distinct_attribute()
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        sample_indexes[0].wait_for_pending_update(response['updateId'])
-        response = sample_indexes[0].get_distinct_attribute()
-        assert response == self.default_distinct_attribute
+def test_reset_distinct_attribute(sample_indexes):
+    """Tests resetting distinct attribute"""
+    response = sample_indexes[0].reset_distinct_attribute()
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    sample_indexes[0].wait_for_pending_update(response['updateId'])
+    response = sample_indexes[0].get_distinct_attribute()
+    assert response == DEFAULT_DISTINCT_ATTRIBUTE

--- a/meilisearch/tests/settings/test_settings_ranking_rules_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_ranking_rules_meilisearch.py
@@ -1,12 +1,7 @@
-import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY
-
 class TestRankingRules:
 
     """ TESTS: ranking rules route """
 
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    index = None
     new_ranking_rules = ['typo', 'exactness']
     default_ranking_rules = [
         'typo',
@@ -17,36 +12,30 @@ class TestRankingRules:
         'exactness'
     ]
 
-    def setup_class(self):
-        self.index = self.client.create_index(uid='indexUID')
-
-    def teardown_class(self):
-        self.index.delete()
-
-    def test_get_ranking_rules_default(self):
+    def test_get_ranking_rules_default(self, sample_indexes):
         """Tests getting the default ranking rules"""
-        response = self.index.get_ranking_rules()
+        response = sample_indexes[0].get_ranking_rules()
         assert isinstance(response, object)
         for rule in self.default_ranking_rules:
             assert rule in response
 
-    def test_update_ranking_rules(self):
+    def test_update_ranking_rules(self, sample_indexes):
         """Tests changing the ranking rules"""
-        response = self.index.update_ranking_rules(self.new_ranking_rules)
+        response = sample_indexes[0].update_ranking_rules(self.new_ranking_rules)
         assert isinstance(response, object)
         assert 'updateId' in response
-        self.index.wait_for_pending_update(response['updateId'])
-        response = self.index.get_ranking_rules()
+        sample_indexes[0].wait_for_pending_update(response['updateId'])
+        response = sample_indexes[0].get_ranking_rules()
         assert isinstance(response, object)
         for rule in self.new_ranking_rules:
             assert rule in response
 
-    def test_reset_ranking_rules(self):
+    def test_reset_ranking_rules(self, sample_indexes):
         """Tests resetting the ranking rules"""
-        response = self.index.reset_ranking_rules()
+        response = sample_indexes[0].reset_ranking_rules()
         assert isinstance(response, object)
         assert 'updateId' in response
-        self.index.wait_for_pending_update(response['updateId'])
-        response = self.index.get_ranking_rules()
+        sample_indexes[0].wait_for_pending_update(response['updateId'])
+        response = sample_indexes[0].get_ranking_rules()
         for rule in self.default_ranking_rules:
             assert rule in response

--- a/meilisearch/tests/settings/test_settings_ranking_rules_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_ranking_rules_meilisearch.py
@@ -9,30 +9,32 @@ DEFAULT_RANKING_RULES = [
     'exactness'
 ]
 
-def test_get_ranking_rules_default(indexes_sample):
+def test_get_ranking_rules_default(empty_index):
     """Tests getting the default ranking rules"""
-    response = indexes_sample[0].get_ranking_rules()
+    response = empty_index().get_ranking_rules()
     assert isinstance(response, object)
     for rule in DEFAULT_RANKING_RULES:
         assert rule in response
 
-def test_update_ranking_rules(indexes_sample):
+def test_update_ranking_rules(empty_index):
     """Tests changing the ranking rules"""
-    response = indexes_sample[0].update_ranking_rules(NEW_RANKING_RULES)
+    index = empty_index()
+    response = index.update_ranking_rules(NEW_RANKING_RULES)
     assert isinstance(response, object)
     assert 'updateId' in response
-    indexes_sample[0].wait_for_pending_update(response['updateId'])
-    response = indexes_sample[0].get_ranking_rules()
+    index.wait_for_pending_update(response['updateId'])
+    response = index.get_ranking_rules()
     assert isinstance(response, object)
     for rule in NEW_RANKING_RULES:
         assert rule in response
 
-def test_reset_ranking_rules(indexes_sample):
+def test_reset_ranking_rules(empty_index):
     """Tests resetting the ranking rules"""
-    response = indexes_sample[0].reset_ranking_rules()
+    index = empty_index()
+    response = index.reset_ranking_rules()
     assert isinstance(response, object)
     assert 'updateId' in response
-    indexes_sample[0].wait_for_pending_update(response['updateId'])
-    response = indexes_sample[0].get_ranking_rules()
+    index.wait_for_pending_update(response['updateId'])
+    response = index.get_ranking_rules()
     for rule in DEFAULT_RANKING_RULES:
         assert rule in response

--- a/meilisearch/tests/settings/test_settings_ranking_rules_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_ranking_rules_meilisearch.py
@@ -9,30 +9,30 @@ DEFAULT_RANKING_RULES = [
     'exactness'
 ]
 
-def test_get_ranking_rules_default(sample_indexes):
+def test_get_ranking_rules_default(indexes_sample):
     """Tests getting the default ranking rules"""
-    response = sample_indexes[0].get_ranking_rules()
+    response = indexes_sample[0].get_ranking_rules()
     assert isinstance(response, object)
     for rule in DEFAULT_RANKING_RULES:
         assert rule in response
 
-def test_update_ranking_rules(sample_indexes):
+def test_update_ranking_rules(indexes_sample):
     """Tests changing the ranking rules"""
-    response = sample_indexes[0].update_ranking_rules(NEW_RANKING_RULES)
+    response = indexes_sample[0].update_ranking_rules(NEW_RANKING_RULES)
     assert isinstance(response, object)
     assert 'updateId' in response
-    sample_indexes[0].wait_for_pending_update(response['updateId'])
-    response = sample_indexes[0].get_ranking_rules()
+    indexes_sample[0].wait_for_pending_update(response['updateId'])
+    response = indexes_sample[0].get_ranking_rules()
     assert isinstance(response, object)
     for rule in NEW_RANKING_RULES:
         assert rule in response
 
-def test_reset_ranking_rules(sample_indexes):
+def test_reset_ranking_rules(indexes_sample):
     """Tests resetting the ranking rules"""
-    response = sample_indexes[0].reset_ranking_rules()
+    response = indexes_sample[0].reset_ranking_rules()
     assert isinstance(response, object)
     assert 'updateId' in response
-    sample_indexes[0].wait_for_pending_update(response['updateId'])
-    response = sample_indexes[0].get_ranking_rules()
+    indexes_sample[0].wait_for_pending_update(response['updateId'])
+    response = indexes_sample[0].get_ranking_rules()
     for rule in DEFAULT_RANKING_RULES:
         assert rule in response

--- a/meilisearch/tests/settings/test_settings_ranking_rules_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_ranking_rules_meilisearch.py
@@ -1,41 +1,38 @@
-class TestRankingRules:
 
-    """ TESTS: ranking rules route """
+NEW_RANKING_RULES = ['typo', 'exactness']
+DEFAULT_RANKING_RULES = [
+    'typo',
+    'words',
+    'proximity',
+    'attribute',
+    'wordsPosition',
+    'exactness'
+]
 
-    new_ranking_rules = ['typo', 'exactness']
-    default_ranking_rules = [
-        'typo',
-        'words',
-        'proximity',
-        'attribute',
-        'wordsPosition',
-        'exactness'
-    ]
+def test_get_ranking_rules_default(sample_indexes):
+    """Tests getting the default ranking rules"""
+    response = sample_indexes[0].get_ranking_rules()
+    assert isinstance(response, object)
+    for rule in DEFAULT_RANKING_RULES:
+        assert rule in response
 
-    def test_get_ranking_rules_default(self, sample_indexes):
-        """Tests getting the default ranking rules"""
-        response = sample_indexes[0].get_ranking_rules()
-        assert isinstance(response, object)
-        for rule in self.default_ranking_rules:
-            assert rule in response
+def test_update_ranking_rules(sample_indexes):
+    """Tests changing the ranking rules"""
+    response = sample_indexes[0].update_ranking_rules(NEW_RANKING_RULES)
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    sample_indexes[0].wait_for_pending_update(response['updateId'])
+    response = sample_indexes[0].get_ranking_rules()
+    assert isinstance(response, object)
+    for rule in NEW_RANKING_RULES:
+        assert rule in response
 
-    def test_update_ranking_rules(self, sample_indexes):
-        """Tests changing the ranking rules"""
-        response = sample_indexes[0].update_ranking_rules(self.new_ranking_rules)
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        sample_indexes[0].wait_for_pending_update(response['updateId'])
-        response = sample_indexes[0].get_ranking_rules()
-        assert isinstance(response, object)
-        for rule in self.new_ranking_rules:
-            assert rule in response
-
-    def test_reset_ranking_rules(self, sample_indexes):
-        """Tests resetting the ranking rules"""
-        response = sample_indexes[0].reset_ranking_rules()
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        sample_indexes[0].wait_for_pending_update(response['updateId'])
-        response = sample_indexes[0].get_ranking_rules()
-        for rule in self.default_ranking_rules:
-            assert rule in response
+def test_reset_ranking_rules(sample_indexes):
+    """Tests resetting the ranking rules"""
+    response = sample_indexes[0].reset_ranking_rules()
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    sample_indexes[0].wait_for_pending_update(response['updateId'])
+    response = sample_indexes[0].get_ranking_rules()
+    for rule in DEFAULT_RANKING_RULES:
+        assert rule in response

--- a/meilisearch/tests/settings/test_settings_searchable_attributes_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_searchable_attributes_meilisearch.py
@@ -2,33 +2,36 @@
 
 NEW_SEARCHABLE_ATTRIBUTES = ['something', 'random']
 
-def test_get_searchable_attributes(indexes_sample, small_movies):
+def test_get_searchable_attributes(empty_index, small_movies):
     """Tests getting the searchable attributes on an empty and populated index"""
-    response = indexes_sample[0].get_searchable_attributes()
+    index = empty_index()
+    response = index.get_searchable_attributes()
     assert isinstance(response, object)
     assert response == ['*']
-    response = indexes_sample[0].add_documents(small_movies, primary_key='id')
-    indexes_sample[0].wait_for_pending_update(response['updateId'])
-    get_attributes = indexes_sample[0].get_searchable_attributes()
+    response = index.add_documents(small_movies, primary_key='id')
+    index.wait_for_pending_update(response['updateId'])
+    get_attributes = index.get_searchable_attributes()
     assert get_attributes == ['*']
 
 
-def test_update_searchable_attributes(indexes_sample):
+def test_update_searchable_attributes(empty_index):
     """Tests updating the searchable attributes"""
-    response = indexes_sample[0].update_searchable_attributes(NEW_SEARCHABLE_ATTRIBUTES)
+    index = empty_index()
+    response = index.update_searchable_attributes(NEW_SEARCHABLE_ATTRIBUTES)
     assert isinstance(response, object)
     assert 'updateId' in response
-    indexes_sample[0].wait_for_pending_update(response['updateId'])
-    response = indexes_sample[0].get_searchable_attributes()
+    index.wait_for_pending_update(response['updateId'])
+    response = index.get_searchable_attributes()
     assert len(response) == len(NEW_SEARCHABLE_ATTRIBUTES)
     for attribute in NEW_SEARCHABLE_ATTRIBUTES:
         assert attribute in response
 
-def test_reset_searchable_attributes(indexes_sample):
+def test_reset_searchable_attributes(empty_index):
     """Tests reseting searchable attributes"""
-    response = indexes_sample[0].reset_searchable_attributes()
+    index = empty_index()
+    response = index.reset_searchable_attributes()
     assert isinstance(response, object)
     assert 'updateId' in response
-    indexes_sample[0].wait_for_pending_update(response['updateId'])
-    response = indexes_sample[0].get_searchable_attributes()
+    index.wait_for_pending_update(response['updateId'])
+    response = index.get_searchable_attributes()
     assert response == ['*']

--- a/meilisearch/tests/settings/test_settings_searchable_attributes_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_searchable_attributes_meilisearch.py
@@ -1,3 +1,4 @@
+# pylint: disable=invalid-name
 
 NEW_SEARCHABLE_ATTRIBUTES = ['something', 'random']
 

--- a/meilisearch/tests/settings/test_settings_searchable_attributes_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_searchable_attributes_meilisearch.py
@@ -1,33 +1,33 @@
 
 NEW_SEARCHABLE_ATTRIBUTES = ['something', 'random']
 
-def test_get_searchable_attributes(sample_indexes, small_movies):
+def test_get_searchable_attributes(indexes_sample, small_movies):
     """Tests getting the searchable attributes on an empty and populated index"""
-    response = sample_indexes[0].get_searchable_attributes()
+    response = indexes_sample[0].get_searchable_attributes()
     assert isinstance(response, object)
     assert response == ['*']
-    response = sample_indexes[0].add_documents(small_movies, primary_key='id')
-    sample_indexes[0].wait_for_pending_update(response['updateId'])
-    get_attributes = sample_indexes[0].get_searchable_attributes()
+    response = indexes_sample[0].add_documents(small_movies, primary_key='id')
+    indexes_sample[0].wait_for_pending_update(response['updateId'])
+    get_attributes = indexes_sample[0].get_searchable_attributes()
     assert get_attributes == ['*']
 
 
-def test_update_searchable_attributes(sample_indexes):
+def test_update_searchable_attributes(indexes_sample):
     """Tests updating the searchable attributes"""
-    response = sample_indexes[0].update_searchable_attributes(NEW_SEARCHABLE_ATTRIBUTES)
+    response = indexes_sample[0].update_searchable_attributes(NEW_SEARCHABLE_ATTRIBUTES)
     assert isinstance(response, object)
     assert 'updateId' in response
-    sample_indexes[0].wait_for_pending_update(response['updateId'])
-    response = sample_indexes[0].get_searchable_attributes()
+    indexes_sample[0].wait_for_pending_update(response['updateId'])
+    response = indexes_sample[0].get_searchable_attributes()
     assert len(response) == len(NEW_SEARCHABLE_ATTRIBUTES)
     for attribute in NEW_SEARCHABLE_ATTRIBUTES:
         assert attribute in response
 
-def test_reset_searchable_attributes(sample_indexes):
+def test_reset_searchable_attributes(indexes_sample):
     """Tests reseting searchable attributes"""
-    response = sample_indexes[0].reset_searchable_attributes()
+    response = indexes_sample[0].reset_searchable_attributes()
     assert isinstance(response, object)
     assert 'updateId' in response
-    sample_indexes[0].wait_for_pending_update(response['updateId'])
-    response = sample_indexes[0].get_searchable_attributes()
+    indexes_sample[0].wait_for_pending_update(response['updateId'])
+    response = indexes_sample[0].get_searchable_attributes()
     assert response == ['*']

--- a/meilisearch/tests/settings/test_settings_searchable_attributes_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_searchable_attributes_meilisearch.py
@@ -1,38 +1,33 @@
 
-class TestSearchableAttributes:
+NEW_SEARCHABLE_ATTRIBUTES = ['something', 'random']
 
-    """ TESTS: searchableAttributes setting """
-
-    new_searchable_attributes = ['something', 'random']
-    full_searchable_attributes = ['id', 'title', 'poster', 'overview', 'release_date']
-
-    def test_get_searchable_attributes(self, sample_indexes, small_movies):
-        """Tests getting the searchable attributes on an empty and populated index"""
-        response = sample_indexes[0].get_searchable_attributes()
-        assert isinstance(response, object)
-        assert response == ['*']
-        response = sample_indexes[0].add_documents(small_movies, primary_key='id')
-        sample_indexes[0].wait_for_pending_update(response['updateId'])
-        get_attributes = sample_indexes[0].get_searchable_attributes()
-        assert get_attributes == ['*']
+def test_get_searchable_attributes(sample_indexes, small_movies):
+    """Tests getting the searchable attributes on an empty and populated index"""
+    response = sample_indexes[0].get_searchable_attributes()
+    assert isinstance(response, object)
+    assert response == ['*']
+    response = sample_indexes[0].add_documents(small_movies, primary_key='id')
+    sample_indexes[0].wait_for_pending_update(response['updateId'])
+    get_attributes = sample_indexes[0].get_searchable_attributes()
+    assert get_attributes == ['*']
 
 
-    def test_update_searchable_attributes(self, sample_indexes):
-        """Tests updating the searchable attributes"""
-        response = sample_indexes[0].update_searchable_attributes(self.new_searchable_attributes)
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        sample_indexes[0].wait_for_pending_update(response['updateId'])
-        response = sample_indexes[0].get_searchable_attributes()
-        assert len(response) == len(self.new_searchable_attributes)
-        for attribute in self.new_searchable_attributes:
-            assert attribute in response
+def test_update_searchable_attributes(sample_indexes):
+    """Tests updating the searchable attributes"""
+    response = sample_indexes[0].update_searchable_attributes(NEW_SEARCHABLE_ATTRIBUTES)
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    sample_indexes[0].wait_for_pending_update(response['updateId'])
+    response = sample_indexes[0].get_searchable_attributes()
+    assert len(response) == len(NEW_SEARCHABLE_ATTRIBUTES)
+    for attribute in NEW_SEARCHABLE_ATTRIBUTES:
+        assert attribute in response
 
-    def test_reset_searchable_attributes(self, sample_indexes):
-        """Tests reseting searchable attributes"""
-        response = sample_indexes[0].reset_searchable_attributes()
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        sample_indexes[0].wait_for_pending_update(response['updateId'])
-        response = sample_indexes[0].get_searchable_attributes()
-        assert response == ['*']
+def test_reset_searchable_attributes(sample_indexes):
+    """Tests reseting searchable attributes"""
+    response = sample_indexes[0].reset_searchable_attributes()
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    sample_indexes[0].wait_for_pending_update(response['updateId'])
+    response = sample_indexes[0].get_searchable_attributes()
+    assert response == ['*']

--- a/meilisearch/tests/settings/test_settings_searchable_attributes_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_searchable_attributes_meilisearch.py
@@ -1,54 +1,38 @@
-import json
-import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY
 
 class TestSearchableAttributes:
 
     """ TESTS: searchableAttributes setting """
 
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    index = None
-    dataset_file = None
-    dataset_json = None
     new_searchable_attributes = ['something', 'random']
     full_searchable_attributes = ['id', 'title', 'poster', 'overview', 'release_date']
 
-    def setup_class(self):
-        self.index = self.client.create_index(uid='indexUID')
-        self.dataset_file = open('./datasets/small_movies.json', 'r')
-        self.dataset_json = json.loads(self.dataset_file.read())
-        self.dataset_file.close()
-
-    def teardown_class(self):
-        self.index.delete()
-
-    def test_get_searchable_attributes(self):
+    def test_get_searchable_attributes(self, sample_indexes, small_movies):
         """Tests getting the searchable attributes on an empty and populated index"""
-        response = self.index.get_searchable_attributes()
+        response = sample_indexes[0].get_searchable_attributes()
         assert isinstance(response, object)
         assert response == ['*']
-        response = self.index.add_documents(self.dataset_json, primary_key='id')
-        self.index.wait_for_pending_update(response['updateId'])
-        get_attributes = self.index.get_searchable_attributes()
+        response = sample_indexes[0].add_documents(small_movies, primary_key='id')
+        sample_indexes[0].wait_for_pending_update(response['updateId'])
+        get_attributes = sample_indexes[0].get_searchable_attributes()
         assert get_attributes == ['*']
 
 
-    def test_update_searchable_attributes(self):
+    def test_update_searchable_attributes(self, sample_indexes):
         """Tests updating the searchable attributes"""
-        response = self.index.update_searchable_attributes(self.new_searchable_attributes)
+        response = sample_indexes[0].update_searchable_attributes(self.new_searchable_attributes)
         assert isinstance(response, object)
         assert 'updateId' in response
-        self.index.wait_for_pending_update(response['updateId'])
-        response = self.index.get_searchable_attributes()
+        sample_indexes[0].wait_for_pending_update(response['updateId'])
+        response = sample_indexes[0].get_searchable_attributes()
         assert len(response) == len(self.new_searchable_attributes)
         for attribute in self.new_searchable_attributes:
             assert attribute in response
 
-    def test_reset_searchable_attributes(self):
+    def test_reset_searchable_attributes(self, sample_indexes):
         """Tests reseting searchable attributes"""
-        response = self.index.reset_searchable_attributes()
+        response = sample_indexes[0].reset_searchable_attributes()
         assert isinstance(response, object)
         assert 'updateId' in response
-        self.index.wait_for_pending_update(response['updateId'])
-        response = self.index.get_searchable_attributes()
+        sample_indexes[0].wait_for_pending_update(response['updateId'])
+        response = sample_indexes[0].get_searchable_attributes()
         assert response == ['*']

--- a/meilisearch/tests/settings/test_settings_stop_words_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_stop_words_meilisearch.py
@@ -1,30 +1,32 @@
 
 NEW_STOP_WORDS = ['of', 'the']
 
-def test_get_stop_words_default(indexes_sample):
+def test_get_stop_words_default(empty_index):
     """Tests call to get stop words by default"""
-    response = indexes_sample[0].get_stop_words()
+    response = empty_index().get_stop_words()
     assert isinstance(response, object)
     assert response == []
 
-def test_update_stop_words(indexes_sample):
+def test_update_stop_words(empty_index):
     """Tests call to modify stop words"""
-    response = indexes_sample[0].update_stop_words(NEW_STOP_WORDS)
+    index = empty_index()
+    response = index.update_stop_words(NEW_STOP_WORDS)
     assert isinstance(response, object)
     assert 'updateId' in response
-    update = indexes_sample[0].wait_for_pending_update(response['updateId'])
+    update = index.wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
-    response = indexes_sample[0].get_stop_words()
+    response = index.get_stop_words()
     assert isinstance(response, object)
     for stop_word in NEW_STOP_WORDS:
         assert stop_word in response
 
-def test_reset_stop_words(indexes_sample):
+def test_reset_stop_words(empty_index):
     """Tests call to reset stop words"""
-    response = indexes_sample[0].reset_stop_words()
+    index = empty_index()
+    response = index.reset_stop_words()
     assert isinstance(response, object)
     assert 'updateId' in response
-    update = indexes_sample[0].wait_for_pending_update(response['updateId'])
+    update = index.wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
-    response = indexes_sample[0].get_stop_words()
+    response = index.get_stop_words()
     assert response == []

--- a/meilisearch/tests/settings/test_settings_stop_words_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_stop_words_meilisearch.py
@@ -1,34 +1,30 @@
 
-class TestStopWords:
+NEW_STOP_WORDS = ['of', 'the']
 
-    """ TESTS: stop words setting """
+def test_get_stop_words_default(sample_indexes):
+    """Tests call to get stop words by default"""
+    response = sample_indexes[0].get_stop_words()
+    assert isinstance(response, object)
+    assert response == []
 
-    new_stop_words = ['of', 'the']
+def test_update_stop_words(sample_indexes):
+    """Tests call to modify stop words"""
+    response = sample_indexes[0].update_stop_words(NEW_STOP_WORDS)
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    update = sample_indexes[0].wait_for_pending_update(response['updateId'])
+    assert update['status'] == 'processed'
+    response = sample_indexes[0].get_stop_words()
+    assert isinstance(response, object)
+    for stop_word in NEW_STOP_WORDS:
+        assert stop_word in response
 
-    def test_get_stop_words_default(self, sample_indexes):
-        """Tests call to get stop words by default"""
-        response = sample_indexes[0].get_stop_words()
-        assert isinstance(response, object)
-        assert response == []
-
-    def test_update_stop_words(self, sample_indexes):
-        """Tests call to modify stop words"""
-        response = sample_indexes[0].update_stop_words(self.new_stop_words)
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        update = sample_indexes[0].wait_for_pending_update(response['updateId'])
-        assert update['status'] == 'processed'
-        response = sample_indexes[0].get_stop_words()
-        assert isinstance(response, object)
-        for stop_word in self.new_stop_words:
-            assert stop_word in response
-
-    def test_reset_stop_words(self, sample_indexes):
-        """Tests call to reset stop words"""
-        response = sample_indexes[0].reset_stop_words()
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        update = sample_indexes[0].wait_for_pending_update(response['updateId'])
-        assert update['status'] == 'processed'
-        response = sample_indexes[0].get_stop_words()
-        assert response == []
+def test_reset_stop_words(sample_indexes):
+    """Tests call to reset stop words"""
+    response = sample_indexes[0].reset_stop_words()
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    update = sample_indexes[0].wait_for_pending_update(response['updateId'])
+    assert update['status'] == 'processed'
+    response = sample_indexes[0].get_stop_words()
+    assert response == []

--- a/meilisearch/tests/settings/test_settings_stop_words_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_stop_words_meilisearch.py
@@ -1,44 +1,34 @@
-import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY
 
 class TestStopWords:
 
     """ TESTS: stop words setting """
 
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    index = None
     new_stop_words = ['of', 'the']
 
-    def setup_class(self):
-        self.index = self.client.create_index(uid='indexUID')
-
-    def teardown_class(self):
-        self.index.delete()
-
-    def test_get_stop_words_default(self):
+    def test_get_stop_words_default(self, sample_indexes):
         """Tests call to get stop words by default"""
-        response = self.index.get_stop_words()
+        response = sample_indexes[0].get_stop_words()
         assert isinstance(response, object)
         assert response == []
 
-    def test_update_stop_words(self):
+    def test_update_stop_words(self, sample_indexes):
         """Tests call to modify stop words"""
-        response = self.index.update_stop_words(self.new_stop_words)
+        response = sample_indexes[0].update_stop_words(self.new_stop_words)
         assert isinstance(response, object)
         assert 'updateId' in response
-        update = self.index.wait_for_pending_update(response['updateId'])
+        update = sample_indexes[0].wait_for_pending_update(response['updateId'])
         assert update['status'] == 'processed'
-        response = self.index.get_stop_words()
+        response = sample_indexes[0].get_stop_words()
         assert isinstance(response, object)
         for stop_word in self.new_stop_words:
             assert stop_word in response
 
-    def test_reset_stop_words(self):
+    def test_reset_stop_words(self, sample_indexes):
         """Tests call to reset stop words"""
-        response = self.index.reset_stop_words()
+        response = sample_indexes[0].reset_stop_words()
         assert isinstance(response, object)
         assert 'updateId' in response
-        update = self.index.wait_for_pending_update(response['updateId'])
+        update = sample_indexes[0].wait_for_pending_update(response['updateId'])
         assert update['status'] == 'processed'
-        response = self.index.get_stop_words()
+        response = sample_indexes[0].get_stop_words()
         assert response == []

--- a/meilisearch/tests/settings/test_settings_stop_words_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_stop_words_meilisearch.py
@@ -1,30 +1,30 @@
 
 NEW_STOP_WORDS = ['of', 'the']
 
-def test_get_stop_words_default(sample_indexes):
+def test_get_stop_words_default(indexes_sample):
     """Tests call to get stop words by default"""
-    response = sample_indexes[0].get_stop_words()
+    response = indexes_sample[0].get_stop_words()
     assert isinstance(response, object)
     assert response == []
 
-def test_update_stop_words(sample_indexes):
+def test_update_stop_words(indexes_sample):
     """Tests call to modify stop words"""
-    response = sample_indexes[0].update_stop_words(NEW_STOP_WORDS)
+    response = indexes_sample[0].update_stop_words(NEW_STOP_WORDS)
     assert isinstance(response, object)
     assert 'updateId' in response
-    update = sample_indexes[0].wait_for_pending_update(response['updateId'])
+    update = indexes_sample[0].wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
-    response = sample_indexes[0].get_stop_words()
+    response = indexes_sample[0].get_stop_words()
     assert isinstance(response, object)
     for stop_word in NEW_STOP_WORDS:
         assert stop_word in response
 
-def test_reset_stop_words(sample_indexes):
+def test_reset_stop_words(indexes_sample):
     """Tests call to reset stop words"""
-    response = sample_indexes[0].reset_stop_words()
+    response = indexes_sample[0].reset_stop_words()
     assert isinstance(response, object)
     assert 'updateId' in response
-    update = sample_indexes[0].wait_for_pending_update(response['updateId'])
+    update = indexes_sample[0].wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
-    response = sample_indexes[0].get_stop_words()
+    response = indexes_sample[0].get_stop_words()
     assert response == []

--- a/meilisearch/tests/settings/test_settings_synonyms_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_synonyms_meilisearch.py
@@ -3,30 +3,32 @@ NEW_SYNONYMS = {
     'hp': ['harry potter']
 }
 
-def test_get_synonyms_default(indexes_sample):
+def test_get_synonyms_default(empty_index):
     """Tests getting default synonyms"""
-    response = indexes_sample[0].get_synonyms()
+    response = empty_index().get_synonyms()
     assert isinstance(response, object)
     assert response == {}
 
-def test_update_synonyms(indexes_sample):
+def test_update_synonyms(empty_index):
     """Tests updating synonyms"""
-    response = indexes_sample[0].update_synonyms(NEW_SYNONYMS)
+    index = empty_index()
+    response = index.update_synonyms(NEW_SYNONYMS)
     assert isinstance(response, object)
     assert 'updateId' in response
-    update = indexes_sample[0].wait_for_pending_update(response['updateId'])
+    update = index.wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
-    response = indexes_sample[0].get_synonyms()
+    response = index.get_synonyms()
     assert isinstance(response, object)
     for synonym in NEW_SYNONYMS:
         assert synonym in response
 
-def test_reset_synonyms(indexes_sample):
+def test_reset_synonyms(empty_index):
     """Tests resetting synonyms"""
-    response = indexes_sample[0].reset_synonyms()
+    index = empty_index()
+    response = index.reset_synonyms()
     assert isinstance(response, object)
     assert 'updateId' in response
-    update = indexes_sample[0].wait_for_pending_update(response['updateId'])
+    update = index.wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
-    response = indexes_sample[0].get_synonyms()
+    response = index.get_synonyms()
     assert response == {}

--- a/meilisearch/tests/settings/test_settings_synonyms_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_synonyms_meilisearch.py
@@ -1,36 +1,32 @@
 
-class TestSynonyms:
+NEW_SYNONYMS = {
+    'hp': ['harry potter']
+}
 
-    """ TESTS: synonyms setting """
+def test_get_synonyms_default(sample_indexes):
+    """Tests getting default synonyms"""
+    response = sample_indexes[0].get_synonyms()
+    assert isinstance(response, object)
+    assert response == {}
 
-    new_synonyms = {
-        'hp': ['harry potter']
-    }
+def test_update_synonyms(sample_indexes):
+    """Tests updating synonyms"""
+    response = sample_indexes[0].update_synonyms(NEW_SYNONYMS)
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    update = sample_indexes[0].wait_for_pending_update(response['updateId'])
+    assert update['status'] == 'processed'
+    response = sample_indexes[0].get_synonyms()
+    assert isinstance(response, object)
+    for synonym in NEW_SYNONYMS:
+        assert synonym in response
 
-    def test_get_synonyms_default(self, sample_indexes):
-        """Tests getting default synonyms"""
-        response = sample_indexes[0].get_synonyms()
-        assert isinstance(response, object)
-        assert response == {}
-
-    def test_update_synonyms(self, sample_indexes):
-        """Tests updating synonyms"""
-        response = sample_indexes[0].update_synonyms(self.new_synonyms)
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        update = sample_indexes[0].wait_for_pending_update(response['updateId'])
-        assert update['status'] == 'processed'
-        response = sample_indexes[0].get_synonyms()
-        assert isinstance(response, object)
-        for synonym in self.new_synonyms:
-            assert synonym in response
-
-    def test_reset_synonyms(self, sample_indexes):
-        """Tests resetting synonyms"""
-        response = sample_indexes[0].reset_synonyms()
-        assert isinstance(response, object)
-        assert 'updateId' in response
-        update = sample_indexes[0].wait_for_pending_update(response['updateId'])
-        assert update['status'] == 'processed'
-        response = sample_indexes[0].get_synonyms()
-        assert response == {}
+def test_reset_synonyms(sample_indexes):
+    """Tests resetting synonyms"""
+    response = sample_indexes[0].reset_synonyms()
+    assert isinstance(response, object)
+    assert 'updateId' in response
+    update = sample_indexes[0].wait_for_pending_update(response['updateId'])
+    assert update['status'] == 'processed'
+    response = sample_indexes[0].get_synonyms()
+    assert response == {}

--- a/meilisearch/tests/settings/test_settings_synonyms_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_synonyms_meilisearch.py
@@ -3,30 +3,30 @@ NEW_SYNONYMS = {
     'hp': ['harry potter']
 }
 
-def test_get_synonyms_default(sample_indexes):
+def test_get_synonyms_default(indexes_sample):
     """Tests getting default synonyms"""
-    response = sample_indexes[0].get_synonyms()
+    response = indexes_sample[0].get_synonyms()
     assert isinstance(response, object)
     assert response == {}
 
-def test_update_synonyms(sample_indexes):
+def test_update_synonyms(indexes_sample):
     """Tests updating synonyms"""
-    response = sample_indexes[0].update_synonyms(NEW_SYNONYMS)
+    response = indexes_sample[0].update_synonyms(NEW_SYNONYMS)
     assert isinstance(response, object)
     assert 'updateId' in response
-    update = sample_indexes[0].wait_for_pending_update(response['updateId'])
+    update = indexes_sample[0].wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
-    response = sample_indexes[0].get_synonyms()
+    response = indexes_sample[0].get_synonyms()
     assert isinstance(response, object)
     for synonym in NEW_SYNONYMS:
         assert synonym in response
 
-def test_reset_synonyms(sample_indexes):
+def test_reset_synonyms(indexes_sample):
     """Tests resetting synonyms"""
-    response = sample_indexes[0].reset_synonyms()
+    response = indexes_sample[0].reset_synonyms()
     assert isinstance(response, object)
     assert 'updateId' in response
-    update = sample_indexes[0].wait_for_pending_update(response['updateId'])
+    update = indexes_sample[0].wait_for_pending_update(response['updateId'])
     assert update['status'] == 'processed'
-    response = sample_indexes[0].get_synonyms()
+    response = indexes_sample[0].get_synonyms()
     assert response == {}

--- a/meilisearch/tests/settings/test_settings_synonyms_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_synonyms_meilisearch.py
@@ -1,46 +1,36 @@
-import meilisearch
-from meilisearch.tests import BASE_URL, MASTER_KEY
 
 class TestSynonyms:
 
     """ TESTS: synonyms setting """
 
-    client = meilisearch.Client(BASE_URL, MASTER_KEY)
-    index = None
     new_synonyms = {
         'hp': ['harry potter']
     }
 
-    def setup_class(self):
-        self.index = self.client.create_index(uid='indexUID')
-
-    def teardown_class(self):
-        self.index.delete()
-
-    def test_get_synonyms_default(self):
+    def test_get_synonyms_default(self, sample_indexes):
         """Tests getting default synonyms"""
-        response = self.index.get_synonyms()
+        response = sample_indexes[0].get_synonyms()
         assert isinstance(response, object)
         assert response == {}
 
-    def test_update_synonyms(self):
+    def test_update_synonyms(self, sample_indexes):
         """Tests updating synonyms"""
-        response = self.index.update_synonyms(self.new_synonyms)
+        response = sample_indexes[0].update_synonyms(self.new_synonyms)
         assert isinstance(response, object)
         assert 'updateId' in response
-        update = self.index.wait_for_pending_update(response['updateId'])
+        update = sample_indexes[0].wait_for_pending_update(response['updateId'])
         assert update['status'] == 'processed'
-        response = self.index.get_synonyms()
+        response = sample_indexes[0].get_synonyms()
         assert isinstance(response, object)
         for synonym in self.new_synonyms:
             assert synonym in response
 
-    def test_reset_synonyms(self):
+    def test_reset_synonyms(self, sample_indexes):
         """Tests resetting synonyms"""
-        response = self.index.reset_synonyms()
+        response = sample_indexes[0].reset_synonyms()
         assert isinstance(response, object)
         assert 'updateId' in response
-        update = self.index.wait_for_pending_update(response['updateId'])
+        update = sample_indexes[0].wait_for_pending_update(response['updateId'])
         assert update['status'] == 'processed'
-        response = self.index.get_synonyms()
+        response = sample_indexes[0].get_synonyms()
         assert response == {}


### PR DESCRIPTION
fixes #170

Tests functionally should be testing the exact same thing as before, main change is side effects of previous tests and setup/teardown methods were moved to fixtures in new conftest.py file, there are some extra changes that came because of this(pylint mainly not liking method tests anymore because they can also be simple functions etc.)

Would appreciate any comments/suggestions. :)


Changes:
- move index creation, cleanup of test run, reading small movies and adding them to index to fixtures
- add an extra fixture to cleanup data after each tests (just to be safe for tests that will come later on, kind of meta test I guess?)
- remove setup and teardown methods, use the new fixtures where ever they were needed
- now that having tests do not need a class, pylint was getting sad, converted many tests to be simple pytest function tests rather than method test.
    - this made pylint still sad because function names for tests are > 30 chars, updated that to 70 chars
    - constants that were class attributes are causing pylint errors, made them SCREAMING_SNAKE_CASE 
- created tests/common.py for common constant values(e.g. index configs, sample index names etc.)
- made meili client a fixture scoped to test session, one client creation should be enough and test can easily access it by using the `client` fixture.

TODO:
- [x] Add detailed PR description about the changes
- [x] use `@pytest.mark.usefixtures` for unused fixtures for happier linter (https://github.com/PyCQA/pylint/issues/1057#issuecomment-237155725)
- [x] try moving tests/__init__.py code to tests/common.py
- [x] Check leftover tests? (even if they are passing without any change try to unify the structure of tests)