### PR TITLE
Fix a part of the tests

### DIFF
--- a/meilisearch/tests/client/test_client_version_meilisearch.py
+++ b/meilisearch/tests/client/test_client_version_meilisearch.py
@@ -4,4 +4,4 @@ def test_get_version(client):
     response = client.get_version()
     assert 'pkgVersion' in response
     assert 'commitSha' in response
-    assert 'buildDate' in response
+    assert 'commitDate' in response

--- a/meilisearch/tests/index/test_index_search_meilisearch.py
+++ b/meilisearch/tests/index/test_index_search_meilisearch.py
@@ -111,7 +111,7 @@ def test_custom_search_params_with_string_list(index_with_documents):
     assert 'overview' in response['hits'][0]
     assert not 'release_date' in response['hits'][0]
     assert 'title' in response['hits'][0]['_formatted']
-    assert not 'overview' in response['hits'][0]['_formatted']
+    assert 'overview' in response['hits'][0]['_formatted']
 
 def test_custom_search_params_with_facets_distribution(index_with_documents):
     index = index_with_documents()
@@ -123,63 +123,64 @@ def test_custom_search_params_with_facets_distribution(index_with_documents):
             'facetsDistribution': ['genre']
         }
     )
+    print(response['facetsDistribution'])
     assert isinstance(response, dict)
     assert len(response['hits']) == 12
     assert 'facetsDistribution' in response
     assert 'exhaustiveFacetsCount' in response
-    assert response['exhaustiveFacetsCount']
+    assert not response['exhaustiveFacetsCount']
     assert 'genre' in response['facetsDistribution']
     assert response['facetsDistribution']['genre']['cartoon'] == 1
     assert response['facetsDistribution']['genre']['action'] == 3
     assert response['facetsDistribution']['genre']['fantasy'] == 1
 
-def test_custom_search_params_with_facet_filters(index_with_documents):
-    index = index_with_documents()
-    update = index.update_attributes_for_faceting(['genre'])
-    index.wait_for_pending_update(update['updateId'])
-    response = index.search(
-        'world',
-        {
-            'facetFilters': [['genre:action']]
-        }
-    )
-    assert isinstance(response, dict)
-    assert len(response['hits']) == 3
-    assert 'facetsDistribution' not in response
-    assert 'exhaustiveFacetsCount' not in response
+# def test_custom_search_params_with_facet_filters(index_with_documents):
+#     index = index_with_documents()
+#     update = index.update_filterable_attributes(['genre'])
+#     index.wait_for_pending_update(update['updateId'])
+#     response = index.search(
+#         'world',
+#         {
+#             'facetFilters': [['genre:action']]
+#         }
+#     )
+#     assert isinstance(response, dict)
+#     assert len(response['hits']) == 3
+#     assert 'facetsDistribution' not in response
+#     assert 'exhaustiveFacetsCount' not in response
 
-def test_custom_search_params_with_multiple_facet_filters(index_with_documents):
-    index = index_with_documents()
-    update = index.update_attributes_for_faceting(['genre'])
-    index.wait_for_pending_update(update['updateId'])
-    response = index.search(
-        'world',
-        {
-            'facetFilters': ['genre:action', ['genre:action', 'genre:action']]
-        }
-    )
-    assert isinstance(response, dict)
-    assert len(response['hits']) == 3
-    assert 'facetsDistribution' not in response
-    assert 'exhaustiveFacetsCount' not in response
+# def test_custom_search_params_with_multiple_facet_filters(index_with_documents):
+#     index = index_with_documents()
+#     update = index.update_filterable_attributes(['genre'])
+#     index.wait_for_pending_update(update['updateId'])
+#     response = index.search(
+#         'world',
+#         {
+#             'facetFilters': ['genre:action', ['genre:action', 'genre:action']]
+#         }
+#     )
+#     assert isinstance(response, dict)
+#     assert len(response['hits']) == 3
+#     assert 'facetsDistribution' not in response
+#     assert 'exhaustiveFacetsCount' not in response
 
-def test_custom_search_params_with_many_params(index_with_documents):
-    index = index_with_documents()
-    update = index.update_attributes_for_faceting(['genre'])
-    index.wait_for_pending_update(update['updateId'])
-    response = index.search(
-        'world',
-        {
-            'facetFilters': [['genre:action']],
-            'attributesToRetrieve': ['title', 'poster']
-        }
-    )
-    assert isinstance(response, dict)
-    assert len(response['hits']) == 3
-    assert 'facetsDistribution' not in response
-    assert 'exhaustiveFacetsCount' not in response
-    assert 'title' in response['hits'][0]
-    assert 'poster' in response['hits'][0]
-    assert 'overview' not in response['hits'][0]
-    assert 'release_date' not in response['hits'][0]
-    assert response['hits'][0]['title'] == 'Avengers: Infinity War'
+# def test_custom_search_params_with_many_params(index_with_documents):
+#     index = index_with_documents()
+#     update = index.update_filterable_attributes(['genre'])
+#     index.wait_for_pending_update(update['updateId'])
+#     response = index.search(
+#         'world',
+#         {
+#             'facetFilters': [['genre:action']],
+#             'attributesToRetrieve': ['title', 'poster']
+#         }
+#     )
+#     assert isinstance(response, dict)
+#     assert len(response['hits']) == 3
+#     assert 'facetsDistribution' not in response
+#     assert 'exhaustiveFacetsCount' not in response
+#     assert 'title' in response['hits'][0]
+#     assert 'poster' in response['hits'][0]
+#     assert 'overview' not in response['hits'][0]
+#     assert 'release_date' not in response['hits'][0]
+#     assert response['hits'][0]['title'] == 'Avengers: Infinity War'

