### PR TITLE
Removing repeated tests

### DIFF
--- a/meilisearch/tests/client/test_client.py
+++ b/meilisearch/tests/client/test_client.py
@@ -1,6 +1,5 @@
 # pylint: disable=invalid-name
 
-import pytest
 import meilisearch
 from meilisearch.tests import BASE_URL, MASTER_KEY
 
@@ -10,15 +9,3 @@ def test_get_client():
     assert client.config
     response = client.health()
     assert response.status_code >= 200 and response.status_code < 400
-
-def test_get_client_without_master_key():
-    """Tests getting a client instance without master key."""
-    client = meilisearch.Client(BASE_URL)
-    with pytest.raises(Exception):
-        client.get_version()
-
-def test_get_client_with_wrong_master_key():
-    """Tests getting a client instance with an invalid master key."""
-    client = meilisearch.Client(BASE_URL, MASTER_KEY + "123")
-    with pytest.raises(Exception):
-        client.get_version()


### PR DESCRIPTION
These same tests are run in the [errors tests](https://github.com/meilisearch/meilisearch-python/blob/937b75f282111ecf13dd824119ff2d02650eb92e/meilisearch/tests/errors/test_api_error_meilisearch.py), but there they check for the specific error that should raise instead of a generic error so I removed the tests here.