### PR TITLE
Remove `delete_if_exist` and `get_or_create`

### DIFF
--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -50,8 +50,8 @@ class Client():
         """
         return Index.create(self.config, uid, options)
 
-    def delete_index_if_exists(self, uid: str) -> bool:
-        """Deletes an index if it already exists
+    def delete_index(self, uid: str) -> Dict[str, Any]:
+        """Deletes an index
 
         Parameters
         ----------
@@ -68,13 +68,7 @@ class Client():
             An error containing details about why MeiliSearch can't process your request. MeiliSearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
 
-        try:
-            self.http.delete(f'{self.config.paths.index}/{uid}')
-            return True
-        except MeiliSearchApiError as error:
-            if error.code != "index_not_found":
-                raise error
-            return False
+        return self.http.delete(f'{self.config.paths.index}/{uid}')
 
     def get_indexes(self) -> List[Index]:
         """Get all indexes.
@@ -176,34 +170,6 @@ class Client():
         if uid is not None:
             return Index(self.config, uid=uid)
         raise Exception('The index UID should not be None')
-
-    def get_or_create_index(self, uid: str, options: Optional[Dict[str, Any]] = None) -> Index:
-        """Get an index, or create it if it doesn't exist.
-
-        Parameters
-        ----------
-        uid:
-            UID of the index
-        options (optional): dict
-            Options passed during index creation (ex: primaryKey)
-
-        Returns
-        -------
-        index:
-            An instance of Index containing the information of the retrieved or newly created index.
-
-        Raises
-        ------
-        MeiliSearchApiError
-            An error containing details about why MeiliSearch can't process your request. MeiliSearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
-        """
-        try:
-            index_instance = self.get_index(uid)
-        except MeiliSearchApiError as err:
-            if err.code != 'index_not_found':
-                raise err
-            index_instance = self.create_index(uid, options)
-        return index_instance
 
     def get_all_stats(self) -> Dict[str, Any]:
         """Get all stats of MeiliSearch

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -55,26 +55,7 @@ class Index():
 
         return self.http.delete(f'{self.config.paths.index}/{self.uid}')
 
-    def delete_if_exists(self) -> bool:
-        """Deletes the index if it already exists
-
-        Returns
-        --------
-        Returns True if an index was deleted or False if not
-
-        Raises
-        MeiliSearchApiError
-            An error containing details about why MeiliSearch can't process your request. MeiliSearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
-        """
-        try:
-            self.delete()
-            return True
-        except MeiliSearchApiError as error:
-            if error.code != "index_not_found":
-                raise error
-            return False
-
-    def update(self, primary_key: str) -> 'Index':
+    def update(self, primary_key: str) -> Dict[str, Any]:
         """Update the index primary-key.
 
         Parameters

--- a/tests/index/test_index.py
+++ b/tests/index/test_index.py
@@ -100,33 +100,6 @@ def test_get_raw_index_with_wrong_uid(client):
     with pytest.raises(Exception):
         client.get_raw_index(uid='wrongUID')
 
-def test_get_or_create_index(client):
-    """Test get_or_create_index method."""
-    index_1 = client.get_or_create_index(common.INDEX_UID4)
-    index_2 = client.get_or_create_index(common.INDEX_UID4)
-    index_3 = client.get_or_create_index(common.INDEX_UID4)
-    assert index_1.uid == index_2.uid == index_3.uid == common.INDEX_UID4
-    update = index_1.add_documents([{
-        'book_id': 1,
-        'name': "Some book"
-    }])
-    index_1.wait_for_pending_update(update['updateId'])
-    documents = index_2.get_documents()
-    assert len(documents) == 1
-    index_2.delete()
-    with pytest.raises(Exception):
-        client.get_index(index_3)
-
-def test_get_or_create_index_with_primary_key(client):
-    """Test get_or_create_index method with primary key."""
-    index_1 = client.get_or_create_index('books', {'primaryKey': common.INDEX_UID4})
-    index_2 = client.get_or_create_index('books', {'primaryKey': 'some_wrong_key'})
-    assert index_1.primary_key == common.INDEX_UID4
-    assert index_1.get_primary_key() == common.INDEX_UID4
-    assert index_2.primary_key == common.INDEX_UID4
-    assert index_2.get_primary_key() == common.INDEX_UID4
-    index_1.delete()
-
 @pytest.mark.usefixtures("indexes_sample")
 def test_index_fetch_info(client):
     """Tests fetching the index info."""
@@ -187,32 +160,3 @@ def test_delete_index(client):
         client.get_index(uid=common.INDEX_UID3)
     assert len(client.get_indexes()) == 0
 
-@pytest.mark.usefixtures("indexes_sample")
-def test_delete_if_exists(client):
-    assert client.get_index(uid=common.INDEX_UID)
-    deleted = Client(BASE_URL, MASTER_KEY).index(common.INDEX_UID).delete_if_exists()
-    assert deleted is True
-    with pytest.raises(MeiliSearchApiError):
-        client.get_index(uid=common.INDEX_UID)
-
-def test_delete_if_exists_no_delete(client):
-    with pytest.raises(MeiliSearchApiError):
-        client.get_index(uid="none")
-
-    deleted = Client(BASE_URL, MASTER_KEY).index("none").delete_if_exists()
-    assert deleted is False
-
-@pytest.mark.usefixtures("indexes_sample")
-def test_delete_index_if_exists(client):
-    assert client.get_index(uid=common.INDEX_UID)
-    deleted = client.delete_index_if_exists(common.INDEX_UID)
-    assert deleted is True
-    with pytest.raises(MeiliSearchApiError):
-        client.get_index(uid=common.INDEX_UID)
-
-def test_delete_index_if_exists_no_delete(client):
-    with pytest.raises(MeiliSearchApiError):
-        client.get_index(uid="none")
-
-    deleted = client.delete_index_if_exists("none")
-    assert deleted is False


### PR DESCRIPTION
### Breaking Changes
Removing:
- delete_if_exist
- get_or_create

All the actions on indexes are now asynchronous, so the method `delete_if_exist` and `get_or_create` are now useless. 

