### PR TITLE
Windows OS encoding issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup, find_packages
 
-with open("README.md", "r") as fh:
+with open("README.md", "r", encoding="utf8") as fh:
     long_description = fh.read()
 
 setup(


### PR DESCRIPTION
## Type of PR
Bug fix - Issue #342 

## Description
Explicitly add the encoding type when creating the long description in the setup.py script, otherwise running tox throws an error in  Windows 