### PR TITLE
Removing dead code

### DIFF
--- a/meilisearch/_httprequests.py
+++ b/meilisearch/_httprequests.py
@@ -7,10 +7,6 @@ from meilisearch.errors import (
 )
 
 class HttpRequests:
-
-    config = None
-    headers = {}
-
     def __init__(self, config):
         self.config = config
         self.headers = {

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -11,9 +11,6 @@ class Client():
     MeiliSearch and its permissions.
     """
 
-    config = None
-    http = None
-
     def __init__(self, url, apiKey=None, timeout=None):
         """
         Parameters

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -13,11 +13,6 @@ class Index():
     https://docs.meilisearch.com/reference/api/indexes.html
     """
 
-    config = None
-    http = None
-    uid = None
-    primary_key = None
-
     def __init__(self, config, uid, primary_key=None, created_at=None, updated_at=None):
         """
         Parameters


### PR DESCRIPTION
Class variables are being created, but they are always immediately set to something new in the instance variables so the original class variable values are never used. Further, if they were used they would raise errors in many cases since they are initialized to `None`, or an empty dict in one case, but are then treated as if they will never be `None` later in the code.

Since the original class variable values are never used I removed them.