### PR TITLE
Update version for the next release (v0.18.3)

### DIFF
--- a/meilisearch/version.py
+++ b/meilisearch/version.py
@@ -1,4 +1,4 @@
-__version__ = "0.18.2"
+__version__ = "0.18.3"
 
 def qualified_version() -> str:
     """Get the qualified version of this module."""


### PR DESCRIPTION
This version makes this package compatible with Meilisearch v0.27.0🎉 
Check out the changelog of [Meilisearch v0.27.0](https://github.com/meilisearch/MeiliSearch/releases/tag/v0.27.0) for more information about the changes.

## 🚀 Enhancements

- Add new methods for the new typo tolerance settings #443 @alallema
`index.get_typo_tolerance()`
`index.update_typo_tolerance(params)`
`index.reset_typo_tolerance()`
- Ensure nested field support #444 @alallema
- Add new search parameters highlightPreTag, highlightPostTag and cropMarker #445 @alallema
