### PR TITLE
Adding generate_tenant_token method

### DIFF
--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -504,21 +504,13 @@ class Client():
         if expires_at and expires_at < datetime.datetime.now():
             raise Exception('The date expires_at should be in the future.')
 
-        api_key = str(self.config.api_key) if api_key is None else api_key
-
-        # Check if the api_key is not the master key
-        try:
-            client = Client(self.config.url, api_key)
-            client.get_keys()
-            raise Exception('The master key can be used to generated a token.')
-        except MeiliSearchError:
-            pass
-
         # Standard JWT header for encryption with SHA256/HS256 algorithm
         header = {
             "typ": "JWT",
             "alg": "HS256"
         }
+
+        api_key = str(self.config.api_key) if api_key is None else api_key
 
         # Add the required fields to the payload
         payload = {

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -496,6 +496,7 @@ class Client():
            Note: If your token does not work remember that the search_rules is mandatory and should be well formatted.
            `exp` must be a `datetime` in the future. It's not possible to create a token from the master key.
         """
+        # Validate all fields
         if api_key == '' or api_key is None and self.config.api_key is None:
             raise Exception('An api key is required in the client or should be passed as an argument.')
         if isinstance(search_rules, Dict) and search_rules == {} or search_rules == {''}:
@@ -505,13 +506,21 @@ class Client():
         if expires_at and expires_at < datetime.datetime.now():
             raise Exception('The date expires_at should be in the future.')
 
+        api_key = str(self.config.api_key) if api_key is None else api_key
+
+        # Check if the api_key is not the master key
+        try:
+            client = Client(self.config.url, api_key)
+            client.get_keys()
+            raise Exception('The master key can be used to generated a token.')
+        except MeiliSearchError:
+            pass
+
         # Standard JWT header for encryption with SHA256/HS256 algorithm
         header = {
             "typ": "JWT",
             "alg": "HS256"
         }
-
-        api_key = str(self.config.api_key) if api_key is None else str(api_key)
 
         # Add the required fields to the payload
         payload = {

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -9,6 +9,7 @@ from meilisearch.config import Config
 from meilisearch.task import get_task, get_tasks, wait_for_task
 from meilisearch._httprequests import HttpRequests
 from meilisearch.errors import MeiliSearchError
+from typing import Any, Dict, List, Optional, Union
 
 class Client():
     """
@@ -471,7 +472,7 @@ class Client():
 
     def generate_tenant_token(
         self,
-        search_rules: Dict[str, Any],
+        search_rules: Union[Dict[str, Any], List[str]],
         expires_at: Optional[int] = None,
         api_key: Optional[str] = None
     ) -> str:
@@ -480,20 +481,20 @@ class Client():
         Parameters
         ----------
         search_rules:
-            A Dictionary or an object which contains the rules to be enforced at search time for all or specific
+            A Dictionary or list of string which contains the rules to be enforced at search time for all or specific
             accessible indexes for the signing API Key.
-            In the specific case of you want to have any restrictions you can also use a array ["*"].
+            In the specific case where you do not want to have any restrictions you can also use a list ["*"].
         expires_at (optional):
             Date and time when the key will expire.
             Note that if an expires_at value is included it should a `timestamp`.
         api_key (optional):
-            The API key parent of the token. If you let it empty the client API Key will be used.
+            The API key parent of the token. If you leave it empty the client API Key will be used.
 
         Returns
         -------
         jwt_token:
            A string containing the jwt tenant token.
-           Note: If your token does not work remember that the searchrules is madatory and should be well formatted.
+           Note: If your token does not work remember that the search_rules is mandatory and should be well formatted.
            `exp` must be a timestamp in the future.
         """
         # Standard JWT header for encryption with SHA256/HS256 algorithm
@@ -508,7 +509,7 @@ class Client():
         payload = {
             'apiKeyPrefix': api_key[0:8],
             'searchRules': search_rules,
-            'exp': expires_at if expires_at is not None else None
+            'exp': expires_at
         }
 
         # Serialize the header and the payload

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -499,9 +499,7 @@ class Client():
         # Validate all fields
         if api_key == '' or api_key is None and self.config.api_key is None:
             raise Exception('An api key is required in the client or should be passed as an argument.')
-        if isinstance(search_rules, Dict) and search_rules == {} or search_rules == {''}:
-            raise Exception('The search_rules field is mandatory and should be defined.')
-        if isinstance(search_rules, List) and search_rules == [] or search_rules == ['']:
+        if not search_rules or search_rules == ['']:
             raise Exception('The search_rules field is mandatory and should be defined.')
         if expires_at and expires_at < datetime.datetime.now():
             raise Exception('The date expires_at should be in the future.')

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -471,19 +471,23 @@ class Client():
 
     def generate_tenant_token(
         self,
-        options: Dict[str, Any],
-        parent_api_key: Optional[str] = None
+        search_rules: Dict[str, Any],
+        expired_at: Optional[float] = None,
+        api_key: Optional[str] = None
     ) -> str:
         """Generate a JWT token for the use of multitenancy.
 
         Parameters
         ----------
-        options:
-            Options, the information to generate the token (ex: { 'searchRules': ['*'], 'exp': '1645089029' }).
-            `searchRules`: A Dictionary which contains the rules to be enforced at search time for all or specific
+        search_rules:
+            A Dictionary or an object which contains the rules to be enforced at search time for all or specific
             accessible indexes for the signing API Key.
             In the specific case of you want to have any restrictions you can also use a array ["*"].
-            Note that if an exp value is included it should a `timestamp`.
+        expired_at (optional):
+            Date and time when the key will expire.
+            Note that if an expired_at value is included it should a `timestamp`.
+        api_key (optional):
+            The API key parent of the token. If you let it empty the client API Key will be used.
 
         Returns
         -------
@@ -495,24 +499,34 @@ class Client():
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
+        # Standard JWT header for encryption with SHA256/HS256 algorithm
         header = {
             "typ": "JWT",
             "alg": "HS256"
         }
 
-        api_key = str(self.config.api_key) if parent_api_key is None else str(parent_api_key)
+        api_key = str(self.config.api_key) if api_key is None else str(api_key)
 
-        options['apiKeyPrefix'] = api_key[0:8]
+        # Add the required fields to the payload
+        payload = {
+            'apiKeyPrefix': api_key[0:8],
+            'searchRules': search_rules,
+            'exp': expired_at if expired_at is not None else None
+        }
 
+        # Serialize the header and the payload
         json_header = json.dumps(header, separators=(",",":")).encode()
-        json_options = json.dumps(options, separators=(",",":")).encode()
+        json_payload = json.dumps(payload, separators=(",",":")).encode()
 
+        # Encode the header and the payload to Base64Url String
         header_encode = self._base64url_encode(json_header)
-        header_options = self._base64url_encode(json_options)
+        header_payload = self._base64url_encode(json_payload)
 
         secret_encoded = api_key.encode()
-        signature = hmac.new(secret_encoded, (header_encode + "." + header_options).encode(), hashlib.sha256).digest()
-        jwt_token = header_encode + '.' + header_options + '.' + self._base64url_encode(signature)
+        # Create Signature Hash
+        signature = hmac.new(secret_encoded, (header_encode + "." + header_payload).encode(), hashlib.sha256).digest()
+        # Create JWT
+        jwt_token = header_encode + '.' + header_payload + '.' + self._base64url_encode(signature)
 
         return jwt_token
 

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -472,7 +472,7 @@ class Client():
     def generate_tenant_token(
         self,
         search_rules: Dict[str, Any],
-        expired_at: Optional[float] = None,
+        expires_at: Optional[int] = None,
         api_key: Optional[str] = None
     ) -> str:
         """Generate a JWT token for the use of multitenancy.
@@ -483,9 +483,9 @@ class Client():
             A Dictionary or an object which contains the rules to be enforced at search time for all or specific
             accessible indexes for the signing API Key.
             In the specific case of you want to have any restrictions you can also use a array ["*"].
-        expired_at (optional):
+        expires_at (optional):
             Date and time when the key will expire.
-            Note that if an expired_at value is included it should a `timestamp`.
+            Note that if an expires_at value is included it should a `timestamp`.
         api_key (optional):
             The API key parent of the token. If you let it empty the client API Key will be used.
 
@@ -493,11 +493,8 @@ class Client():
         -------
         jwt_token:
            A string containing the jwt tenant token.
-
-        Raises
-        ------
-        MeiliSearchApiError
-            An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
+           Note: If your token does not work remember that the searchrules is madatory and should be well formatted.
+           `exp` must be a timestamp in the future.
         """
         # Standard JWT header for encryption with SHA256/HS256 algorithm
         header = {
@@ -511,7 +508,7 @@ class Client():
         payload = {
             'apiKeyPrefix': api_key[0:8],
             'searchRules': search_rules,
-            'exp': expired_at if expired_at is not None else None
+            'exp': expires_at if expires_at is not None else None
         }
 
         # Serialize the header and the payload

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -485,7 +485,7 @@ class Client():
             accessible indexes for the signing API Key.
             In the specific case where you do not want to have any restrictions you can also use a list ["*"].
         expires_at (optional):
-            Date and time when the key will expire.
+            Date and time when the key will expire. Note that if an expires_at value is included it should be in UTC time.
         api_key (optional):
             The API key parent of the token. If you leave it empty the client API Key will be used.
 
@@ -501,7 +501,7 @@ class Client():
             raise Exception('An api key is required in the client or should be passed as an argument.')
         if not search_rules or search_rules == ['']:
             raise Exception('The search_rules field is mandatory and should be defined.')
-        if expires_at and expires_at < datetime.datetime.now():
+        if expires_at and expires_at < datetime.datetime.utcnow():
             raise Exception('The date expires_at should be in the future.')
 
         # Standard JWT header for encryption with SHA256/HS256 algorithm

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -472,6 +472,7 @@ class Client():
     def generate_tenant_token(
         self,
         search_rules: Union[Dict[str, Any], List[str]],
+        *,
         expires_at: Optional[datetime.datetime] = None,
         api_key: Optional[str] = None
     ) -> str:

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -10,9 +10,7 @@ import datetime
 def test_generate_tenant_token_with_search_rules(get_private_key, index_with_documents):
     """Tests create a tenant token with only search rules."""
     index_with_documents()
-    key = get_private_key
-
-    client = meilisearch.Client(BASE_URL, key['key'])
+    client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
     token = client.generate_tenant_token(search_rules=["*"])
 
@@ -25,9 +23,7 @@ def test_generate_tenant_token_with_search_rules(get_private_key, index_with_doc
 def test_generate_tenant_token_with_api_key(client, get_private_key, index_with_documents):
     """Tests create a tenant token with only search rules."""
     index_with_documents()
-    key = get_private_key
-
-    token = client.generate_tenant_token(search_rules=["*"], api_key=key['key'])
+    token = client.generate_tenant_token(search_rules=["*"], api_key=get_private_key['key'])
 
     token_client = meilisearch.Client(BASE_URL, token)
     response = token_client.index('indexUID').search('')
@@ -38,14 +34,10 @@ def test_generate_tenant_token_with_api_key(client, get_private_key, index_with_
 def test_generate_tenant_token_with_expires_at(client, get_private_key, index_with_documents):
     """Tests create a tenant token with search rules and expiration date."""
     index_with_documents()
-    key = get_private_key
-
-    client = meilisearch.Client(BASE_URL, key['key'])
-
+    client = meilisearch.Client(BASE_URL, get_private_key['key'])
     tomorrow = datetime.datetime.now() + datetime.timedelta(days=1)
-    timestamp = datetime.datetime.timestamp(tomorrow)
 
-    token = client.generate_tenant_token(search_rules=["*"], expires_at=int(timestamp))
+    token = client.generate_tenant_token(search_rules=["*"], expires_at=tomorrow)
 
     token_client = meilisearch.Client(BASE_URL, token)
     response = token_client.index('indexUID').search('')
@@ -53,40 +45,55 @@ def test_generate_tenant_token_with_expires_at(client, get_private_key, index_wi
     assert len(response['hits']) == 20
     assert response['query'] == ''
 
-def test_generate_tenant_token_without_search_rules(get_private_key, index_with_documents):
+def test_generate_tenant_token_with_empty_search_rules_in_list(get_private_key, index_with_documents):
     """Tests create a tenant token without search rules."""
-    index_with_documents()
-    key = get_private_key
+    client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
-    client = meilisearch.Client(BASE_URL, key['key'])
+    with pytest.raises(Exception):
+        client.generate_tenant_token(search_rules=[''])
 
-    token = client.generate_tenant_token(search_rules='')
+def test_generate_tenant_token_without_search_rules_in_list(get_private_key, index_with_documents):
+    """Tests create a tenant token without search rules."""
+    client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
-    token_client = meilisearch.Client(BASE_URL, token)
-    with pytest.raises(MeiliSearchApiError):
-        token_client.index('indexUID').search('')
+    with pytest.raises(Exception):
+        client.generate_tenant_token(search_rules=[])
 
-def test_generate_tenant_token_with_master_key(client, get_private_key, index_with_documents):
+def test_generate_tenant_token_without_search_rules_in_dict(get_private_key, index_with_documents):
+    """Tests create a tenant token without search rules."""
+    client = meilisearch.Client(BASE_URL, get_private_key['key'])
+
+    with pytest.raises(Exception):
+        client.generate_tenant_token(search_rules={})
+
+def test_generate_tenant_token_wit_empty_search_rules_in_dict(get_private_key, index_with_documents):
+    """Tests create a tenant token without search rules."""
+    client = meilisearch.Client(BASE_URL, get_private_key['key'])
+
+    with pytest.raises(Exception):
+        client.generate_tenant_token(search_rules={''})
+
+def test_generate_tenant_token_with_master_key(client, index_with_documents):
     """Tests create a tenant token with master key."""
-    index_with_documents()
     token = client.generate_tenant_token(search_rules=['*'])
 
     token_client = meilisearch.Client(BASE_URL, token)
     with pytest.raises(MeiliSearchApiError):
         token_client.index('indexUID').search('')
 
-def test_generate_tenant_token_with_bad_expires_at(client, get_private_key, index_with_documents):
+def test_generate_tenant_token_with_bad_expires_at(client, get_private_key):
     """Tests create a tenant token with only search rules."""
-    index_with_documents()
-    key = get_private_key
-
-    client = meilisearch.Client(BASE_URL, key['key'])
+    client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
     yesterday = datetime.datetime.now() + datetime.timedelta(days=-1)
-    timestamp = datetime.datetime.timestamp(yesterday)
 
-    token = client.generate_tenant_token(search_rules=["*"], expires_at=int(timestamp))
+    with pytest.raises(Exception):
+        client.generate_tenant_token(search_rules=["*"], expires_at=yesterday)
 
-    token_client = meilisearch.Client(BASE_URL, token)
-    with pytest.raises(MeiliSearchApiError):
-        token_client.index('indexUID').search('')
+def test_generate_tenant_token_with_no_api_key(client):
+    """Tests create a tenant token with only search rules."""
+    client = meilisearch.Client(BASE_URL)
+
+    with pytest.raises(Exception):
+        client.generate_tenant_token(search_rules=["*"])
+

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -36,7 +36,7 @@ def test_generate_tenant_token_with_api_key(client, get_private_key, index_with_
     assert response['query'] == ''
 
 def test_generate_tenant_token_with_expires_at(client, get_private_key, index_with_documents):
-    """Tests create a tenant token with only search rules."""
+    """Tests create a tenant token with search rules and expiration date."""
     index_with_documents()
     key = get_private_key
 
@@ -54,7 +54,7 @@ def test_generate_tenant_token_with_expires_at(client, get_private_key, index_wi
     assert response['query'] == ''
 
 def test_generate_tenant_token_without_search_rules(get_private_key, index_with_documents):
-    """Tests create a tenant token with only search rules."""
+    """Tests create a tenant token without search rules."""
     index_with_documents()
     key = get_private_key
 
@@ -67,10 +67,8 @@ def test_generate_tenant_token_without_search_rules(get_private_key, index_with_
         token_client.index('indexUID').search('')
 
 def test_generate_tenant_token_with_master_key(client, get_private_key, index_with_documents):
-    """Tests create a tenant token with only search rules."""
+    """Tests create a tenant token with master key."""
     index_with_documents()
-    key = get_private_key
-
     token = client.generate_tenant_token(search_rules=['*'])
 
     token_client = meilisearch.Client(BASE_URL, token)

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -81,7 +81,7 @@ def test_generate_tenant_token_without_search_rules_in_dict(get_private_key):
     with pytest.raises(Exception):
         client.generate_tenant_token(search_rules={})
 
-def test_generate_tenant_token_wit_empty_search_rules_in_dict(get_private_key):
+def test_generate_tenant_token_with_empty_search_rules_in_dict(get_private_key):
     """Tests create a tenant token without search rules."""
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
 

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -23,7 +23,7 @@ def test_generate_tenant_token_with_search_rules(get_private_key, index_with_doc
     assert response['query'] == ''
 
 def test_generate_tenant_token_with_search_rules_on_one_index(get_private_key, empty_index):
-    """Tests create a tenant token with only search rules."""
+    """Tests create a tenant token with search rules set for one index."""
     empty_index()
     empty_index('tenant_token')
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
@@ -38,7 +38,7 @@ def test_generate_tenant_token_with_search_rules_on_one_index(get_private_key, e
         response = token_client.index('tenant_token').search('')
 
 def test_generate_tenant_token_with_api_key(client, get_private_key, empty_index):
-    """Tests create a tenant token with only search rules."""
+    """Tests create a tenant token with search rules and an api key."""
     empty_index()
     token = client.generate_tenant_token(search_rules=["*"], api_key=get_private_key['key'])
 
@@ -89,7 +89,7 @@ def test_generate_tenant_token_with_empty_search_rules_in_dict(get_private_key):
         client.generate_tenant_token(search_rules={''})
 
 def test_generate_tenant_token_with_bad_expires_at(client, get_private_key):
-    """Tests create a tenant token with only search rules."""
+    """Tests create a tenant token with a bad expires at."""
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
     yesterday = datetime.datetime.utcnow() + datetime.timedelta(days=-1)
@@ -98,7 +98,7 @@ def test_generate_tenant_token_with_bad_expires_at(client, get_private_key):
         client.generate_tenant_token(search_rules=["*"], expires_at=yesterday)
 
 def test_generate_tenant_token_with_no_api_key(client):
-    """Tests create a tenant token with only search rules."""
+    """Tests create a tenant token with no api key."""
     client = meilisearch.Client(BASE_URL)
 
     with pytest.raises(Exception):

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -88,11 +88,6 @@ def test_generate_tenant_token_wit_empty_search_rules_in_dict(get_private_key):
     with pytest.raises(Exception):
         client.generate_tenant_token(search_rules={''})
 
-def test_generate_tenant_token_with_master_key(client):
-    """Tests create a tenant token with master key."""
-    with pytest.raises(Exception):
-        client.generate_tenant_token(search_rules=['*'])
-
 def test_generate_tenant_token_with_bad_expires_at(client, get_private_key):
     """Tests create a tenant token with only search rules."""
     client = meilisearch.Client(BASE_URL, get_private_key['key'])

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -92,7 +92,7 @@ def test_generate_tenant_token_with_bad_expires_at(client, get_private_key):
     """Tests create a tenant token with only search rules."""
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
-    yesterday = datetime.datetime.now() + datetime.timedelta(days=-1)
+    yesterday = datetime.datetime.utcnow() + datetime.timedelta(days=-1)
 
     with pytest.raises(Exception):
         client.generate_tenant_token(search_rules=["*"], expires_at=yesterday)

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -75,11 +75,8 @@ def test_generate_tenant_token_wit_empty_search_rules_in_dict(get_private_key, i
 
 def test_generate_tenant_token_with_master_key(client, index_with_documents):
     """Tests create a tenant token with master key."""
-    token = client.generate_tenant_token(search_rules=['*'])
-
-    token_client = meilisearch.Client(BASE_URL, token)
-    with pytest.raises(MeiliSearchApiError):
-        token_client.index('indexUID').search('')
+    with pytest.raises(Exception):
+        client.generate_tenant_token(search_rules=['*'])
 
 def test_generate_tenant_token_with_bad_expires_at(client, get_private_key):
     """Tests create a tenant token with only search rules."""

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -1,8 +1,10 @@
 # pylint: disable=invalid-name
 
 from re import search
+import pytest
 import meilisearch
 from tests import BASE_URL, MASTER_KEY
+from meilisearch.errors import MeiliSearchApiError
 import datetime
 
 def test_generate_tenant_token_with_search_rules(get_private_key, index_with_documents):
@@ -33,17 +35,17 @@ def test_generate_tenant_token_with_api_key(client, get_private_key, index_with_
     assert len(response['hits']) == 20
     assert response['query'] == ''
 
-def test_generate_tenant_token_with_expired_at(client, get_private_key, index_with_documents):
+def test_generate_tenant_token_with_expires_at(client, get_private_key, index_with_documents):
     """Tests create a tenant token with only search rules."""
     index_with_documents()
     key = get_private_key
 
     client = meilisearch.Client(BASE_URL, key['key'])
 
-    tomorrow = datetime.datetime.now() + datetime.timedelta(days=1, hours=3)
+    tomorrow = datetime.datetime.now() + datetime.timedelta(days=1)
     timestamp = datetime.datetime.timestamp(tomorrow)
 
-    token = client.generate_tenant_token(search_rules=["*"], expired_at=int(timestamp))
+    token = client.generate_tenant_token(search_rules=["*"], expires_at=int(timestamp))
 
     token_client = meilisearch.Client(BASE_URL, token)
     response = token_client.index('indexUID').search('')
@@ -61,7 +63,32 @@ def test_generate_tenant_token_without_search_rules(get_private_key, index_with_
     token = client.generate_tenant_token(search_rules='')
 
     token_client = meilisearch.Client(BASE_URL, token)
-    response = token_client.index('indexUID').search('')
-    assert isinstance(response, dict)
-    assert len(response['hits']) == 20
-    assert response['query'] == ''
+    with pytest.raises(MeiliSearchApiError):
+        token_client.index('indexUID').search('')
+
+def test_generate_tenant_token_with_master_key(client, get_private_key, index_with_documents):
+    """Tests create a tenant token with only search rules."""
+    index_with_documents()
+    key = get_private_key
+
+    token = client.generate_tenant_token(search_rules=['*'])
+
+    token_client = meilisearch.Client(BASE_URL, token)
+    with pytest.raises(MeiliSearchApiError):
+        token_client.index('indexUID').search('')
+
+def test_generate_tenant_token_with_bad_expires_at(client, get_private_key, index_with_documents):
+    """Tests create a tenant token with only search rules."""
+    index_with_documents()
+    key = get_private_key
+
+    client = meilisearch.Client(BASE_URL, key['key'])
+
+    yesterday = datetime.datetime.now() + datetime.timedelta(days=-1)
+    timestamp = datetime.datetime.timestamp(yesterday)
+
+    token = client.generate_tenant_token(search_rules=["*"], expires_at=int(timestamp))
+
+    token_client = meilisearch.Client(BASE_URL, token)
+    with pytest.raises(MeiliSearchApiError):
+        token_client.index('indexUID').search('')

--- a/tests/client/test_client_token.py
+++ b/tests/client/test_client_token.py
@@ -1,0 +1,67 @@
+# pylint: disable=invalid-name
+
+from re import search
+import meilisearch
+from tests import BASE_URL, MASTER_KEY
+import datetime
+
+def test_generate_tenant_token_with_search_rules(get_private_key, index_with_documents):
+    """Tests create a tenant token with only search rules."""
+    index_with_documents()
+    key = get_private_key
+
+    client = meilisearch.Client(BASE_URL, key['key'])
+
+    token = client.generate_tenant_token(search_rules=["*"])
+
+    token_client = meilisearch.Client(BASE_URL, token)
+    response = token_client.index('indexUID').search('')
+    assert isinstance(response, dict)
+    assert len(response['hits']) == 20
+    assert response['query'] == ''
+
+def test_generate_tenant_token_with_api_key(client, get_private_key, index_with_documents):
+    """Tests create a tenant token with only search rules."""
+    index_with_documents()
+    key = get_private_key
+
+    token = client.generate_tenant_token(search_rules=["*"], api_key=key['key'])
+
+    token_client = meilisearch.Client(BASE_URL, token)
+    response = token_client.index('indexUID').search('')
+    assert isinstance(response, dict)
+    assert len(response['hits']) == 20
+    assert response['query'] == ''
+
+def test_generate_tenant_token_with_expired_at(client, get_private_key, index_with_documents):
+    """Tests create a tenant token with only search rules."""
+    index_with_documents()
+    key = get_private_key
+
+    client = meilisearch.Client(BASE_URL, key['key'])
+
+    tomorrow = datetime.datetime.now() + datetime.timedelta(days=1, hours=3)
+    timestamp = datetime.datetime.timestamp(tomorrow)
+
+    token = client.generate_tenant_token(search_rules=["*"], expired_at=int(timestamp))
+
+    token_client = meilisearch.Client(BASE_URL, token)
+    response = token_client.index('indexUID').search('')
+    assert isinstance(response, dict)
+    assert len(response['hits']) == 20
+    assert response['query'] == ''
+
+def test_generate_tenant_token_without_search_rules(get_private_key, index_with_documents):
+    """Tests create a tenant token with only search rules."""
+    index_with_documents()
+    key = get_private_key
+
+    client = meilisearch.Client(BASE_URL, key['key'])
+
+    token = client.generate_tenant_token(search_rules='')
+
+    token_client = meilisearch.Client(BASE_URL, token)
+    response = token_client.index('indexUID').search('')
+    assert isinstance(response, dict)
+    assert len(response['hits']) == 20
+    assert response['query'] == ''

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ from pytest import fixture
 from tests import common
 import meilisearch
 from meilisearch.errors import MeiliSearchApiError
+from typing import Optional
 
 @fixture(scope='session')
 def client():
@@ -67,8 +68,9 @@ def songs_ndjson():
         return song_ndjson_file.read().encode('utf-8')
 
 @fixture(scope='function')
-def empty_index(client):
-    def index_maker(index_name=common.INDEX_UID):
+def empty_index(client, index_uid: Optional[str] = None):
+    index_uid = index_uid if index_uid else common.INDEX_UID
+    def index_maker(index_name=index_uid):
         task = client.create_index(uid=index_name)
         client.wait_for_task(task['uid'])
         return client.get_index(uid=index_name)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,3 +109,9 @@ def test_key_info(client):
         client.delete_key(key['key'])
     except MeiliSearchApiError:
         pass
+
+@fixture(scope='function')
+def get_private_key(client):
+    keys = client.get_keys()['results']
+    key = next(x for x in keys if 'Default Admin API' in x['description'])
+    return key

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -113,5 +113,5 @@ def test_key_info(client):
 @fixture(scope='function')
 def get_private_key(client):
     keys = client.get_keys()['results']
-    key = next(x for x in keys if 'Default Admin API' in x['description'])
+    key = next(x for x in keys if 'Default Search API' in x['description'])
     return key


### PR DESCRIPTION
## Tenant tokens

Introduction of the new method `generate_tenant_token`  in order to facilitate the generation of the tenant token.

Related to:
- this issue: https://github.com/meilisearch/meilisearch/issues/1991
- this spec: https://github.com/meilisearch/specifications/pull/89
