### PR TITLE
Apply documents changes

### DIFF
--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -261,13 +261,13 @@ class Index():
             f'{self.config.paths.index}/{self.uid}/{self.config.paths.document}/{document_id}'
         )
 
-    def get_documents(self, resource_query: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+    def get_documents(self, parameters: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
         """Get a set of documents from the index.
 
         Parameters
         ----------
-        resource_query (optional):
-            resource_query accepted by the get documents route: https://docs.meilisearch.com/reference/api/documents.html#get-documents
+        parameters (optional):
+            parameters accepted by the get documents route: https://docs.meilisearch.com/reference/api/documents.html#get-documents
 
         Returns
         -------
@@ -279,10 +279,10 @@ class Index():
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        if resource_query is None:
-            resource_query = {}
+        if parameters is None:
+            parameters = {}
         return self.http.get(
-            f'{self.config.paths.index}/{self.uid}/{self.config.paths.document}?{parse.urlencode(resource_query)}'
+            f'{self.config.paths.index}/{self.uid}/{self.config.paths.document}?{parse.urlencode(parameters)}'
         )
 
     def add_documents(

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -261,13 +261,13 @@ class Index():
             f'{self.config.paths.index}/{self.uid}/{self.config.paths.document}/{document_id}'
         )
 
-    def get_documents(self, resourceQuery: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+    def get_documents(self, resource_query: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
         """Get a set of documents from the index.
 
         Parameters
         ----------
-        resourceQuery (optional):
-            resourceQuery accepted by the get documents route: https://docs.meilisearch.com/reference/api/documents.html#get-documents
+        resource_query (optional):
+            resource_query accepted by the get documents route: https://docs.meilisearch.com/reference/api/documents.html#get-documents
 
         Returns
         -------
@@ -279,10 +279,10 @@ class Index():
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        if resourceQuery is None:
-            resourceQuery = {}
+        if resource_query is None:
+            resource_query = {}
         return self.http.get(
-            f'{self.config.paths.index}/{self.uid}/{self.config.paths.document}?{parse.urlencode(resourceQuery)}'
+            f'{self.config.paths.index}/{self.uid}/{self.config.paths.document}?{parse.urlencode(resource_query)}'
         )
 
     def add_documents(

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -272,7 +272,7 @@ class Index():
         Returns
         -------
         document:
-            List of dictionaries containing the documents information.
+            Dictionary with limit, offset, total and results a list of dictionaries containing the documents information.
 
         Raises
         ------

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -261,13 +261,13 @@ class Index():
             f'{self.config.paths.index}/{self.uid}/{self.config.paths.document}/{document_id}'
         )
 
-    def get_documents(self, parameters: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+    def get_documents(self, resourceQuery: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
         """Get a set of documents from the index.
 
         Parameters
         ----------
-        parameters (optional):
-            parameters accepted by the get documents route: https://docs.meilisearch.com/reference/api/documents.html#get-all-documents
+        resourceQuery (optional):
+            resourceQuery accepted by the get documents route: https://docs.meilisearch.com/reference/api/documents.html#get-documents
 
         Returns
         -------
@@ -279,10 +279,10 @@ class Index():
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        if parameters is None:
-            parameters = {}
+        if resourceQuery is None:
+            resourceQuery = {}
         return self.http.get(
-            f'{self.config.paths.index}/{self.uid}/{self.config.paths.document}?{parse.urlencode(parameters)}'
+            f'{self.config.paths.index}/{self.uid}/{self.config.paths.document}?{parse.urlencode(resourceQuery)}'
         )
 
     def add_documents(

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -261,13 +261,13 @@ class Index():
             f'{self.config.paths.index}/{self.uid}/{self.config.paths.document}/{document_id}'
         )
 
-    def get_documents(self, documents_query: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+    def get_documents(self, parameters: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
         """Get a set of documents from the index.
 
         Parameters
         ----------
-        documents_query (optional):
-            documents_query accepted by the get documents route: https://docs.meilisearch.com/reference/api/documents.html#get-documents
+        parameters (optional):
+            parameters accepted by the get documents route: https://docs.meilisearch.com/reference/api/documents.html#get-documents
 
         Returns
         -------
@@ -279,10 +279,10 @@ class Index():
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        if documents_query is None:
-            documents_query = {}
+        if parameters is None:
+            parameters = {}
         return self.http.get(
-            f'{self.config.paths.index}/{self.uid}/{self.config.paths.document}?{parse.urlencode(documents_query)}'
+            f'{self.config.paths.index}/{self.uid}/{self.config.paths.document}?{parse.urlencode(parameters)}'
         )
 
     def add_documents(

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -261,13 +261,13 @@ class Index():
             f'{self.config.paths.index}/{self.uid}/{self.config.paths.document}/{document_id}'
         )
 
-    def get_documents(self, parameters: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
+    def get_documents(self, documents_query: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
         """Get a set of documents from the index.
 
         Parameters
         ----------
-        parameters (optional):
-            parameters accepted by the get documents route: https://docs.meilisearch.com/reference/api/documents.html#get-documents
+        documents_query (optional):
+            documents_query accepted by the get documents route: https://docs.meilisearch.com/reference/api/documents.html#get-documents
 
         Returns
         -------
@@ -279,10 +279,10 @@ class Index():
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        if parameters is None:
-            parameters = {}
+        if documents_query is None:
+            documents_query = {}
         return self.http.get(
-            f'{self.config.paths.index}/{self.uid}/{self.config.paths.document}?{parse.urlencode(parameters)}'
+            f'{self.config.paths.index}/{self.uid}/{self.config.paths.document}?{parse.urlencode(documents_query)}'
         )
 
     def add_documents(

--- a/tests/index/test_index_document_meilisearch.py
+++ b/tests/index/test_index_document_meilisearch.py
@@ -8,8 +8,8 @@ import pytest
 def test_get_documents_default(empty_index):
     """Tests getting documents on a clean index."""
     response = empty_index().get_documents()
-    assert isinstance(response, list)
-    assert response == []
+    assert isinstance(response['results'], list)
+    assert response['results'] == []
 
 def test_add_documents(empty_index, small_movies):
     """Tests adding new documents to a clean index."""
@@ -60,38 +60,38 @@ def test_get_document_inexistent(empty_index):
 def test_get_documents_populated(index_with_documents):
     """Tests getting documents from a populated index."""
     response = index_with_documents().get_documents()
-    assert isinstance(response, list)
-    assert len(response) == 20
+    assert isinstance(response['results'], list)
+    assert len(response['results']) == 20
 
 def test_get_documents_offset_optional_params(index_with_documents):
     """Tests getting documents from a populated index with optional parameters."""
     index = index_with_documents()
     response = index.get_documents()
-    assert isinstance(response, list)
-    assert len(response) == 20
+    assert isinstance(response['results'], list)
+    assert len(response['results']) == 20
     response_offset_limit = index.get_documents({
         'limit': 3,
         'offset': 1,
-        'attributesToRetrieve': 'title'
+        'fields': 'title'
     })
-    assert len(response_offset_limit) == 3
-    assert response_offset_limit[0]['title'] == response[1]['title']
+    assert len(response_offset_limit['results']) == 3
+    assert response_offset_limit['results'][0]['title'] == response['results'][1]['title']
 
 def test_update_documents(index_with_documents, small_movies):
     """Tests updating a single document and a set of documents."""
     index = index_with_documents()
     response = index.get_documents()
-    response[0]['title'] = 'Some title'
-    update = index.update_documents([response[0]])
+    response['results'][0]['title'] = 'Some title'
+    update = index.update_documents([response['results'][0]])
     assert isinstance(update, dict)
     assert 'uid' in update
     index.wait_for_task(update['uid'])
     response = index.get_documents()
-    assert response[0]['title'] == 'Some title'
+    assert response['results'][0]['title'] == 'Some title'
     update = index.update_documents(small_movies)
     index.wait_for_task(update['uid'])
     response = index.get_documents()
-    assert response[0]['title'] != 'Some title'
+    assert response['results'][0]['title'] != 'Some title'
 
 @pytest.mark.parametrize('batch_size', [2, 3, 1000])
 @pytest.mark.parametrize(
@@ -145,8 +145,8 @@ def test_delete_all_documents(index_with_documents):
     assert 'uid' in response
     index.wait_for_task(response['uid'])
     response = index.get_documents()
-    assert isinstance(response, list)
-    assert response == []
+    assert isinstance(response['results'], list)
+    assert response['results'] == []
 
 def test_add_documents_csv(empty_index, songs_csv):
     """Tests adding new documents to a clean index."""

--- a/tests/index/test_index_document_meilisearch.py
+++ b/tests/index/test_index_document_meilisearch.py
@@ -36,7 +36,6 @@ def test_add_documents_in_batches(
     response = index.add_documents_in_batches(small_movies, batch_size, primary_key)
     assert ceil(len(small_movies) / batch_size) == len(response)
 
-    print(response, '\n', '\n')
     for r in response:
         assert 'uid' in r
         update = index.wait_for_task(r['uid'])


### PR DESCRIPTION
# Pull Request

Related to: https://github.com/meilisearch/integration-guides/issues/205

## What does this PR do?

Breaking because enforces the users to use Meilisearch v0.28.0

- `GET /documents/:uid`, `GET /documents` Add the possibility to reduce the body payload by using a query parameter called `fields` (previously called `attributesToRetrieve`), check the issue and the spec for the entire behavior.
- The documents objects in now return wrap in a `results`
- [x] Adapt resource_query naming following all the routes
- [x] Fix tests