### PR TITLE
Add typo tolerance settings

### DIFF
--- a/meilisearch/config.py
+++ b/meilisearch/config.py
@@ -25,6 +25,7 @@ class Config:
         accept_new_fields = 'accept-new-fields'
         filterable_attributes = 'filterable-attributes'
         sortable_attributes = 'sortable-attributes'
+        typo_tolerance = 'typo-tolerance'
         dumps = 'dumps'
 
     def __init__(

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -666,8 +666,7 @@ class Index():
     # RANKING RULES SUB-ROUTES
 
     def get_ranking_rules(self) -> List[str]:
-        """
-        Get ranking rules of the index.
+        """Get ranking rules of the index.
 
         Returns
         -------
@@ -684,8 +683,7 @@ class Index():
         )
 
     def update_ranking_rules(self, body: List[str]) -> Dict[str, Any]:
-        """
-        Update ranking rules of the index.
+        """Update ranking rules of the index.
 
         Parameters
         ----------
@@ -729,8 +727,7 @@ class Index():
     # DISTINCT ATTRIBUTE SUB-ROUTES
 
     def get_distinct_attribute(self) -> Optional[str]:
-        """
-        Get distinct attribute of the index.
+        """Get distinct attribute of the index.
 
         Returns
         -------
@@ -747,8 +744,7 @@ class Index():
         )
 
     def update_distinct_attribute(self, body: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Update distinct attribute of the index.
+        """Update distinct attribute of the index.
 
         Parameters
         ----------
@@ -792,8 +788,7 @@ class Index():
     # SEARCHABLE ATTRIBUTES SUB-ROUTES
 
     def get_searchable_attributes(self) -> List[str]:
-        """
-        Get searchable attributes of the index.
+        """Get searchable attributes of the index.
 
         Returns
         -------
@@ -810,8 +805,7 @@ class Index():
         )
 
     def update_searchable_attributes(self, body: List[str]) -> Dict[str, Any]:
-        """
-        Update searchable attributes of the index.
+        """Update searchable attributes of the index.
 
         Parameters
         ----------
@@ -855,8 +849,7 @@ class Index():
     # DISPLAYED ATTRIBUTES SUB-ROUTES
 
     def get_displayed_attributes(self) -> List[str]:
-        """
-        Get displayed attributes of the index.
+        """Get displayed attributes of the index.
 
         Returns
         -------
@@ -873,8 +866,7 @@ class Index():
         )
 
     def update_displayed_attributes(self, body: List[str]) -> Dict[str, Any]:
-        """
-        Update displayed attributes of the index.
+        """Update displayed attributes of the index.
 
         Parameters
         ----------
@@ -918,8 +910,7 @@ class Index():
     # STOP WORDS SUB-ROUTES
 
     def get_stop_words(self) -> List[str]:
-        """
-        Get stop words of the index.
+        """Get stop words of the index.
 
         Returns
         -------
@@ -936,8 +927,7 @@ class Index():
         )
 
     def update_stop_words(self, body: List[str]) -> Dict[str, Any]:
-        """
-        Update stop words of the index.
+        """Update stop words of the index.
 
         Parameters
         ----------
@@ -981,8 +971,7 @@ class Index():
     # SYNONYMS SUB-ROUTES
 
     def get_synonyms(self) -> Dict[str, List[str]]:
-        """
-        Get synonyms of the index.
+        """Get synonyms of the index.
 
         Returns
         -------
@@ -999,8 +988,7 @@ class Index():
         )
 
     def update_synonyms(self, body: Dict[str, List[str]]) -> Dict[str, Any]:
-        """
-        Update synonyms of the index.
+        """Update synonyms of the index.
 
         Parameters
         ----------
@@ -1044,8 +1032,7 @@ class Index():
     # FILTERABLE ATTRIBUTES SUB-ROUTES
 
     def get_filterable_attributes(self) -> List[str]:
-        """
-        Get filterable attributes of the index.
+        """Get filterable attributes of the index.
 
         Returns
         -------
@@ -1062,8 +1049,7 @@ class Index():
         )
 
     def update_filterable_attributes(self, body: List[str]) -> Dict[str, Any]:
-        """
-        Update filterable attributes of the index.
+        """Update filterable attributes of the index.
 
         Parameters
         ----------
@@ -1108,8 +1094,7 @@ class Index():
     # SORTABLE ATTRIBUTES SUB-ROUTES
 
     def get_sortable_attributes(self) -> List[str]:
-        """
-        Get sortable attributes of the index.
+        """Get sortable attributes of the index.
 
         Returns
         -------
@@ -1126,8 +1111,7 @@ class Index():
         )
 
     def update_sortable_attributes(self, body: List[str]) -> Dict[str, Any]:
-        """
-        Update sortable attributes of the index.
+        """Update sortable attributes of the index.
 
         Parameters
         ----------
@@ -1171,8 +1155,7 @@ class Index():
     # TYPO TOLERANCE SUB-ROUTES
 
     def get_typo_tolerance(self) -> Dict[str, Any]:
-        """
-        Get typo tolerance of the index.
+        """Get typo tolerance of the index.
 
         Returns
         -------
@@ -1189,8 +1172,7 @@ class Index():
         )
 
     def update_typo_tolerance(self, body: Dict[str, Any]) -> Dict[str, Any]:
-        """
-        Update typo tolerance of the index.
+        """Update typo tolerance of the index.
 
         Parameters
         ----------

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -289,7 +289,7 @@ class Index():
         self,
         documents: List[Dict[str, Any]],
         primary_key: Optional[str] = None,
-    ) -> Dict[str, int]:
+    ) -> Dict[str, Any]:
         """Add documents to the index.
 
         Parameters
@@ -318,7 +318,7 @@ class Index():
         documents: List[Dict[str, Any]],
         batch_size: int = 1000,
         primary_key: Optional[str] = None,
-    ) -> List[Dict[str, int]]:
+    ) -> List[Dict[str, Any]]:
         """Add documents to the index in batches.
 
         Parameters
@@ -355,7 +355,7 @@ class Index():
         self,
         str_documents: str,
         primary_key: Optional[str] = None,
-    ) -> Dict[str, int]:
+    ) -> Dict[str, Any]:
         """Add string documents from JSON file to the index.
 
         Parameters
