### PR TITLE
Apply search changes

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -282,7 +282,7 @@ search_parameter_guide_highlight_tag_1: |-
   })
 search_parameter_guide_matches_1: |-
   client.index('movies').search('winter feast', {
-    'matches': 'true'
+    'showMatchesPosition': 'true'
   })
 settings_guide_synonyms_1: |-
   client.index('tops').update_settings({
@@ -491,7 +491,7 @@ faceted_search_filter_1: |-
   })
 faceted_search_facets_distribution_1: |-
   client.index('movies').search('Batman', {
-    'facetsDistribution': ['genres']
+    'facets': ['genres']
   })
 faceted_search_walkthrough_filter_1: |-
   client.index('movies').search('thriller', {

--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ index.search(
   ],
   "offset": 0,
   "limit": 20,
-  "nbHits": 1,
+  "estimatedTotalHits": 1,
   "processingTimeMs": 0,
   "query": "wonder"
 }

--- a/tests/index/test_index_search_meilisearch.py
+++ b/tests/index/test_index_search_meilisearch.py
@@ -186,18 +186,16 @@ def test_custom_search_params_with_facets_distribution(index_with_documents):
     response = index.search(
         'world',
         {
-            'facetsDistribution': ['genre']
+            'facets': ['genre']
         }
     )
     assert isinstance(response, dict)
     assert len(response['hits']) == 12
-    assert 'facetsDistribution' in response
-    assert 'exhaustiveFacetsCount' in response
-    assert not response['exhaustiveFacetsCount']
-    assert 'genre' in response['facetsDistribution']
-    assert response['facetsDistribution']['genre']['cartoon'] == 1
-    assert response['facetsDistribution']['genre']['action'] == 3
-    assert response['facetsDistribution']['genre']['fantasy'] == 1
+    assert 'facetDistribution' in response
+    assert 'genre' in response['facetDistribution']
+    assert response['facetDistribution']['genre']['cartoon'] == 1
+    assert response['facetDistribution']['genre']['action'] == 3
+    assert response['facetDistribution']['genre']['fantasy'] == 1
 
 def test_custom_search_params_with_filter_string(index_with_documents):
     index = index_with_documents()
@@ -211,8 +209,7 @@ def test_custom_search_params_with_filter_string(index_with_documents):
     )
     assert isinstance(response, dict)
     assert len(response['hits']) == 3
-    assert 'facetsDistribution' not in response
-    assert 'exhaustiveFacetsCount' not in response
+    assert 'facetDistribution' not in response
 
 def test_custom_search_params_with_filter_string_with_space(index_with_documents):
     index = index_with_documents()
@@ -226,8 +223,7 @@ def test_custom_search_params_with_filter_string_with_space(index_with_documents
     )
     assert isinstance(response, dict)
     assert len(response['hits']) == 1
-    assert 'facetsDistribution' not in response
-    assert 'exhaustiveFacetsCount' not in response
+    assert 'facetDistribution' not in response
 
 def test_custom_search_params_with_multiple_filter_string_with_space(index_with_documents):
     index = index_with_documents()
@@ -241,8 +237,7 @@ def test_custom_search_params_with_multiple_filter_string_with_space(index_with_
     )
     assert isinstance(response, dict)
     assert len(response['hits']) == 1
-    assert 'facetsDistribution' not in response
-    assert 'exhaustiveFacetsCount' not in response
+    assert 'facetDistribution' not in response
 
 def test_custom_search_params_with_array_filter_with_space(index_with_documents):
     index = index_with_documents()
@@ -256,8 +251,7 @@ def test_custom_search_params_with_array_filter_with_space(index_with_documents)
     )
     assert isinstance(response, dict)
     assert len(response['hits']) == 1
-    assert 'facetsDistribution' not in response
-    assert 'exhaustiveFacetsCount' not in response
+    assert 'facetDistribution' not in response
 
 def test_custom_search_params_with_mutilple_filter_string(index_with_documents):
     index = index_with_documents()
@@ -271,8 +265,7 @@ def test_custom_search_params_with_mutilple_filter_string(index_with_documents):
     )
     assert isinstance(response, dict)
     assert len(response['hits']) == 2
