### PR TITLE
Apply indexes changes

### DIFF
--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -90,7 +90,7 @@ class Client():
         Returns
         -------
         indexes:
-            List of Index instances.
+            Dictionary with limit, offset, total and results a list of Index instances.
 
         Raises
         ------

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -93,16 +93,18 @@ class Client():
         """
         response = self.http.get(self.config.paths.index)
 
-        return [
-            Index(
-                self.config,
-                index["uid"],
-                index["primaryKey"],
-                index["createdAt"],
-                index["updatedAt"],
-            )
-            for index in response['results']
-        ]
+        return {
+            'results' : [
+                Index(
+                    self.config,
+                    index["uid"],
+                    index["primaryKey"],
+                    index["createdAt"],
+                    index["updatedAt"],
+                )
+                for index in response['results']
+            ]
+        }
 
     def get_raw_indexes(self) -> List[Dict[str, Any]]:
         """Get all indexes in dictionary format.

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -79,13 +79,13 @@ class Client():
 
         return self.http.delete(f'{self.config.paths.index}/{uid}')
 
-    def get_indexes(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, List[Index]]:
+    def get_indexes(self, indexes_query: Optional[Dict[str, Any]] = None) -> Dict[str, List[Index]]:
         """Get all indexes.
 
         Parameters
         ----------
-        parameters (optional):
-            parameters accepted by the get indexes route: https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
+        indexes_query (optional):
+            indexes_query accepted by the get indexes route: https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
 
         Returns
         -------
@@ -97,10 +97,10 @@ class Client():
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        if parameters is None:
-            parameters = {}
+        if indexes_query is None:
+            indexes_query = {}
         response = self.http.get(
-            f'{self.config.paths.index}?{parse.urlencode(parameters)}'
+            f'{self.config.paths.index}?{parse.urlencode(indexes_query)}'
         )
         response['results'] = [
                 Index(

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -101,7 +101,7 @@ class Client():
                 index["createdAt"],
                 index["updatedAt"],
             )
-            for index in response
+            for index in response['results']
         ]
 
     def get_raw_indexes(self) -> List[Dict[str, Any]]:

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -125,7 +125,7 @@ class Client():
         Returns
         -------
         indexes:
-            List of indexes in dictionary format. (e.g [{ 'uid': 'movies' 'primaryKey': 'objectID' }])
+            Dictionary with limit, offset, total and results a list of indexes in dictionary format. (e.g [{ 'uid': 'movies' 'primaryKey': 'objectID' }])
 
         Raises
         ------

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -79,13 +79,13 @@ class Client():
 
         return self.http.delete(f'{self.config.paths.index}/{uid}')
 
-    def get_indexes(self, resource_query: Optional[Dict[str, Any]] = None) -> Dict[str, List[Index]]:
+    def get_indexes(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, List[Index]]:
         """Get all indexes.
 
         Parameters
         ----------
-        resource_query (optional):
-            resource_query accepted by the get indexes route: https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
+        parameters (optional):
+            parameters accepted by the get indexes route: https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
 
         Returns
         -------
