### PR TITLE
Apply key changes

### DIFF
--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -240,13 +240,13 @@ class Client():
             return False
         return True
 
-    def get_key(self, key: str) -> Dict[str, Any]:
+    def get_key(self, key_or_uid: str) -> Dict[str, Any]:
         """Gets information about a specific API key.
 
         Parameters
         ----------
-        key:
-            The key for which to retrieve the information.
+        key_or_uid:
+            The key or the uid for which to retrieve the information.
 
         Returns
         -------
@@ -259,7 +259,7 @@ class Client():
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        return self.http.get(f'{self.config.paths.keys}/{key}')
+        return self.http.get(f'{self.config.paths.keys}/{key_or_uid}')
 
     def get_keys(self) -> Dict[str, Any]:
         """Gets the Meilisearch API keys.
@@ -267,7 +267,7 @@ class Client():
         Returns
         -------
         keys:
-            API keys.
+            Dictionary with limit, offset, total and results a list of dictionaries containing the key information.
             https://docs.meilisearch.com/reference/api/keys.html#get-keys
 
         Raises

--- a/tests/client/test_client_key_meilisearch.py
+++ b/tests/client/test_client_key_meilisearch.py
@@ -31,9 +31,11 @@ def test_create_keys_default(client, test_key_info):
     key = client.create_key(test_key_info)
     assert isinstance(key, dict)
     assert 'key' in key
+    assert 'name' in key
     assert 'actions' in key
     assert 'indexes' in key
     assert key['key'] is not None
+    assert key['name'] is not None
     assert key['expiresAt'] is None
     assert key['createdAt'] is not None
     assert key['updatedAt'] is not None
@@ -43,9 +45,10 @@ def test_create_keys_default(client, test_key_info):
 
 def test_create_keys_with_options(client, test_key_info):
     """Tests the creation of a key with arguments."""
-    key = client.create_key(options={'description': test_key_info['description'], 'actions': test_key_info['actions'], 'indexes': test_key_info['indexes'], 'expiresAt': datetime(2030, 6, 4, 21, 8, 12, 32).isoformat()[:-3]+'Z' })
+    key = client.create_key(options={'description': test_key_info['description'], 'actions': test_key_info['actions'], 'indexes': test_key_info['indexes'], 'uid': '82acc342-d2df-4291-84bd-8400d3f05f06', 'expiresAt': datetime(2030, 6, 4, 21, 8, 12, 32).isoformat()[:-3]+'Z' })
     assert isinstance(key, dict)
     assert key['key'] is not None
+    assert key['name'] is None
     assert key['description'] == test_key_info['description']
     assert key['expiresAt'] is not None
     assert key['createdAt'] is not None
@@ -61,11 +64,11 @@ def test_create_keys_without_actions(client):
 def test_update_keys(client, test_key_info):
     """Tests updating a key."""
     key = client.create_key(test_key_info)
-    assert key['actions'] == test_key_info['actions']
-    update_key = client.update_key(key=key['key'], options={ 'actions': ['search'] })
+    assert key['name'] == test_key_info['name']
+    update_key = client.update_key(key=key['key'], options={ 'name': 'keyTest' })
     assert update_key['key'] is not None
     assert update_key['expiresAt'] is None
-    assert update_key['actions'] == ['search']
+    assert update_key['name'] == 'keyTest'
 
 def test_delete_key(client, test_key):
     """Tests deleting a key."""

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,5 +123,5 @@ def test_key_info(client):
 @fixture(scope='function')
 def get_private_key(client):
     keys = client.get_keys()['results']
-    key = next(x for x in keys if 'Default Search API' in x['description'])
+    key = next(x for x in keys if 'Default Search API' in x['name'])
     return key

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -109,7 +109,7 @@ def test_key(client):
 
 @fixture(scope='function')
 def test_key_info(client):
-    key_info = {'description': 'test', 'actions': ['search'], 'indexes': [common.INDEX_UID], 'expiresAt': None}
+    key_info = {'name': 'testKeyName', 'description': 'test', 'actions': ['search'], 'indexes': [common.INDEX_UID], 'expiresAt': None}
 
     yield key_info
 


### PR DESCRIPTION
# Pull Request

Related to: https://github.com/meilisearch/integration-guides/issues/205

## What does this PR do?

Breaking because enforces the users to use Meilisearch v0.28.0

### Changes

- `PATCH /keys/:uid_or_key` can update **only** `name` and `description` fields.
- [x] Add test for new `:name` attributes
- [x] Add test with `:uid`
- [x] Replace `masterKey` with `apiKey`.