### PR TITLE
Add missing code samples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -360,3 +360,18 @@ post_dump_1: |-
   client.create_dump()
 get_dump_status_1: |-
   client.get_dump_status('20201101-110357260')
+get_attributes_for_faceting_1: |-
+  client.index('movies').get_attributes_for_faceting()
+update_attributes_for_faceting_1: |-
+  client.index('movies').update_attributes_for_faceting([
+    'genres',
+    'director'
+  ])
+reset_attributes_for_faceting_1: |-
+  client.index('movies').reset_attributes_for_faceting()
+add_movies_json_1: |-
+  import json
+
+  json_file = open('movies.json')
+  movies = json.load(json_file)
+  index.add_documents(movies)


### PR DESCRIPTION
Closes #140 

The PR adds the following samples to `.code-samples.meilisearch.yaml`.
```
get_attributes_for_faceting_1
update_attributes_for_faceting_1
reset_attributes_for_faceting_1
add_movies_json_1
```

Sample for `settings_guide_synonyms_1` already exists.