@@ -382,7 +382,7 @@ class Index():
         self,
         str_documents: str,
         primary_key: Optional[str] = None,
-    ) -> Dict[str, int]:
+    ) -> Dict[str, Any]:
         """Add string documents from a CSV file to the index.
 
         Parameters
@@ -409,7 +409,7 @@ class Index():
         self,
         str_documents: str,
         primary_key: Optional[str] = None,
-    ) -> Dict[str, int]:
+    ) -> Dict[str, Any]:
         """Add string documents from a NDJSON file to the index.
 
         Parameters
@@ -437,7 +437,7 @@ class Index():
         str_documents: str,
         primary_key: Optional[str] = None,
         content_type: Optional[str] = None,
-    ) -> Dict[str, int]:
+    ) -> Dict[str, Any]:
         """Add string documents to the index.
 
         Parameters
@@ -467,7 +467,7 @@ class Index():
         self,
         documents: List[Dict[str, Any]],
         primary_key: Optional[str] = None
-    ) -> Dict[str, int]:
+    ) -> Dict[str, Any]:
         """Update documents in the index.
 
         Parameters
@@ -615,7 +615,7 @@ class Index():
             f'{self.config.paths.index}/{self.uid}/{self.config.paths.setting}'
         )
 
-    def update_settings(self, body: Dict[str, Any]) -> Dict[str, int]:
+    def update_settings(self, body: Dict[str, Any]) -> Dict[str, Any]:
         """Update settings of the index.
 
         https://docs.meilisearch.com/reference/api/settings.html#update-settings
@@ -643,7 +643,7 @@ class Index():
             body
         )
 
-    def reset_settings(self) -> Dict[str, int]:
+    def reset_settings(self) -> Dict[str, Any]:
         """Reset settings of the index to default values.
 
         https://docs.meilisearch.com/reference/api/settings.html#reset-settings
@@ -683,7 +683,7 @@ class Index():
             self.__settings_url_for(self.config.paths.ranking_rules)
         )
 
-    def update_ranking_rules(self, body: List[str]) -> Dict[str, int]:
+    def update_ranking_rules(self, body: List[str]) -> Dict[str, Any]:
         """
         Update ranking rules of the index.
 
@@ -708,7 +708,7 @@ class Index():
             body
         )
 
-    def reset_ranking_rules(self) -> Dict[str, int]:
+    def reset_ranking_rules(self) -> Dict[str, Any]:
         """Reset ranking rules of the index to default values.
 
         Returns
@@ -746,7 +746,7 @@ class Index():
             self.__settings_url_for(self.config.paths.distinct_attribute)
         )
 