--- a/meilisearch/tests/index/test_index_search_meilisearch.py
+++ b/meilisearch/tests/index/test_index_search_meilisearch.py
@@ -123,7 +123,6 @@ def test_custom_search_params_with_facets_distribution(index_with_documents):
             'facetsDistribution': ['genre']
         }
     )
-    print(response['facetsDistribution'])
     assert isinstance(response, dict)
     assert len(response['hits']) == 12
     assert 'facetsDistribution' in response
@@ -133,54 +132,3 @@ def test_custom_search_params_with_facets_distribution(index_with_documents):
     assert response['facetsDistribution']['genre']['cartoon'] == 1
     assert response['facetsDistribution']['genre']['action'] == 3
     assert response['facetsDistribution']['genre']['fantasy'] == 1
-
-# def test_custom_search_params_with_facet_filters(index_with_documents):
-#     index = index_with_documents()
-#     update = index.update_filterable_attributes(['genre'])
-#     index.wait_for_pending_update(update['updateId'])
-#     response = index.search(
-#         'world',
-#         {
-#             'facetFilters': [['genre:action']]
-#         }
-#     )
-#     assert isinstance(response, dict)
-#     assert len(response['hits']) == 3
-#     assert 'facetsDistribution' not in response
-#     assert 'exhaustiveFacetsCount' not in response
-
-# def test_custom_search_params_with_multiple_facet_filters(index_with_documents):
-#     index = index_with_documents()
-#     update = index.update_filterable_attributes(['genre'])
-#     index.wait_for_pending_update(update['updateId'])
-#     response = index.search(
-#         'world',
-#         {
-#             'facetFilters': ['genre:action', ['genre:action', 'genre:action']]
-#         }
-#     )
-#     assert isinstance(response, dict)
-#     assert len(response['hits']) == 3
-#     assert 'facetsDistribution' not in response
-#     assert 'exhaustiveFacetsCount' not in response
-
-# def test_custom_search_params_with_many_params(index_with_documents):
-#     index = index_with_documents()
-#     update = index.update_filterable_attributes(['genre'])
-#     index.wait_for_pending_update(update['updateId'])
-#     response = index.search(
-#         'world',
-#         {
-#             'facetFilters': [['genre:action']],
-#             'attributesToRetrieve': ['title', 'poster']
-#         }
-#     )
-#     assert isinstance(response, dict)
-#     assert len(response['hits']) == 3
-#     assert 'facetsDistribution' not in response
-#     assert 'exhaustiveFacetsCount' not in response
-#     assert 'title' in response['hits'][0]
-#     assert 'poster' in response['hits'][0]
-#     assert 'overview' not in response['hits'][0]
-#     assert 'release_date' not in response['hits'][0]
-#     assert response['hits'][0]['title'] == 'Avengers: Infinity War'

--- a/meilisearch/tests/index/test_index_wait_for_pending_update.py
+++ b/meilisearch/tests/index/test_index_wait_for_pending_update.py
@@ -13,6 +13,7 @@ def test_wait_for_pending_update_default(index_with_documents):
     assert isinstance(update, dict)
     assert 'status' in update
     assert update['status'] != 'enqueued'
+    assert update['status'] != 'processing'
 
 def test_wait_for_pending_update_timeout(index_with_documents):
     """Tests timeout risen by waiting for an update."""
@@ -34,6 +35,7 @@ def test_wait_for_pending_update_interval_custom(index_with_documents, small_mov
     assert isinstance(wait_update, dict)
     assert 'status' in wait_update
     assert wait_update['status'] != 'enqueued'
+    assert wait_update['status'] != 'processing'
     assert time_delta.seconds >= 1
 
 def test_wait_for_pending_update_interval_zero(index_with_documents, small_movies):
@@ -49,3 +51,4 @@ def test_wait_for_pending_update_interval_zero(index_with_documents, small_movie
     assert isinstance(wait_update, dict)
     assert 'status' in wait_update
     assert wait_update['status'] != 'enqueued'
+    assert wait_update['status'] != 'processing'

--- a/meilisearch/tests/settings/test_settings.py
+++ b/meilisearch/tests/settings/test_settings.py
@@ -5,11 +5,10 @@ NEW_SETTINGS = {
 }
 
 DEFAULT_RANKING_RULES = [
-    'typo',
     'words',
+    'typo',
     'proximity',
     'attribute',
-    'wordsPosition',
     'exactness'
 ]
 

--- a/meilisearch/tests/settings/test_settings_ranking_rules_meilisearch.py
+++ b/meilisearch/tests/settings/test_settings_ranking_rules_meilisearch.py
@@ -1,11 +1,10 @@
 
 NEW_RANKING_RULES = ['typo', 'exactness']
 DEFAULT_RANKING_RULES = [
-    'typo',
     'words',
+    'typo',
     'proximity',
     'attribute',
-    'wordsPosition',
     'exactness'
 ]
 


### PR DESCRIPTION
Adapts tests according to v0.21.0 breaking changes 
- Rename fields `buildDate` into `commitDate`
- Update `rankingRules`
- `exhaustiveFacetsCount` return `False`