@@ -97,10 +97,10 @@ class Client():
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        if resource_query is None:
-            resource_query = {}
+        if parameters is None:
+            parameters = {}
         response = self.http.get(
-            f'{self.config.paths.index}?{parse.urlencode(resource_query)}'
+            f'{self.config.paths.index}?{parse.urlencode(parameters)}'
         )
         response['results'] = [
                 Index(
@@ -114,13 +114,13 @@ class Client():
             ]
         return response
 
-    def get_raw_indexes(self, resource_query: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+    def get_raw_indexes(self, parameters: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
         """Get all indexes in dictionary format.
 
         Parameters
         ----------
-        resource_query (optional):
-            resource_query accepted by the get indexes route: https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
+        parameters (optional):
+            parameters accepted by the get indexes route: https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
 
         Returns
         -------
@@ -132,10 +132,10 @@ class Client():
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        if resource_query is None:
-            resource_query = {}
+        if parameters is None:
+            parameters = {}
         return self.http.get(
-            f'{self.config.paths.index}?{parse.urlencode(resource_query)}'
+            f'{self.config.paths.index}?{parse.urlencode(parameters)}'
         )
 
     def get_index(self, uid: str) -> Index:

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -3,6 +3,7 @@ import hashlib
 import hmac
 import json
 import datetime
+from urllib import parse
 from typing import Any, Dict, List, Optional, Union
 from meilisearch.index import Index
 from meilisearch.config import Config
@@ -78,8 +79,13 @@ class Client():
 
         return self.http.delete(f'{self.config.paths.index}/{uid}')
 
-    def get_indexes(self) -> List[Index]:
+    def get_indexes(self, resource_query: Optional[Dict[str, Any]] = None) -> Dict[str, List[Index]]:
         """Get all indexes.
+
+        Parameters
+        ----------
+        resource_query (optional):
+            resource_query accepted by the get indexes route: https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
 
         Returns
         -------
@@ -91,10 +97,12 @@ class Client():
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        response = self.http.get(self.config.paths.index)
-
-        return {
-            'results' : [
+        if resource_query is None:
+            resource_query = {}
+        response = self.http.get(
+            f'{self.config.paths.index}?{parse.urlencode(resource_query)}'
+        )
+        response['results'] = [
                 Index(
                     self.config,
                     index["uid"],
@@ -104,10 +112,15 @@ class Client():
                 )
                 for index in response['results']
             ]
-        }
+        return response
 
-    def get_raw_indexes(self) -> List[Dict[str, Any]]:
+    def get_raw_indexes(self, resource_query: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
         """Get all indexes in dictionary format.
+
+        Parameters
+        ----------
+        resource_query (optional):
+            resource_query accepted by the get indexes route: https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
 
         Returns
         -------
@@ -119,7 +132,11 @@ class Client():
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        return self.http.get(self.config.paths.index)
+        if resource_query is None:
+            resource_query = {}
+        return self.http.get(
+            f'{self.config.paths.index}?{parse.urlencode(resource_query)}'
+        )
 
     def get_index(self, uid: str) -> Index:
         """Get the index.

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -79,13 +79,13 @@ class Client():
 
         return self.http.delete(f'{self.config.paths.index}/{uid}')
 
-    def get_indexes(self, indexes_query: Optional[Dict[str, Any]] = None) -> Dict[str, List[Index]]:
+    def get_indexes(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, List[Index]]:
         """Get all indexes.
 
         Parameters
         ----------
-        indexes_query (optional):
-            indexes_query accepted by the get indexes route: https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
+        parameters (optional):
+            parameters accepted by the get indexes route: https://docs.meilisearch.com/reference/api/indexes.html#list-all-indexes
 
         Returns
         -------
@@ -97,10 +97,10 @@ class Client():
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        if indexes_query is None:
-            indexes_query = {}
+        if parameters is None:
+            parameters = {}
         response = self.http.get(
-            f'{self.config.paths.index}?{parse.urlencode(indexes_query)}'
+            f'{self.config.paths.index}?{parse.urlencode(parameters)}'
         )
         response['results'] = [
                 Index(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,7 +21,7 @@ def clear_indexes(client):
     yield
     # Deletes all the indexes in the Meilisearch instance.
     indexes = client.get_indexes()
-    for index in indexes:
+    for index in indexes['results']:
         task = client.index(index.uid).delete()
         client.wait_for_task(task['uid'])
 

--- a/tests/index/test_index.py
+++ b/tests/index/test_index.py
@@ -40,7 +40,7 @@ def test_create_index_with_uid_in_options(client):
 def test_get_indexes(client):
     """Tests getting all indexes."""
     response = client.get_indexes()
-    uids = [index.uid for index in response]
+    uids = [index.uid for index in response['results']]
     assert isinstance(response, list)
     assert common.INDEX_UID in uids
     assert common.INDEX_UID2 in uids
@@ -165,7 +165,7 @@ def test_delete_index_by_client(client):
     client.wait_for_task(response['uid'])
     with pytest.raises(Exception):
         client.get_index(uid=common.INDEX_UID3)
-    assert len(client.get_indexes()) == 0
+    assert len(client.get_indexes()['results']) == 0
 
 @pytest.mark.usefixtures("indexes_sample")
 def test_delete(client):

--- a/tests/index/test_index.py
+++ b/tests/index/test_index.py
@@ -48,9 +48,9 @@ def test_get_indexes(client):
     assert len(response['results']) == 3
 
 @pytest.mark.usefixtures("indexes_sample")
-def test_get_indexes_with_resource_query(client):
+def test_get_indexes_with_parameters(client):
     """Tests getting all indexes."""
-    response = client.get_indexes(resource_query={'limit':1, 'offset': 1})
+    response = client.get_indexes(parameters={'limit':1, 'offset': 1})
     assert len(response['results']) == 1
 
 @pytest.mark.usefixtures("indexes_sample")
@@ -64,8 +64,8 @@ def test_get_raw_indexes(client):
     assert len(response['results']) == 3
 
 @pytest.mark.usefixtures("indexes_sample")
-def test_get_raw_indexeswith_resource_query(client):
-    response = client.get_raw_indexes(resource_query={'limit':1, 'offset': 1})
+def test_get_raw_indexeswith_parameters(client):
+    response = client.get_raw_indexes(parameters={'limit':1, 'offset': 1})
     assert isinstance(response['results'], list)
     assert len(response['results']) == 1
 

--- a/tests/index/test_index.py
+++ b/tests/index/test_index.py
@@ -49,7 +49,7 @@ def test_get_indexes(client):
 
 @pytest.mark.usefixtures("indexes_sample")
 def test_get_raw_indexes(client):
-    response = client.get_raw_indexes()
+    response = client.get_raw_indexes()['results']
     uids = [index['uid'] for index in response]
     assert isinstance(response, list)
     assert common.INDEX_UID in uids

--- a/tests/index/test_index.py
+++ b/tests/index/test_index.py
@@ -41,21 +41,33 @@ def test_get_indexes(client):
     """Tests getting all indexes."""
     response = client.get_indexes()
     uids = [index.uid for index in response['results']]
-    assert isinstance(response, list)
+    assert isinstance(response['results'], list)
     assert common.INDEX_UID in uids
     assert common.INDEX_UID2 in uids
     assert common.INDEX_UID3 in uids
-    assert len(response) == 3
+    assert len(response['results']) == 3
+
+@pytest.mark.usefixtures("indexes_sample")
+def test_get_indexes_with_resource_query(client):
+    """Tests getting all indexes."""
+    response = client.get_indexes(resource_query={'limit':1, 'offset': 1})
+    assert len(response['results']) == 1
 
 @pytest.mark.usefixtures("indexes_sample")
 def test_get_raw_indexes(client):
-    response = client.get_raw_indexes()['results']
-    uids = [index['uid'] for index in response]
-    assert isinstance(response, list)
+    response = client.get_raw_indexes()
+    uids = [index['uid'] for index in response['results']]
+    assert isinstance(response['results'], list)
     assert common.INDEX_UID in uids
     assert common.INDEX_UID2 in uids
     assert common.INDEX_UID3 in uids
-    assert len(response) == 3
+    assert len(response['results']) == 3
+
+@pytest.mark.usefixtures("indexes_sample")
+def test_get_raw_indexeswith_resource_query(client):
+    response = client.get_raw_indexes(resource_query={'limit':1, 'offset': 1})
+    assert isinstance(response['results'], list)
+    assert len(response['results']) == 1
 
 def test_index_with_any_uid(client):
     index = client.index('anyUID')


### PR DESCRIPTION
# Pull Request

Related to: https://github.com/meilisearch/meilisearch/issues/2373

## What does this PR do?

### Changes

- [x] `client.get_indexes` accept pagination metadata, added limit (default: 20), offset (default: 0), total.
- [x] Wrap the indexes objects in a `results` key.

```python
client.get_indexes()
```

returns for example
```python
{
   results: [ Index(uid: "movies" ) ]
}
```

```python
client.get_indexes()
```

returns for example

```python
{
   results: [ { uid: "movies" ... } ]
}
```