-    def update_distinct_attribute(self, body: Dict[str, Any]) -> Dict[str, int]:
+    def update_distinct_attribute(self, body: Dict[str, Any]) -> Dict[str, Any]:
         """
         Update distinct attribute of the index.
 
@@ -771,7 +771,7 @@ class Index():
             body
         )
 
-    def reset_distinct_attribute(self) -> Dict[str, int]:
+    def reset_distinct_attribute(self) -> Dict[str, Any]:
         """Reset distinct attribute of the index to default values.
 
         Returns
@@ -809,7 +809,7 @@ class Index():
             self.__settings_url_for(self.config.paths.searchable_attributes)
         )
 
-    def update_searchable_attributes(self, body: List[str]) -> Dict[str, int]:
+    def update_searchable_attributes(self, body: List[str]) -> Dict[str, Any]:
         """
         Update searchable attributes of the index.
 
@@ -834,7 +834,7 @@ class Index():
             body
         )
 
-    def reset_searchable_attributes(self) -> Dict[str, int]:
+    def reset_searchable_attributes(self) -> Dict[str, Any]:
         """Reset searchable attributes of the index to default values.
 
         Returns
@@ -872,7 +872,7 @@ class Index():
             self.__settings_url_for(self.config.paths.displayed_attributes)
         )
 
-    def update_displayed_attributes(self, body: List[str]) -> Dict[str, int]:
+    def update_displayed_attributes(self, body: List[str]) -> Dict[str, Any]:
         """
         Update displayed attributes of the index.
 
@@ -897,7 +897,7 @@ class Index():
             body
         )
 
-    def reset_displayed_attributes(self) -> Dict[str, int]:
+    def reset_displayed_attributes(self) -> Dict[str, Any]:
         """Reset displayed attributes of the index to default values.
 
         Returns
@@ -935,7 +935,7 @@ class Index():
             self.__settings_url_for(self.config.paths.stop_words)
         )
 
-    def update_stop_words(self, body: List[str]) -> Dict[str, int]:
+    def update_stop_words(self, body: List[str]) -> Dict[str, Any]:
         """
         Update stop words of the index.
 
@@ -960,7 +960,7 @@ class Index():
             body
         )
 
-    def reset_stop_words(self) -> Dict[str, int]:
+    def reset_stop_words(self) -> Dict[str, Any]:
         """Reset stop words of the index to default values.
 
         Returns
@@ -998,7 +998,7 @@ class Index():
             self.__settings_url_for(self.config.paths.synonyms)
         )
 
-    def update_synonyms(self, body: Dict[str, List[str]]) -> Dict[str, int]:
+    def update_synonyms(self, body: Dict[str, List[str]]) -> Dict[str, Any]:
         """
         Update synonyms of the index.
 
@@ -1023,7 +1023,7 @@ class Index():
             body
         )
 
-    def reset_synonyms(self) -> Dict[str, int]:
+    def reset_synonyms(self) -> Dict[str, Any]:
         """Reset synonyms of the index to default values.
 
         Returns
@@ -1061,7 +1061,7 @@ class Index():
             self.__settings_url_for(self.config.paths.filterable_attributes)
         )
 
-    def update_filterable_attributes(self, body: List[str]) -> Dict[str, int]:
+    def update_filterable_attributes(self, body: List[str]) -> Dict[str, Any]:
         """
         Update filterable attributes of the index.
 
@@ -1086,7 +1086,7 @@ class Index():
             body
         )
 
-    def reset_filterable_attributes(self) -> Dict[str, int]:
+    def reset_filterable_attributes(self) -> Dict[str, Any]:
         """Reset filterable attributes of the index to default values.
 
         Returns
@@ -1125,7 +1125,7 @@ class Index():
             self.__settings_url_for(self.config.paths.sortable_attributes)
         )
 
-    def update_sortable_attributes(self, body: List[str]) -> Dict[str, int]:
+    def update_sortable_attributes(self, body: List[str]) -> Dict[str, Any]:
         """
         Update sortable attributes of the index.
 
@@ -1150,7 +1150,7 @@ class Index():
             body
         )
 
-    def reset_sortable_attributes(self) -> Dict[str, int]:
+    def reset_sortable_attributes(self) -> Dict[str, Any]:
         """Reset sortable attributes of the index to default values.
 
         Returns
