### PR TITLE
Feature/Analytics

### DIFF
--- a/meilisearch/_httprequests.py
+++ b/meilisearch/_httprequests.py
@@ -7,12 +7,14 @@ from meilisearch.errors import (
     MeiliSearchCommunicationError,
     MeiliSearchTimeoutError,
 )
+from meilisearch.version import qualified_version
 
 class HttpRequests:
     def __init__(self, config: Config) -> None:
         self.config = config
         self.headers = {
             'Authorization': f'Bearer {self.config.api_key}',
+            'User-Agent': qualified_version(),
         }
 
     def send_request(

--- a/tests/client/test_http_requests.py
+++ b/tests/client/test_http_requests.py
@@ -1,0 +1,15 @@
+
+import meilisearch
+from tests import BASE_URL, MASTER_KEY
+
+from meilisearch.config import Config
+from meilisearch._httprequests import HttpRequests
+from meilisearch.version import qualified_version
+
+def test_get_headers_from_http_requests_instance():
+    """Tests getting defined headers from instance in HttpRequests."""
+    config = Config(BASE_URL, MASTER_KEY, timeout=None)
+    http = HttpRequests(config=config)
+
+    assert http.headers['Authorization'] == f"Bearer {MASTER_KEY}"
+    assert http.headers['User-Agent'] == qualified_version()


### PR DESCRIPTION
Added a pre-defined User-Agent header using `meilisearch.version`

After the implementation the MeiliSearch server is outputting the expected 💯 
`[2022-03-30T04:41:46Z INFO  actix_web::middleware::logger] 192.168.208.3 "GET /indexes HTTP/1.1" 200 2 "-" "Meilisearch Python (v0.18.1)" 0.000619`

Add Python support as requested here https://github.com/meilisearch/integration-guides/issues/150
Related to #409 