### PR TITLE
Fix MeiliSearchTimeoutError typo

### DIFF
--- a/meilisearch/errors.py
+++ b/meilisearch/errors.py
@@ -32,8 +32,8 @@ class MeiliSearchCommunicationError(MeiliSearchError):
     def __str__(self):
         return f'MeiliSearchCommunicationError, {self.message}'
 
-class MeiliSearchTimeOutError(MeiliSearchError):
+class MeiliSearchTimeoutError(MeiliSearchError):
     """Error when MeiliSearch operation takes longer than expected"""
 
     def __str__(self):
-        return f'MeiliSearchTimeOutError, {self.message}'
+        return f'MeiliSearchTimeoutError, {self.message}'

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -2,7 +2,7 @@ import urllib
 from datetime import datetime
 from time import sleep
 from meilisearch._httprequests import HttpRequests
-from meilisearch.errors import MeiliSearchTimeOutError
+from meilisearch.errors import MeiliSearchTimeoutError
 
 # pylint: disable=too-many-public-methods
 class Index():
@@ -186,7 +186,7 @@ class Index():
         update_id: int
             identifier of the update to retrieve
         timeout_in_ms (optional): int
-            time the method should wait before raising a MeiliSearchTimeOutError
+            time the method should wait before raising a MeiliSearchTimeoutError
         interval_in_ms (optional): int
             time interval the method should wait (sleep) between requests
 
@@ -197,7 +197,7 @@ class Index():
 
         Raises
         ------
-        MeiliSearchTimeOutError
+        MeiliSearchTimeoutError
             An error containing details about why MeiliSearch can't process your request. MeiliSearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
         start_time = datetime.now()
@@ -209,7 +209,7 @@ class Index():
             sleep(interval_in_ms / 1000)
             time_delta = datetime.now() - start_time
             elapsed_time = time_delta.seconds * 1000 + time_delta.microseconds / 1000
-        raise MeiliSearchTimeOutError(f'timeout of ${timeout_in_ms}ms has exceeded on process ${update_id} when waiting for pending update to resolve.')
+        raise MeiliSearchTimeoutError(f'timeout of ${timeout_in_ms}ms has exceeded on process ${update_id} when waiting for pending update to resolve.')
 
     def get_stats(self):
         """Get stats of the index.

--- a/meilisearch/tests/index/test_index_wait_for_pending_update.py
+++ b/meilisearch/tests/index/test_index_wait_for_pending_update.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime
 import pytest
-from meilisearch.errors import MeiliSearchTimeOutError
+from meilisearch.errors import MeiliSearchTimeoutError
 
 def test_wait_for_pending_update_default(index_with_documents):
     """Tests waiting for an update with default parameters."""
@@ -16,7 +16,7 @@ def test_wait_for_pending_update_default(index_with_documents):
 
 def test_wait_for_pending_update_timeout(index_with_documents):
     """Tests timeout risen by waiting for an update."""
-    with pytest.raises(MeiliSearchTimeOutError):
+    with pytest.raises(MeiliSearchTimeoutError):
         index_with_documents().wait_for_pending_update(2, timeout_in_ms=0)
 
 def test_wait_for_pending_update_interval_custom(index_with_documents, small_movies):


### PR DESCRIPTION
Changing `MeiliSearchTimeOutError` => `MeiliSearchTimeoutError` (without capital o)

Introduced by: https://github.com/meilisearch/meilisearch-python/pull/187

Using pythons syntax of [TimeoutError](https://docs.python.org/3/library/exceptions.html#TimeoutError)