### PR TITLE
Added an option to specify a timeout duration

### DIFF
--- a/meilisearch/_httprequests.py
+++ b/meilisearch/_httprequests.py
@@ -17,9 +17,18 @@ class HttpRequests:
         try:
             request_path = self.config.url + '/' + path
             if body is None:
-                request = http_method(request_path, headers=self.headers)
+                request = http_method(
+                    request_path,
+                    timeout=self.config.timeout,
+                    headers=self.headers,
+                )
             else:
-                request = http_method(request_path, headers=self.headers, json=body)
+                request = http_method(
+                    request_path,
+                    timeout=self.config.timeout,
+                    headers=self.headers,
+                    json=body,
+                )
             return self.__validate(request)
         except requests.exceptions.ConnectionError as err:
             raise MeiliSearchCommunicationError(err) from err

--- a/meilisearch/_httprequests.py
+++ b/meilisearch/_httprequests.py
@@ -1,5 +1,9 @@
 import requests
-from meilisearch.errors import MeiliSearchApiError, MeiliSearchCommunicationError
+from meilisearch.errors import (
+    MeiliSearchApiError,
+    MeiliSearchCommunicationError,
+    MeiliSearchTimeoutError,
+)
 
 class HttpRequests:
 
@@ -30,6 +34,9 @@ class HttpRequests:
                     json=body,
                 )
             return self.__validate(request)
+
+        except requests.exceptions.Timeout as err:
+            raise MeiliSearchTimeoutError(err) from err
         except requests.exceptions.ConnectionError as err:
             raise MeiliSearchCommunicationError(err) from err
 

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -14,7 +14,7 @@ class Client():
     config = None
     http = None
 
-    def __init__(self, url, apiKey=None):
+    def __init__(self, url, apiKey=None, timeout=10):
         """
         Parameters
         ----------
@@ -23,7 +23,8 @@ class Client():
         apiKey : str
             The optional API key for MeiliSearch
         """
-        self.config = Config(url, apiKey)
+        self.config = Config(url, apiKey, timeout=timeout)
+
         self.http = HttpRequests(self.config)
 
     def create_index(self, uid, options=None):

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -14,7 +14,7 @@ class Client():
     config = None
     http = None
 
-    def __init__(self, url, apiKey=None, timeout=10):
+    def __init__(self, url, apiKey=None, timeout=None):
         """
         Parameters
         ----------

--- a/meilisearch/config.py
+++ b/meilisearch/config.py
@@ -23,7 +23,7 @@ class Config:
         attributes_for_faceting = 'attributes-for-faceting'
         dumps = 'dumps'
 
-    def __init__(self, url, api_key=None):
+    def __init__(self, url, api_key=None, timeout=10):
         """
         Parameters
         ----------
@@ -35,4 +35,5 @@ class Config:
 
         self.url = url
         self.api_key = api_key
+        self.timeout = timeout
         self.paths = self.Paths()

--- a/meilisearch/config.py
+++ b/meilisearch/config.py
@@ -23,7 +23,7 @@ class Config:
         attributes_for_faceting = 'attributes-for-faceting'
         dumps = 'dumps'
 