@@ -1166,6 +1166,69 @@ class Index():
         """
         return self.http.delete(
             self.__settings_url_for(self.config.paths.sortable_attributes),
+        )
+
+    # TYPO TOLERANCE SUB-ROUTES
+
+    def get_typo_tolerance(self) -> Dict[str, Any]:
+        """
+        Get typo tolerance of the index.
+
+        Returns
+        -------
+        settings: dict
+            Dictionary containing the typo tolerance of the index.
+
+        Raises
+        ------
+        MeiliSearchApiError
+            An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
+        """
+        return self.http.get(
+            self.__settings_url_for(self.config.paths.typo_tolerance)
+        )
+
+    def update_typo_tolerance(self, body: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Update typo tolerance of the index.
+
+        Parameters
+        ----------
+        body: dict
+            Dictionary containing the typo tolerance.
+
+        Returns
+        -------
+        task:
+            Dictionary containing a task to track the informations about the progress of an asynchronous process.
+            https://docs.meilisearch.com/reference/api/tasks.html#get-one-task
+
+        Raises
+        ------
+        MeiliSearchApiError
+            An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
+        """
+        return self.http.post(
+            self.__settings_url_for(self.config.paths.typo_tolerance),
+            body
+        )
+
+    def reset_typo_tolerance(self) -> Dict[str, Any]:
+        """Reset typo tolerance of the index to default values.
+
+        Returns
+        -------
+        task:
+            Dictionary containing a task to track the informations about the progress of an asynchronous process.
+            https://docs.meilisearch.com/reference/api/tasks.html#get-one-task
+
+        Raises
+        ------
+        MeiliSearchApiError
+            An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
+        """
+        return self.http.delete(
+            self.__settings_url_for(self.config.paths.typo_tolerance),
         )
 
     @staticmethod

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -31,7 +31,7 @@ def test_get_settings_default(empty_index):
         assert rule in response['rankingRules']
     for typo in DEFAULT_TYPO_TOLERANCE:
         assert typo in response['typoTolerance']
-        assert DEFAULT_TYPO_TOLERANCE.get(typo) == response['typoTolerance'][typo]
+        assert DEFAULT_TYPO_TOLERANCE[typo] == response['typoTolerance'][typo]
     assert response['distinctAttribute'] is None
     assert response['searchableAttributes'] == ['*']
     assert response['displayedAttributes'] == ['*']
@@ -84,7 +84,7 @@ def test_reset_settings(empty_index):
         assert rule in response['rankingRules']
     for typo in DEFAULT_TYPO_TOLERANCE:
         assert typo in response['typoTolerance']
-        assert DEFAULT_TYPO_TOLERANCE.get(typo) == response['typoTolerance'][typo]
+        assert DEFAULT_TYPO_TOLERANCE[typo] == response['typoTolerance'][typo]
     assert response['distinctAttribute'] is None
     assert response['displayedAttributes'] == ['*']
     assert response['searchableAttributes'] == ['*']

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -31,6 +31,7 @@ def test_get_settings_default(empty_index):
         assert rule in response['rankingRules']
     for typo in DEFAULT_TYPO_TOLERANCE:
         assert typo in response['typoTolerance']
+        assert DEFAULT_TYPO_TOLERANCE.get(typo) == response['typoTolerance'][typo]
     assert response['distinctAttribute'] is None
     assert response['searchableAttributes'] == ['*']
     assert response['displayedAttributes'] == ['*']
@@ -83,6 +84,7 @@ def test_reset_settings(empty_index):
         assert rule in response['rankingRules']
     for typo in DEFAULT_TYPO_TOLERANCE:
         assert typo in response['typoTolerance']
+        assert DEFAULT_TYPO_TOLERANCE.get(typo) == response['typoTolerance'][typo]
     assert response['distinctAttribute'] is None
     assert response['displayedAttributes'] == ['*']
     assert response['searchableAttributes'] == ['*']

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -13,7 +13,7 @@ DEFAULT_RANKING_RULES = [
     'exactness'
 ]
 