-    assert 'facetsDistribution' not in response
-    assert 'exhaustiveFacetsCount' not in response
+    assert 'facetDistribution' not in response
     assert response['hits'][0]['title'] == 'Avengers: Infinity War'
 
 def test_custom_search_params_with_filter(index_with_documents):
@@ -287,8 +280,7 @@ def test_custom_search_params_with_filter(index_with_documents):
     )
     assert isinstance(response, dict)
     assert len(response['hits']) == 3
-    assert 'facetsDistribution' not in response
-    assert 'exhaustiveFacetsCount' not in response
+    assert 'facetDistribution' not in response
 
 def test_custom_search_params_with_multiple_filter(index_with_documents):
     index = index_with_documents()
@@ -302,8 +294,7 @@ def test_custom_search_params_with_multiple_filter(index_with_documents):
     )
     assert isinstance(response, dict)
     assert len(response['hits']) == 3
-    assert 'facetsDistribution' not in response
-    assert 'exhaustiveFacetsCount' not in response
+    assert 'facetDistribution' not in response
 
 def test_custom_search_params_with_many_params(index_with_documents):
     index = index_with_documents()
@@ -318,8 +309,7 @@ def test_custom_search_params_with_many_params(index_with_documents):
     )
     assert isinstance(response, dict)
     assert len(response['hits']) == 3
-    assert 'facetsDistribution' not in response
-    assert 'exhaustiveFacetsCount' not in response
+    assert 'facetDistribution' not in response
     assert 'title' in response['hits'][0]
     assert 'poster' in response['hits'][0]
     assert 'overview' not in response['hits'][0]
@@ -347,8 +337,7 @@ def test_custom_search_params_with_sort_string(index_with_documents):
     )
     assert isinstance(response, dict)
     assert len(response['hits']) == 12
-    assert 'facetsDistribution' not in response
-    assert 'exhaustiveFacetsCount' not in response
+    assert 'facetDistribution' not in response
     assert response['hits'][0]['title'] == 'Alita: Battle Angel'
     assert response['hits'][1]['title'] == 'Aquaman'
 
@@ -373,8 +362,7 @@ def test_custom_search_params_with_sort_int(index_with_documents):
     )
     assert isinstance(response, dict)
     assert len(response['hits']) == 12
-    assert 'facetsDistribution' not in response
-    assert 'exhaustiveFacetsCount' not in response
+    assert 'facetDistribution' not in response
     assert response['hits'][0]['title'] == 'Avengers: Infinity War'
     assert response['hits'][1]['title'] == 'Redcon-1'
 
@@ -399,8 +387,7 @@ def test_custom_search_params_with_multiple_sort(index_with_documents):
     )
     assert isinstance(response, dict)
     assert len(response['hits']) == 12
-    assert 'facetsDistribution' not in response
-    assert 'exhaustiveFacetsCount' not in response
+    assert 'facetDistribution' not in response
     assert response['hits'][0]['title'] == 'Alita: Battle Angel'
     assert response['hits'][1]['title'] == 'Aquaman'
 
@@ -408,8 +395,7 @@ def test_phrase_search(index_with_documents):
     response = index_with_documents().search('coco "dumbo"')
     assert isinstance(response, dict)
     assert len(response['hits']) == 1
-    assert 'facetsDistribution' not in response
-    assert 'exhaustiveFacetsCount' not in response
+    assert 'facetDistribution' not in response
     assert 'title' in response['hits'][0]
     assert 'poster' in response['hits'][0]
     assert 'overview' in response['hits'][0]


### PR DESCRIPTION
Breaking because enforces the users to use Meilisearch v0.28.0

- Rename `nbHits` response parameter to `estimatedTotalHits`.
- Delete `exhaustiveNbHits` response parameter.
- Delete `exhaustiveFacetsCount` response parameter.
- `matches` request parameter is renamed `showMatchesPosition`.
- `facetsDistribution` request parameter is renamed `facets`.
- `facetsDistribution` response parameter is renamed `facetDistribution`.