-    def __init__(self, url, api_key=None, timeout=10):
+    def __init__(self, url, api_key=None, timeout=None):
         """
         Parameters
         ----------

--- a/meilisearch/tests/client/test_client.py
+++ b/meilisearch/tests/client/test_client.py
@@ -1,6 +1,9 @@
 # pylint: disable=invalid-name
 
+import pytest
+
 import meilisearch
+from meilisearch.errors import MeiliSearchTimeoutError
 from meilisearch.tests import BASE_URL, MASTER_KEY
 
 def test_get_client():
@@ -9,3 +12,22 @@ def test_get_client():
     assert client.config
     response = client.health()
     assert response.status_code >= 200 and response.status_code < 400
+
+
+def test_client_timeout_set():
+    client = meilisearch.Client(BASE_URL, MASTER_KEY, timeout=5)
+    response = client.health()
+    assert response.status_code >= 200 and response.status_code < 400
+
+
+def test_client_timeout_not_set():
+    client = meilisearch.Client(BASE_URL, MASTER_KEY)
+    response = client.health()
+    assert response.status_code >= 200 and response.status_code < 400
+
+
+def test_client_timeout_error():
+    client = meilisearch.Client(BASE_URL, MASTER_KEY, timeout=1e-10)
+
+    with pytest.raises(MeiliSearchTimeoutError):
+        client.health()

--- a/meilisearch/tests/client/test_client.py
+++ b/meilisearch/tests/client/test_client.py
@@ -21,7 +21,7 @@ def test_client_timeout_set():
 
 
 def test_client_timeout_not_set():
-    default_timeout = 10
+    default_timeout = None
     client = meilisearch.Client(BASE_URL, MASTER_KEY)
     response = client.health()
     assert client.config.timeout == default_timeout

--- a/meilisearch/tests/client/test_client.py
+++ b/meilisearch/tests/client/test_client.py
@@ -27,7 +27,7 @@ def test_client_timeout_not_set():
 
 
 def test_client_timeout_error():
-    client = meilisearch.Client(BASE_URL, MASTER_KEY, timeout=1e-10)
+    client = meilisearch.Client("http://wrongurl:1234", MASTER_KEY, timeout=1)
 
     with pytest.raises(MeiliSearchTimeoutError):
         client.health()

--- a/meilisearch/tests/client/test_client.py
+++ b/meilisearch/tests/client/test_client.py
@@ -1,10 +1,8 @@
 # pylint: disable=invalid-name
 
-import pytest
-
 import meilisearch
-from meilisearch.errors import MeiliSearchTimeoutError
 from meilisearch.tests import BASE_URL, MASTER_KEY
+
 
 def test_get_client():
     """Tests getting a client instance."""
@@ -15,19 +13,16 @@ def test_get_client():
 
 
 def test_client_timeout_set():
-    client = meilisearch.Client(BASE_URL, MASTER_KEY, timeout=5)
+    timeout = 5
+    client = meilisearch.Client(BASE_URL, MASTER_KEY, timeout=timeout)
     response = client.health()
+    assert client.config.timeout == timeout
     assert response.status_code >= 200 and response.status_code < 400
 
 
 def test_client_timeout_not_set():
+    default_timeout = 10
     client = meilisearch.Client(BASE_URL, MASTER_KEY)
     response = client.health()
+    assert client.config.timeout == default_timeout
     assert response.status_code >= 200 and response.status_code < 400
-
-
-def test_client_timeout_error():
-    client = meilisearch.Client("http://wrongurl:1234", MASTER_KEY, timeout=1)
-
-    with pytest.raises(MeiliSearchTimeoutError):
-        client.health()

--- a/meilisearch/tests/errors/test_communication_error_meilisearch.py
+++ b/meilisearch/tests/errors/test_communication_error_meilisearch.py
@@ -7,6 +7,6 @@ from meilisearch.tests import MASTER_KEY
 
 
 def test_meilisearch_communication_error_host():
-    client = meilisearch.Client("http://wrongurl:1234", MASTER_KEY)
+    client = meilisearch.Client("http://wrongurl:1234", MASTER_KEY, timeout=1)
     with pytest.raises(MeiliSearchCommunicationError):
         client.create_index("some_index")

--- a/meilisearch/tests/errors/test_communication_error_meilisearch.py
+++ b/meilisearch/tests/errors/test_communication_error_meilisearch.py
@@ -11,6 +11,6 @@ from meilisearch.tests import MASTER_KEY
 @patch("requests.post")
 def test_meilisearch_communication_error_host(mock_post):
     mock_post.side_effect = requests.exceptions.ConnectionError()
-    client = meilisearch.Client("http://wrongurl:1234", MASTER_KEY, timeout=None)
+    client = meilisearch.Client("http://wrongurl:1234", MASTER_KEY)
     with pytest.raises(MeiliSearchCommunicationError):
         client.create_index("some_index")

--- a/meilisearch/tests/errors/test_communication_error_meilisearch.py
+++ b/meilisearch/tests/errors/test_communication_error_meilisearch.py
@@ -1,12 +1,16 @@
 # pylint: disable=invalid-name
 
+from unittest.mock import patch
 import pytest
+import requests
 import meilisearch
 from meilisearch.errors import MeiliSearchCommunicationError
 from meilisearch.tests import MASTER_KEY
 
 
-def test_meilisearch_communication_error_host():
-    client = meilisearch.Client("http://wrongurl:1234", MASTER_KEY, timeout=1)
+@patch("requests.post")
+def test_meilisearch_communication_error_host(mock_post):
+    mock_post.side_effect = requests.exceptions.ConnectionError()
+    client = meilisearch.Client("http://wrongurl:1234", MASTER_KEY, timeout=None)
     with pytest.raises(MeiliSearchCommunicationError):
         client.create_index("some_index")

--- a/meilisearch/tests/errors/test_timeout_error_meilisearch.py
+++ b/meilisearch/tests/errors/test_timeout_error_meilisearch.py
@@ -21,13 +21,3 @@ def test_client_timeout_set():
         client.health()
 
     assert client.config.timeout == timeout
-
-
-def test_client_timeout_not_set():
-    timeout = 10
-    client = meilisearch.Client("http://wrongurl:1234", MASTER_KEY)
-
-    with pytest.raises(Exception):
-        client.health()
-
-    assert client.config.timeout == timeout

--- a/meilisearch/tests/errors/test_timeout_error_meilisearch.py
+++ b/meilisearch/tests/errors/test_timeout_error_meilisearch.py
@@ -1,0 +1,33 @@
+import pytest
+import meilisearch
+from meilisearch.errors import MeiliSearchTimeoutError
+from meilisearch.tests import BASE_URL, MASTER_KEY
+
+
+@pytest.mark.usefixtures("indexes_sample")
+def test_client_timeout_error(small_movies):
+    client = meilisearch.Client(BASE_URL, MASTER_KEY, timeout=1e-99)
+
+    with pytest.raises(MeiliSearchTimeoutError):
+        index = client.index("indexUID")
+        index.add_documents(small_movies)
+
+
+def test_client_timeout_set():
+    timeout = 1
+    client = meilisearch.Client("http://wrongurl:1234", MASTER_KEY, timeout=timeout)
+
+    with pytest.raises(Exception):
+        client.health()
+
+    assert client.config.timeout == timeout
+
+
+def test_client_timeout_not_set():
+    timeout = 10
+    client = meilisearch.Client("http://wrongurl:1234", MASTER_KEY)
+
+    with pytest.raises(Exception):
+        client.health()
+
+    assert client.config.timeout == timeout


### PR DESCRIPTION
Closes #231

I did not implement this with the Session as suggested in the issue simply because in the requests documentation there doesn't seem to be a way to set a default timeout for the session. It is possible with httpx to do this so maybe I'm missing something in requests. If anyone knows how and would rather use a session I can update it.

As an added bonus this does speed up the tests significantly be setting a timeout of 1 second on the communication error test.