### PR TITLE
Addition related to API keys

### DIFF
--- a/meilisearch/_httprequests.py
+++ b/meilisearch/_httprequests.py
@@ -60,6 +60,14 @@ class HttpRequests:
     ) -> Any:
         return self.send_request(requests.post, path, body, content_type)
 
+    def patch(
+        self,
+        path: str,
+        body: Optional[Union[Dict[str, Any], List[Dict[str, Any]], List[str], str]] = None,
+        content_type: Optional[str] = 'application/json',
+    ) -> Any:
+        return self.send_request(requests.patch, path, body, content_type)
+
     def put(
         self,
         path: str,

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -280,8 +280,7 @@ class Client():
         MeiliSearchApiError
             An error containing details about why MeiliSearch can't process your request. MeiliSearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        payload = {**options}
-        return self.http.post(f'{self.config.paths.keys}', payload)
+        return self.http.post(f'{self.config.paths.keys}', options)
 
     def udpate_key(
         self,
@@ -310,9 +309,8 @@ class Client():
         MeiliSearchApiError
             An error containing details about why MeiliSearch can't process your request. MeiliSearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        payload = {**options}
         url = f'{self.config.paths.keys}/{key}'
-        return self.http.patch(url, payload)
+        return self.http.patch(url, options)
 
     def delete_key(self, key: str) -> Dict[str, int]:
         """Deletes an API key.

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -217,15 +217,34 @@ class Client():
             return False
         return True
 
-    def get_keys(self) -> Dict[str, str]:
-        """Get all keys.
+    def get_key(self, key: str) -> Dict[str, str]:
+        """Gets information about a specific API key.
 
-        Get the public and private keys.
+        Parameters
+        ----------
+        key:
+            The key for which to retrieve the information.
+
+        Returns
+        -------
+        key:
+            The API key.
+            https://docs.meilisearch.com/reference/api/keys.html#get-key
+
+        Raises
+        ------
+        MeiliSearchApiError
+            An error containing details about why MeiliSearch can't process your request. MeiliSearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
+        """
+        return self.http.get(f'{self.config.paths.keys}/{key}')
+
+    def get_keys(self) -> Dict[str, str]:
+        """Gets the MeiliSearch API keys.
 
         Returns
         -------
         keys:
-            Dictionary of keys and their information.
+            API keys.
             https://docs.meilisearch.com/reference/api/keys.html#get-keys
 
         Raises
@@ -234,6 +253,90 @@ class Client():
             An error containing details about why MeiliSearch can't process your request. MeiliSearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
         return self.http.get(self.config.paths.keys)
+
+    def create_key(
+        self,
+        options: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, int]:
+        """Creates a new API key.
+
+        Parameters
+        ----------
+        options:
+            Options, the information to use in creating the key (ex: { 'actions': ['*'], 'indexes': ['movies'], 'description': 'Search Key', 'expiresAt': '22-01-01' }).
+            An `actions`, an `indexes` and a `expiresAt` fields are mandatory,`None` should be specified for no expiration date.
+            `actions`: A list of actions permitted for the key. ["*"] for all actions.
+            `indexes`: A list of indexes permitted for the key. ["*"] for all indexes.
+            Note that if an expires_at value is included it should be in UTC time.
+
+        Returns
+        -------
+        keys:
+            The new API key.
+            https://docs.meilisearch.com/reference/api/keys.html#get-keys
+
+        Raises
+        ------
+        MeiliSearchApiError
+            An error containing details about why MeiliSearch can't process your request. MeiliSearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
+        """
+        if options is None:
+            options= {}
+        payload = {**options}
+        return self.http.post(f'{self.config.paths.keys}', payload)
+
+    def udpate_key(
+        self,
+        key: str,
+        options: Optional[Dict[str, Any]] = None
+    ) -> Dict[str, int]:
+        """Update an API key.
+
+        Parameters
+        ----------
+        key:
+            The information to use in updating the key. Note that if an expires_at value
+            is included it should be in UTC time.
+        options:
+            Options, the information to use in creating the key (ex: { 'description': 'Search Key', 'expiresAt': '22-01-01' }).
+
+        Returns
+        -------
+        key:
+            The updated API key.
+            https://docs.meilisearch.com/reference/api/keys.html#get-keys
+
+        Raises
+        ------
+        MeiliSearchApiError
+            An error containing details about why MeiliSearch can't process your request. MeiliSearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
+        """
+        if options is None:
+            options= {}
+        payload = {**options}
+        url = f'{self.config.paths.keys}/{key}'
+        return self.http.patch(url, payload)
+
+    def delete_key(self, key: str) -> Dict[str, int]:
+        """Deletes an API key.
+
+        Parameters
+        ----------
+        key:
+            The key to delete.
+
+        Returns
+        -------
+        keys:
+            The Response status code. 204 signifies a successful delete.
+            https://docs.meilisearch.com/reference/api/keys.html#get-keys
+
+        Raises
+        ------
+        MeiliSearchApiError
+            An error containing details about why MeiliSearch can't process your request. MeiliSearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
+        """
+        return self.http.delete(f'{self.config.paths.keys}/{key}')
 
     def get_version(self) -> Dict[str, str]:
         """Get version MeiliSearch

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -257,7 +257,7 @@ class Client():
     def create_key(
         self,
         options: Dict[str, Any]
-    ) -> Dict[str, int]:
+    ) -> Dict[str, Any]:
         """Creates a new API key.
 
         Parameters
@@ -286,7 +286,7 @@ class Client():
         self,
         key: str,
         options: Dict[str, Any]
-    ) -> Dict[str, int]:
+    ) -> Dict[str, Any]:
         """Update an API key.
 
         Parameters

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -217,7 +217,7 @@ class Client():
             return False
         return True
 
-    def get_key(self, key: str) -> Dict[str, str]:
+    def get_key(self, key: str) -> Dict[str, Any]:
         """Gets information about a specific API key.
 
         Parameters
@@ -238,7 +238,7 @@ class Client():
         """
         return self.http.get(f'{self.config.paths.keys}/{key}')
 
-    def get_keys(self) -> Dict[str, str]:
+    def get_keys(self) -> List[Dict[str, Any]]:
         """Gets the MeiliSearch API keys.
 
         Returns
@@ -256,7 +256,7 @@ class Client():
 
     def create_key(
         self,
-        options: Optional[Dict[str, Any]] = None
+        options: Dict[str, Any]
     ) -> Dict[str, int]:
         """Creates a new API key.
 
@@ -288,17 +288,18 @@ class Client():
     def udpate_key(
         self,
         key: str,
-        options: Optional[Dict[str, Any]] = None
+        options: Dict[str, Any]
     ) -> Dict[str, int]:
         """Update an API key.
 
         Parameters
+
         ----------
         key:
-            The information to use in updating the key. Note that if an expires_at value
-            is included it should be in UTC time.
+            The key for which to update the information.
         options:
-            Options, the information to use in creating the key (ex: { 'description': 'Search Key', 'expiresAt': '22-01-01' }).
+            The information to use in creating the key (ex: { 'description': 'Search Key', 'expiresAt': '22-01-01' }). Note that if an
+            expires_at value is included it should be in UTC time.
 
         Returns
         -------

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -280,8 +280,6 @@ class Client():
         MeiliSearchApiError
             An error containing details about why MeiliSearch can't process your request. MeiliSearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        if options is None:
-            options= {}
         payload = {**options}
         return self.http.post(f'{self.config.paths.keys}', payload)
 
@@ -312,8 +310,6 @@ class Client():
         MeiliSearchApiError
             An error containing details about why MeiliSearch can't process your request. MeiliSearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        if options is None:
-            options= {}
         payload = {**options}
         url = f'{self.config.paths.keys}/{key}'
         return self.http.patch(url, payload)

--- a/tests/client/test_client_key_meilisearch.py
+++ b/tests/client/test_client_key_meilisearch.py
@@ -5,17 +5,16 @@ from meilisearch.errors import MeiliSearchApiError
 
 def test_get_keys_default(client):
     """Tests if public and private keys have been generated and can be retrieved."""
-    key = client.get_keys()
-    assert isinstance(key, list)
-    assert len(key) == 2
-    assert 'actions' in key[0]
-    assert 'indexes' in key[0]
-    assert key[0]['key'] is not None
-    assert key[1]['key'] is not None
+    keys = client.get_keys()
+    assert isinstance(keys, list)
+    assert len(keys) == 2
+    assert 'actions' in keys[0]
+    assert 'indexes' in keys[0]
+    assert keys[0]['key'] is not None
+    assert keys[1]['key'] is not None
 
 def test_get_key(client, test_key):
     """Tests if a key can be retrieved."""
-    keys = client.get_keys()
     key = client.get_key(test_key['key'])
     assert isinstance(key, dict)
     assert 'actions' in key

--- a/tests/client/test_client_key_meilisearch.py
+++ b/tests/client/test_client_key_meilisearch.py
@@ -1,0 +1,79 @@
+import pytest
+from tests import common
+from datetime import datetime, timedelta
+
+def test_get_keys_default(client):
+    """Tests if public and private keys have been generated and can be retrieved."""
+    key = client.get_keys()
+    assert isinstance(key, list)
+    assert len(key) >= 2
+    assert 'actions' in key[0]
+    assert 'indexes' in key[0]
+    assert key[0]['key'] is not None
+    assert key[1]['key'] is not None
+
+def test_get_key(client):
+    """Tests if a key can be retrieved."""
+    keys = client.get_keys()
+    key = client.get_key(keys[0]['key'])
+    assert isinstance(key, dict)
+    assert 'actions' in key
+    assert 'indexes' in key
+    assert key['createdAt'] is not None
+
+def test_get_key_inexistent(client):
+    """Tests getting a key that does not exists."""
+    with pytest.raises(Exception):
+        client.get_key('No existing key')
+
+def test_create_keys_default(client):
+    """Tests the creation of a key with no optional argument."""
+    key = client.create_key(options={ 'actions': ['*'], 'indexes': [common.INDEX_UID], 'expiresAt': None })
+    assert isinstance(key, dict)
+    assert 'key' in key
+    assert 'actions' in key
+    assert 'indexes' in key
+    assert key['key'] is not None
+    assert key['expiresAt'] is None
+    assert key['createdAt'] is not None
+    assert key['updatedAt'] is not None
+    assert key['key'] is not None
+    assert key['actions'] == ['*']
+    assert key['indexes'] == [common.INDEX_UID]
+
+def test_create_keys_with_options(client):
+    """Tests the creation of a key with arguments."""
+    key = client.create_key(options={ 'actions': ['*'], 'indexes': [common.INDEX_UID], 'description': 'Test key', 'expiresAt': datetime(2030, 6, 4, 21, 8, 12, 32).isoformat()[:-3]+'Z' })
+    assert isinstance(key, dict)
+    assert key['key'] is not None
+    assert key['description'] == 'Test key'
+    assert key['expiresAt'] is not None
+    assert key['createdAt'] is not None
+    assert key['updatedAt'] is not None
+    assert key['actions'] == ['*']
+    assert key['indexes'] == [common.INDEX_UID]
+
+def test_create_keys_without_actions(client):
+    """Tests the creation of a key with missing arguments."""
+    with pytest.raises(Exception):
+        client.create_key(options={'indexes': [common.INDEX_UID]})
+
+def test_update_keys(client):
+    """Tests updating a key."""
+    key = client.create_key(options={ 'actions': ['*'], 'indexes': ['*'], 'expiresAt': None })
+    assert key['actions'] == ['*']
+    update_key = client.udpate_key(key=key['key'], options={ 'actions': ['search'] })
+    assert update_key['key'] is not None
+    assert update_key['expiresAt'] is None
+    assert update_key['actions'] == ['search']
+
+def test_delete_key(client):
+    """Tests deleting a key."""
+    key = client.create_key(options={ 'actions': ['*'], 'indexes': ['*'], 'expiresAt': None })
+    resp = client.delete_key(key['key'])
+    assert resp.status_code == 204
+
+def test_delete_key_inexisting(client):
+    """Tests deleting a key that does not exists."""
+    with pytest.raises(Exception):
+        client.delete_key('No existing key')

--- a/tests/client/test_client_key_meilisearch.py
+++ b/tests/client/test_client_key_meilisearch.py
@@ -1,12 +1,12 @@
 import pytest
 from tests import common
-from datetime import datetime, timedelta
+from datetime import datetime
 
 def test_get_keys_default(client):
     """Tests if public and private keys have been generated and can be retrieved."""
     key = client.get_keys()
     assert isinstance(key, list)
-    assert len(key) >= 2
+    assert len(key) == 2
     assert 'actions' in key[0]
     assert 'indexes' in key[0]
     assert key[0]['key'] is not None
@@ -40,6 +40,7 @@ def test_create_keys_default(client):
     assert key['key'] is not None
     assert key['actions'] == ['*']
     assert key['indexes'] == [common.INDEX_UID]
+    client.delete_key(key['key'])
 
 def test_create_keys_with_options(client):
     """Tests the creation of a key with arguments."""
@@ -52,6 +53,7 @@ def test_create_keys_with_options(client):
     assert key['updatedAt'] is not None
     assert key['actions'] == ['*']
     assert key['indexes'] == [common.INDEX_UID]
+    client.delete_key(key['key'])
 
 def test_create_keys_without_actions(client):
     """Tests the creation of a key with missing arguments."""
@@ -66,6 +68,7 @@ def test_update_keys(client):
     assert update_key['key'] is not None
     assert update_key['expiresAt'] is None
     assert update_key['actions'] == ['search']
+    client.delete_key(update_key['key'])
 
 def test_delete_key(client):
     """Tests deleting a key."""


### PR DESCRIPTION
### Breaking Changes

Granular management of API keys is now added to MeiliSearch. New methods have been created to manage this:
- `http.patch` use by `update_key`
- `client.get_key` get information about a specific API key.
- `client.create_key` create a new API key.
- `client.delete_key` delete an API key.
- `client.update_key` update an API key.

Note: Thanks to @sanders41 whose code is largely inspired by [his implementation](https://github.com/sanders41/meilisearch-python-async/blob/e44941b7bf5735c8e99f0a2a12b707db03ac048a/meilisearch_python_async/client.py#L298) and [here](https://github.com/meilisearch/meilisearch-python/pull/372#issuecomment-999062854).