### PR TITLE
Fixing __str__ issues with MeiliSearchApiError

### DIFF
--- a/meilisearch/errors.py
+++ b/meilisearch/errors.py
@@ -17,6 +17,9 @@ class MeiliSearchApiError(MeiliSearchError):
 
     def __init__(self, error: str, request: Response) -> None:
         self.status_code = request.status_code
+        self.error_code = None
+        self.error_link = None
+
         if request.text:
             self.message = f'{json.loads(request.text)["message"]}'
             self.error_code = f'{json.loads(request.text)["errorCode"]}'
@@ -26,7 +29,10 @@ class MeiliSearchApiError(MeiliSearchError):
         super().__init__(self.message)
 
     def __str__(self) -> str:
-        return f'MeiliSearchApiError. Error code: {self.error_code}. Error message: {self.message}. Error documentation: {self.error_link}'
+        if self.error_code and self.error_link:
+            return f'MeiliSearchApiError. Error code: {self.error_code}. Error message: {self.message}. Error documentation: {self.error_link}'
+
+        return f'MeiliSearchApiError. {self.message}'
 
 class MeiliSearchCommunicationError(MeiliSearchError):
     """Error when connecting to MeiliSearch"""

--- a/meilisearch/errors.py
+++ b/meilisearch/errors.py
@@ -21,9 +21,10 @@ class MeiliSearchApiError(MeiliSearchError):
         self.error_link = None
 
         if request.text:
-            self.message = f'{json.loads(request.text)["message"]}'
-            self.error_code = f'{json.loads(request.text)["errorCode"]}'
-            self.error_link = f'{json.loads(request.text)["errorLink"]}'
+            json_data = json.loads(request.text)
+            self.message = json_data.get('message')
+            self.error_code = json_data.get('errorCode')
+            self.error_link = json_data.get('errorLink')
         else:
             self.message = error
         super().__init__(self.message)

--- a/meilisearch/tests/errors/test_api_error_meilisearch.py
+++ b/meilisearch/tests/errors/test_api_error_meilisearch.py
@@ -1,6 +1,8 @@
 # pylint: disable=invalid-name
 
+from unittest.mock import patch
 import pytest
+import requests
 import meilisearch
 from meilisearch.errors import MeiliSearchApiError
 from meilisearch.tests import BASE_URL, MASTER_KEY
@@ -14,3 +16,15 @@ def test_meilisearch_api_error_wrong_master_key():
     client = meilisearch.Client(BASE_URL, MASTER_KEY + '123')
     with pytest.raises(MeiliSearchApiError):
         client.create_index("some_index")
+
+@patch('requests.post')
+def test_meilisearch_api_error_no_error_code(mock_post):
+    """Here to test for regressions related to https://github.com/meilisearch/meilisearch-python/issues/305."""
+
+    mock_response = requests.models.Response()
+    mock_response.status_code = 408
+    mock_post.return_value = mock_response
+
+    with pytest.raises(MeiliSearchApiError):
+        client = meilisearch.Client(BASE_URL, MASTER_KEY + '123')
+        client.create_index('some_index')


### PR DESCRIPTION
Fixes #305

It may be possible to come up with a better error to return if we get more info on how to recreate the issue, but this should at least prevent the converting to string error and also keep other errors from happening in similar situations.