-DEFAUT_TYPO_TOLERANCE =   {
+DEFAULT_TYPO_TOLERANCE =   {
     'enabled': True,
     'minWordSizeForTypos': {
         'oneTypo': 5,
@@ -29,7 +29,7 @@ def test_get_settings_default(empty_index):
     assert isinstance(response, dict)
     for rule in DEFAULT_RANKING_RULES:
         assert rule in response['rankingRules']
-    for typo in DEFAUT_TYPO_TOLERANCE:
+    for typo in DEFAULT_TYPO_TOLERANCE:
         assert typo in response['typoTolerance']
     assert response['distinctAttribute'] is None
     assert response['searchableAttributes'] == ['*']
@@ -81,7 +81,7 @@ def test_reset_settings(empty_index):
     response = index.get_settings()
     for rule in DEFAULT_RANKING_RULES:
         assert rule in response['rankingRules']
-    for typo in DEFAUT_TYPO_TOLERANCE:
+    for typo in DEFAULT_TYPO_TOLERANCE:
         assert typo in response['typoTolerance']
     assert response['distinctAttribute'] is None
     assert response['displayedAttributes'] == ['*']

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -13,12 +13,24 @@ DEFAULT_RANKING_RULES = [
     'exactness'
 ]
 
+DEFAUT_TYPO_TOLERANCE =   {
+    'enabled': True,
+    'minWordSizeForTypos': {
+        'oneTypo': 5,
+        'twoTypos': 9,
+    },
+    'disableOnWords': [],
+    'disableOnAttributes': [],
+}
+
 def test_get_settings_default(empty_index):
     """Tests getting all settings by default."""
     response = empty_index().get_settings()
     assert isinstance(response, dict)
     for rule in DEFAULT_RANKING_RULES:
         assert rule in response['rankingRules']
+    for typo in DEFAUT_TYPO_TOLERANCE:
+        assert typo in response['typoTolerance']
     assert response['distinctAttribute'] is None
     assert response['searchableAttributes'] == ['*']
     assert response['displayedAttributes'] == ['*']
@@ -69,6 +81,8 @@ def test_reset_settings(empty_index):
     response = index.get_settings()
     for rule in DEFAULT_RANKING_RULES:
         assert rule in response['rankingRules']
+    for typo in DEFAUT_TYPO_TOLERANCE:
+        assert typo in response['typoTolerance']
     assert response['distinctAttribute'] is None
     assert response['displayedAttributes'] == ['*']
     assert response['searchableAttributes'] == ['*']

--- a/tests/settings/test_settings_typo_tolerance_meilisearch.py
+++ b/tests/settings/test_settings_typo_tolerance_meilisearch.py
@@ -1,5 +1,5 @@
-TYPO_TOLERANCE =   {
-    'enabled': 'true',
+DEFAUT_TYPO_TOLERANCE =   {
+    'enabled': True,
     'minWordLengthForTypo': {
         'oneTypo': 5,
         'twoTypos': 9,
@@ -8,36 +8,46 @@ TYPO_TOLERANCE =   {
     'disableOnAttributes': [],
 }
 
+NEW_TYPO_TOLERANCE =   {
+    'enabled': True,
+    'minWordLengthForTypo': {
+        'oneTypo': 6,
+        'twoTypos': 10,
+    },
+    'disableOnWords': [],
+    'disableOnAttributes': ['title'],
+}
+
 def test_get_typo_tolerance_default(empty_index):
     """Tests getting default typo_tolerance."""
     response = empty_index().get_typo_tolerance()
     assert isinstance(response, dict)
-    assert response == {}
+    assert response == DEFAUT_TYPO_TOLERANCE
 
 def test_update_typo_tolerance(empty_index):
     """Tests updating typo_tolerance."""
     index = empty_index()
-    response = index.update_typo_tolerance(TYPO_TOLERANCE)
+    response = index.update_typo_tolerance(NEW_TYPO_TOLERANCE)
     assert isinstance(response, dict)
     assert 'uid' in response
     update = index.wait_for_task(response['uid'])
     assert update['status'] == 'succeeded'
     response = index.get_typo_tolerance()
     assert isinstance(response, dict)
-    for typo_tolerance in TYPO_TOLERANCE:
+    for typo_tolerance in NEW_TYPO_TOLERANCE:
         assert typo_tolerance in response
 
 def test_reset_typo_tolerance(empty_index):
     """Tests resetting the typo_tolerance setting to its default value."""
     index = empty_index()
     # Update the settings first
-    response = index.update_typo_tolerance(TYPO_TOLERANCE)
+    response = index.update_typo_tolerance(NEW_TYPO_TOLERANCE)
     update = index.wait_for_task(response['uid'])
     assert update['status'] == 'succeeded'
     # Check the settings have been correctly updated
     response = index.get_typo_tolerance()
     assert isinstance(response, dict)
-    for typo_tolerance in TYPO_TOLERANCE:
+    for typo_tolerance in NEW_TYPO_TOLERANCE:
         assert typo_tolerance in response
     # Check the reset of the settings
     response = index.reset_typo_tolerance()
@@ -46,4 +56,4 @@ def test_reset_typo_tolerance(empty_index):
     update = index.wait_for_task(response['uid'])
     assert update['status'] == 'succeeded'
     response = index.get_typo_tolerance()
-    assert response == {}
+    assert response == DEFAUT_TYPO_TOLERANCE

--- a/tests/settings/test_settings_typo_tolerance_meilisearch.py
+++ b/tests/settings/test_settings_typo_tolerance_meilisearch.py
@@ -37,6 +37,7 @@ def test_update_typo_tolerance(empty_index):
     assert isinstance(response, dict)
     for typo_tolerance in NEW_TYPO_TOLERANCE:
         assert typo_tolerance in response
+        assert NEW_TYPO_TOLERANCE.get(typo_tolerance) == response[typo_tolerance]
 
 def test_reset_typo_tolerance(empty_index):
     """Tests resetting the typo_tolerance setting to its default value."""
@@ -50,6 +51,7 @@ def test_reset_typo_tolerance(empty_index):
     assert isinstance(response, dict)
     for typo_tolerance in NEW_TYPO_TOLERANCE:
         assert typo_tolerance in response
+        assert NEW_TYPO_TOLERANCE.get(typo_tolerance) == response[typo_tolerance]
     # Check the reset of the settings
     response = index.reset_typo_tolerance()
     assert isinstance(response, dict)

--- a/tests/settings/test_settings_typo_tolerance_meilisearch.py
+++ b/tests/settings/test_settings_typo_tolerance_meilisearch.py
@@ -1,6 +1,6 @@
 DEFAUT_TYPO_TOLERANCE =   {
     'enabled': True,
-    'minWordLengthForTypo': {
+    'minWordSizeForTypos': {
         'oneTypo': 5,
         'twoTypos': 9,
     },
@@ -10,7 +10,7 @@ DEFAUT_TYPO_TOLERANCE =   {
 
 NEW_TYPO_TOLERANCE =   {
     'enabled': True,
-    'minWordLengthForTypo': {
+    'minWordSizeForTypos': {
         'oneTypo': 6,
         'twoTypos': 10,
     },
@@ -23,6 +23,7 @@ def test_get_typo_tolerance_default(empty_index):
     response = empty_index().get_typo_tolerance()
     assert isinstance(response, dict)
     assert response == DEFAUT_TYPO_TOLERANCE
+    print(response)
 
 def test_update_typo_tolerance(empty_index):
     """Tests updating typo_tolerance."""

--- a/tests/settings/test_settings_typo_tolerance_meilisearch.py
+++ b/tests/settings/test_settings_typo_tolerance_meilisearch.py
@@ -1,4 +1,4 @@
-DEFAUT_TYPO_TOLERANCE =   {
+DEFAULT_TYPO_TOLERANCE =   {
     'enabled': True,
     'minWordSizeForTypos': {
         'oneTypo': 5,
@@ -22,7 +22,7 @@ def test_get_typo_tolerance_default(empty_index):
     """Tests getting default typo_tolerance."""
     response = empty_index().get_typo_tolerance()
     assert isinstance(response, dict)
-    assert response == DEFAUT_TYPO_TOLERANCE
+    assert response == DEFAULT_TYPO_TOLERANCE
     print(response)
 
 def test_update_typo_tolerance(empty_index):
@@ -57,4 +57,4 @@ def test_reset_typo_tolerance(empty_index):
     update = index.wait_for_task(response['uid'])
     assert update['status'] == 'succeeded'
     response = index.get_typo_tolerance()
-    assert response == DEFAUT_TYPO_TOLERANCE
+    assert response == DEFAULT_TYPO_TOLERANCE

--- a/tests/settings/test_settings_typo_tolerance_meilisearch.py
+++ b/tests/settings/test_settings_typo_tolerance_meilisearch.py
@@ -28,51 +28,39 @@ def test_get_typo_tolerance_default(empty_index):
 def test_update_typo_tolerance(empty_index):
     """Tests updating typo_tolerance."""
     index = empty_index()
+    response_update = index.update_typo_tolerance(NEW_TYPO_TOLERANCE)
+    update = index.wait_for_task(response_update['uid'])
+    response_get = index.get_typo_tolerance()
 
-    response = index.update_typo_tolerance(NEW_TYPO_TOLERANCE)
-
-    assert isinstance(response, dict)
-    assert 'uid' in response
-
-    update = index.wait_for_task(response['uid'])
-
+    assert isinstance(response_update, dict)
+    assert 'uid' in response_update
     assert update['status'] == 'succeeded'
-
-    response = index.get_typo_tolerance()
-
-    assert isinstance(response, dict)
+    assert isinstance(response_get, dict)
     for typo_tolerance in NEW_TYPO_TOLERANCE:
-        assert typo_tolerance in response
-        assert NEW_TYPO_TOLERANCE[typo_tolerance] == response[typo_tolerance]
+        assert typo_tolerance in response_get
+        assert NEW_TYPO_TOLERANCE[typo_tolerance] == response_get[typo_tolerance]
 
 def test_reset_typo_tolerance(empty_index):
     """Tests resetting the typo_tolerance setting to its default value."""
     index = empty_index()
 
-    # Update the settings first
-    response = index.update_typo_tolerance(NEW_TYPO_TOLERANCE)
-    update = index.wait_for_task(response['uid'])
+    # Update the settings
+    response_update = index.update_typo_tolerance(NEW_TYPO_TOLERANCE)
+    update1 = index.wait_for_task(response_update['uid'])
+    # Get the setting after update
+    response_get = index.get_typo_tolerance()
+    # Reset the setting
+    response_reset = index.reset_typo_tolerance()
+    update2 = index.wait_for_task(response_reset['uid'])
+    # Get the setting after reset
+    response_last = index.get_typo_tolerance()
 
-    assert update['status'] == 'succeeded'
-
-    # Check the settings have been correctly updated
-    response = index.get_typo_tolerance()
-
-    assert isinstance(response, dict)
+    assert update1['status'] == 'succeeded'
+    assert isinstance(response_get, dict)
     for typo_tolerance in NEW_TYPO_TOLERANCE:
-        assert typo_tolerance in response
-        assert NEW_TYPO_TOLERANCE[typo_tolerance] == response[typo_tolerance]
-
-    # Check the reset of the settings
-    response = index.reset_typo_tolerance()
-
-    assert isinstance(response, dict)
-    assert 'uid' in response
-
-    update = index.wait_for_task(response['uid'])
-
-    assert update['status'] == 'succeeded'
-
-    response = index.get_typo_tolerance()
-
-    assert response == DEFAULT_TYPO_TOLERANCE
+        assert typo_tolerance in response_get
+        assert NEW_TYPO_TOLERANCE[typo_tolerance] == response_get[typo_tolerance]
+    assert isinstance(response_reset, dict)
+    assert 'uid' in response_reset
+    assert update2['status'] == 'succeeded'
+    assert response_last == DEFAULT_TYPO_TOLERANCE

--- a/tests/settings/test_settings_typo_tolerance_meilisearch.py
+++ b/tests/settings/test_settings_typo_tolerance_meilisearch.py
@@ -23,7 +23,6 @@ def test_get_typo_tolerance_default(empty_index):
     response = empty_index().get_typo_tolerance()
     assert isinstance(response, dict)
     assert response == DEFAULT_TYPO_TOLERANCE
-    print(response)
 
 def test_update_typo_tolerance(empty_index):
     """Tests updating typo_tolerance."""
@@ -37,7 +36,7 @@ def test_update_typo_tolerance(empty_index):
     assert isinstance(response, dict)
     for typo_tolerance in NEW_TYPO_TOLERANCE:
         assert typo_tolerance in response
-        assert NEW_TYPO_TOLERANCE.get(typo_tolerance) == response[typo_tolerance]
+        assert NEW_TYPO_TOLERANCE[typo_tolerance] == response[typo_tolerance]
 
 def test_reset_typo_tolerance(empty_index):
     """Tests resetting the typo_tolerance setting to its default value."""
@@ -51,7 +50,7 @@ def test_reset_typo_tolerance(empty_index):
     assert isinstance(response, dict)
     for typo_tolerance in NEW_TYPO_TOLERANCE:
         assert typo_tolerance in response
-        assert NEW_TYPO_TOLERANCE.get(typo_tolerance) == response[typo_tolerance]
+        assert NEW_TYPO_TOLERANCE[typo_tolerance] == response[typo_tolerance]
     # Check the reset of the settings
     response = index.reset_typo_tolerance()
     assert isinstance(response, dict)

--- a/tests/settings/test_settings_typo_tolerance_meilisearch.py
+++ b/tests/settings/test_settings_typo_tolerance_meilisearch.py
@@ -1,0 +1,49 @@
+TYPO_TOLERANCE =   {
+    'enabled': 'true',
+    'minWordLengthForTypo': {
+        'oneTypo': 5,
+        'twoTypos': 9,
+    },
+    'disableOnWords': [],
+    'disableOnAttributes': [],
+}
+
+def test_get_typo_tolerance_default(empty_index):
+    """Tests getting default typo_tolerance."""
+    response = empty_index().get_typo_tolerance()
+    assert isinstance(response, dict)
+    assert response == {}
+
+def test_update_typo_tolerance(empty_index):
+    """Tests updating typo_tolerance."""
+    index = empty_index()
+    response = index.update_typo_tolerance(TYPO_TOLERANCE)
+    assert isinstance(response, dict)
+    assert 'uid' in response
+    update = index.wait_for_task(response['uid'])
+    assert update['status'] == 'succeeded'
+    response = index.get_typo_tolerance()
+    assert isinstance(response, dict)
+    for typo_tolerance in TYPO_TOLERANCE:
+        assert typo_tolerance in response
+
+def test_reset_typo_tolerance(empty_index):
+    """Tests resetting the typo_tolerance setting to its default value."""
+    index = empty_index()
+    # Update the settings first
+    response = index.update_typo_tolerance(TYPO_TOLERANCE)
+    update = index.wait_for_task(response['uid'])
+    assert update['status'] == 'succeeded'
+    # Check the settings have been correctly updated
+    response = index.get_typo_tolerance()
+    assert isinstance(response, dict)
+    for typo_tolerance in TYPO_TOLERANCE:
+        assert typo_tolerance in response
+    # Check the reset of the settings
+    response = index.reset_typo_tolerance()
+    assert isinstance(response, dict)
+    assert 'uid' in response
+    update = index.wait_for_task(response['uid'])
+    assert update['status'] == 'succeeded'
+    response = index.get_typo_tolerance()
+    assert response == {}

--- a/tests/settings/test_settings_typo_tolerance_meilisearch.py
+++ b/tests/settings/test_settings_typo_tolerance_meilisearch.py
@@ -21,18 +21,25 @@ NEW_TYPO_TOLERANCE =   {
 def test_get_typo_tolerance_default(empty_index):
     """Tests getting default typo_tolerance."""
     response = empty_index().get_typo_tolerance()
+
     assert isinstance(response, dict)
     assert response == DEFAULT_TYPO_TOLERANCE
 
 def test_update_typo_tolerance(empty_index):
     """Tests updating typo_tolerance."""
     index = empty_index()
+
     response = index.update_typo_tolerance(NEW_TYPO_TOLERANCE)
+
     assert isinstance(response, dict)
     assert 'uid' in response
+
     update = index.wait_for_task(response['uid'])
+
     assert update['status'] == 'succeeded'
+
     response = index.get_typo_tolerance()
+
     assert isinstance(response, dict)
     for typo_tolerance in NEW_TYPO_TOLERANCE:
         assert typo_tolerance in response
@@ -41,21 +48,31 @@ def test_update_typo_tolerance(empty_index):
 def test_reset_typo_tolerance(empty_index):
     """Tests resetting the typo_tolerance setting to its default value."""
     index = empty_index()
+
     # Update the settings first
     response = index.update_typo_tolerance(NEW_TYPO_TOLERANCE)
     update = index.wait_for_task(response['uid'])
+
     assert update['status'] == 'succeeded'
+
     # Check the settings have been correctly updated
     response = index.get_typo_tolerance()
+
     assert isinstance(response, dict)
     for typo_tolerance in NEW_TYPO_TOLERANCE:
         assert typo_tolerance in response
         assert NEW_TYPO_TOLERANCE[typo_tolerance] == response[typo_tolerance]
+
     # Check the reset of the settings
     response = index.reset_typo_tolerance()
+
     assert isinstance(response, dict)
     assert 'uid' in response
+
     update = index.wait_for_task(response['uid'])
+
     assert update['status'] == 'succeeded'
+
     response = index.get_typo_tolerance()
+
     assert response == DEFAULT_TYPO_TOLERANCE


### PR DESCRIPTION
This PR introduces the new setting: [typoTolerance](https://github.com/meilisearch/specifications/pull/117)

new methods: 
`index.get_typo_tolerance()`
`index.update_typo_tolerance(params)`
`index.reset_typo_tolerance()`