### PR TITLE
Fix API key wording according to v0.25.0 of MeiliSearch

### DIFF
--- a/tests/client/test_client_key_meilisearch.py
+++ b/tests/client/test_client_key_meilisearch.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from meilisearch.errors import MeiliSearchApiError
 
 def test_get_keys_default(client):
-    """Tests if public and private keys have been generated and can be retrieved."""
+    """Tests if search and admin keys have been generated and can be retrieved."""
     keys = client.get_keys()
     assert isinstance(keys, dict)
     assert len(keys['results']) == 2


### PR DESCRIPTION
Not a big deal, but we should remove the following wording
- `private key`
- `public key`

Indeed, since [MeiliSearch v0.25.0](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.25.0), `private key` is replaced by `admin key` and `public key` by `search key`. 