### PR TITLE
Add uid to the generateTenantToken method

### DIFF
--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -1,3 +1,4 @@
+import re
 import base64
 import hashlib
 import hmac
@@ -5,6 +6,7 @@ import json
 import datetime
 from urllib import parse
 from typing import Any, Dict, List, Optional, Union
+from xmlrpc.client import Boolean
 from meilisearch.index import Index
 from meilisearch.config import Config
 from meilisearch.task import get_task, get_tasks, wait_for_task
@@ -473,6 +475,7 @@ class Client():
 
     def generate_tenant_token(
         self,
+        uid: str,
         search_rules: Union[Dict[str, Any], List[str]],
         *,
         expires_at: Optional[datetime.datetime] = None,
@@ -482,6 +485,8 @@ class Client():
 
         Parameters
         ----------
+        uid:
+            The uid of the API key used as issuer of the token.
         search_rules:
             A Dictionary or list of string which contains the rules to be enforced at search time for all or specific
             accessible indexes for the signing API Key.
@@ -501,6 +506,8 @@ class Client():
         # Validate all fields
         if api_key == '' or api_key is None and self.config.api_key is None:
             raise Exception('An api key is required in the client or should be passed as an argument.')
+        if uid == '' or uid is None or self._valid_uuid(uid) is False:
+            raise Exception('An uid is required and must comply to the uuid4 format.')
         if not search_rules or search_rules == ['']:
             raise Exception('The search_rules field is mandatory and should be defined.')
         if expires_at and expires_at < datetime.datetime.utcnow():
@@ -516,7 +523,7 @@ class Client():
 
         # Add the required fields to the payload
         payload = {
-            'apiKeyPrefix': api_key[0:8],
+            'apiKeyUid': uid,
             'searchRules': search_rules,
             'exp': int(datetime.datetime.timestamp(expires_at)) if expires_at is not None else None
         }
@@ -542,3 +549,11 @@ class Client():
         data: bytes
     ) -> str:
         return base64.urlsafe_b64encode(data).decode('utf-8').replace('=','')
+
+    @staticmethod
+    def _valid_uuid(
+        uuid: str
+    ) -> bool:
+        uuid4hex = re.compile(r'^[a-f0-9]{8}-?[a-f0-9]{4}-?4[a-f0-9]{3}-?[89ab][a-f0-9]{3}-?[a-f0-9]{12}', re.I)
+        match = uuid4hex.match(uuid)
+        return bool(match)

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -475,7 +475,7 @@ class Client():
 
     def generate_tenant_token(
         self,
-        uid: str,
+        api_key_uid: str,
         search_rules: Union[Dict[str, Any], List[str]],
         *,
         expires_at: Optional[datetime.datetime] = None,
@@ -485,7 +485,7 @@ class Client():
 
         Parameters
         ----------
-        uid:
+        api_key_uid:
             The uid of the API key used as issuer of the token.
         search_rules:
             A Dictionary or list of string which contains the rules to be enforced at search time for all or specific
@@ -506,7 +506,7 @@ class Client():
         # Validate all fields
         if api_key == '' or api_key is None and self.config.api_key is None:
             raise Exception('An api key is required in the client or should be passed as an argument.')
-        if uid == '' or uid is None or self._valid_uuid(uid) is False:
+        if api_key_uid == '' or api_key_uid is None or self._valid_uuid(api_key_uid) is False:
             raise Exception('An uid is required and must comply to the uuid4 format.')
         if not search_rules or search_rules == ['']:
             raise Exception('The search_rules field is mandatory and should be defined.')
@@ -523,7 +523,7 @@ class Client():
 
         # Add the required fields to the payload
         payload = {
-            'apiKeyUid': uid,
+            'apiKeyUid': api_key_uid,
             'searchRules': search_rules,
             'exp': int(datetime.datetime.timestamp(expires_at)) if expires_at is not None else None
         }

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -72,7 +72,7 @@ def test_generate_tenant_token_without_search_rules_in_list(get_private_key):
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
     with pytest.raises(Exception):
-        client.generate_tenant_token(uid=get_private_key['uid'], search_rules=[])
+        client.generate_tenant_token(api_key_uid=get_private_key['uid'], search_rules=[])
 
 def test_generate_tenant_token_without_search_rules_in_dict(get_private_key):
     """Tests create a tenant token without search rules."""

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -65,7 +65,7 @@ def test_generate_tenant_token_with_empty_search_rules_in_list(get_private_key):
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
     with pytest.raises(Exception):
-        client.generate_tenant_token(uid=get_private_key['uid'], search_rules=[''])
+        client.generate_tenant_token(api_key_uid=get_private_key['uid'], search_rules=[''])
 
 def test_generate_tenant_token_without_search_rules_in_list(get_private_key):
     """Tests create a tenant token without search rules."""

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -12,7 +12,7 @@ def test_generate_tenant_token_with_search_rules(get_private_key, index_with_doc
     index_with_documents()
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
-    token = client.generate_tenant_token(search_rules=["*"])
+    token = client.generate_tenant_token(uid=get_private_key['uid'], search_rules=["*"])
 
     token_client = meilisearch.Client(BASE_URL, token)
     response = token_client.index('indexUID').search('', {
@@ -28,7 +28,7 @@ def test_generate_tenant_token_with_search_rules_on_one_index(get_private_key, e
     empty_index('tenant_token')
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
-    token = client.generate_tenant_token(search_rules=['indexUID'])
+    token = client.generate_tenant_token(uid=get_private_key['uid'], search_rules=['indexUID'])
 
     token_client = meilisearch.Client(BASE_URL, token)
     response = token_client.index('indexUID').search('')
@@ -40,7 +40,7 @@ def test_generate_tenant_token_with_search_rules_on_one_index(get_private_key, e
 def test_generate_tenant_token_with_api_key(client, get_private_key, empty_index):
     """Tests create a tenant token with search rules and an api key."""
     empty_index()
-    token = client.generate_tenant_token(search_rules=["*"], api_key=get_private_key['key'])
+    token = client.generate_tenant_token(uid=get_private_key['uid'], search_rules=["*"], api_key=get_private_key['key'])
 
     token_client = meilisearch.Client(BASE_URL, token)
     response = token_client.index('indexUID').search('')
@@ -53,7 +53,7 @@ def test_generate_tenant_token_with_expires_at(client, get_private_key, empty_in
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
     tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
 
-    token = client.generate_tenant_token(search_rules=["*"], expires_at=tomorrow)
+    token = client.generate_tenant_token(uid=get_private_key['uid'], search_rules=["*"], expires_at=tomorrow)
 
     token_client = meilisearch.Client(BASE_URL, token)
     response = token_client.index('indexUID').search('')
@@ -65,28 +65,28 @@ def test_generate_tenant_token_with_empty_search_rules_in_list(get_private_key):
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
     with pytest.raises(Exception):
-        client.generate_tenant_token(search_rules=[''])
+        client.generate_tenant_token(uid=get_private_key['uid'], search_rules=[''])
 
 def test_generate_tenant_token_without_search_rules_in_list(get_private_key):
     """Tests create a tenant token without search rules."""
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
     with pytest.raises(Exception):
-        client.generate_tenant_token(search_rules=[])
+        client.generate_tenant_token(uid=get_private_key['uid'], search_rules=[])
 
 def test_generate_tenant_token_without_search_rules_in_dict(get_private_key):
     """Tests create a tenant token without search rules."""
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
     with pytest.raises(Exception):
-        client.generate_tenant_token(search_rules={})
+        client.generate_tenant_token(uid=get_private_key['uid'], search_rules={})
 
 def test_generate_tenant_token_with_empty_search_rules_in_dict(get_private_key):
     """Tests create a tenant token without search rules."""
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
     with pytest.raises(Exception):
-        client.generate_tenant_token(search_rules={''})
+        client.generate_tenant_token(uid=get_private_key['uid'], search_rules={''})
 
 def test_generate_tenant_token_with_bad_expires_at(client, get_private_key):
     """Tests create a tenant token with a bad expires at."""
@@ -95,7 +95,7 @@ def test_generate_tenant_token_with_bad_expires_at(client, get_private_key):
     yesterday = datetime.datetime.utcnow() + datetime.timedelta(days=-1)
 
     with pytest.raises(Exception):
-        client.generate_tenant_token(search_rules=["*"], expires_at=yesterday)
+        client.generate_tenant_token(uid=get_private_key['uid'], search_rules=["*"], expires_at=yesterday)
 
 def test_generate_tenant_token_with_no_api_key(client):
     """Tests create a tenant token with no api key."""
@@ -104,3 +104,9 @@ def test_generate_tenant_token_with_no_api_key(client):
     with pytest.raises(Exception):
         client.generate_tenant_token(search_rules=["*"])
 
+def test_generate_tenant_token_with_no_uid(client, get_private_key):
+    """Tests create a tenant token with no uid."""
+    client = meilisearch.Client(BASE_URL, get_private_key['key'])
+
+    with pytest.raises(Exception):
+        client.generate_tenant_token(uid=None, search_rules=["*"])

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -109,4 +109,4 @@ def test_generate_tenant_token_with_no_uid(client, get_private_key):
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
     with pytest.raises(Exception):
-        client.generate_tenant_token(uid=None, search_rules=["*"])
+        client.generate_tenant_token(api_key_uid=None, search_rules=["*"])

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -53,7 +53,7 @@ def test_generate_tenant_token_with_expires_at(client, get_private_key, empty_in
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
     tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
 
-    token = client.generate_tenant_token(uid=get_private_key['uid'], search_rules=["*"], expires_at=tomorrow)
+    token = client.generate_tenant_token(api_key_uid=get_private_key['uid'], search_rules=["*"], expires_at=tomorrow)
 
     token_client = meilisearch.Client(BASE_URL, token)
     response = token_client.index('indexUID').search('')

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -79,7 +79,7 @@ def test_generate_tenant_token_without_search_rules_in_dict(get_private_key):
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
     with pytest.raises(Exception):
-        client.generate_tenant_token(uid=get_private_key['uid'], search_rules={})
+        client.generate_tenant_token(api_key_uid=get_private_key['uid'], search_rules={})
 
 def test_generate_tenant_token_with_empty_search_rules_in_dict(get_private_key):
     """Tests create a tenant token without search rules."""

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -12,7 +12,7 @@ def test_generate_tenant_token_with_search_rules(get_private_key, index_with_doc
     index_with_documents()
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
-    token = client.generate_tenant_token(uid=get_private_key['uid'], search_rules=["*"])
+    token = client.generate_tenant_token(api_key_uid=get_private_key['uid'], search_rules=["*"])
 
     token_client = meilisearch.Client(BASE_URL, token)
     response = token_client.index('indexUID').search('', {

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -28,7 +28,7 @@ def test_generate_tenant_token_with_search_rules_on_one_index(get_private_key, e
     empty_index('tenant_token')
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
-    token = client.generate_tenant_token(uid=get_private_key['uid'], search_rules=['indexUID'])
+    token = client.generate_tenant_token(api_key_uid=get_private_key['uid'], search_rules=['indexUID'])
 
     token_client = meilisearch.Client(BASE_URL, token)
     response = token_client.index('indexUID').search('')

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -95,7 +95,7 @@ def test_generate_tenant_token_with_bad_expires_at(client, get_private_key):
     yesterday = datetime.datetime.utcnow() + datetime.timedelta(days=-1)
 
     with pytest.raises(Exception):
-        client.generate_tenant_token(uid=get_private_key['uid'], search_rules=["*"], expires_at=yesterday)
+        client.generate_tenant_token(api_key_uid=get_private_key['uid'], search_rules=["*"], expires_at=yesterday)
 
 def test_generate_tenant_token_with_no_api_key(client):
     """Tests create a tenant token with no api key."""

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -86,7 +86,7 @@ def test_generate_tenant_token_with_empty_search_rules_in_dict(get_private_key):
     client = meilisearch.Client(BASE_URL, get_private_key['key'])
 
     with pytest.raises(Exception):
-        client.generate_tenant_token(uid=get_private_key['uid'], search_rules={''})
+        client.generate_tenant_token(api_key_uid=get_private_key['uid'], search_rules={''})
 
 def test_generate_tenant_token_with_bad_expires_at(client, get_private_key):
     """Tests create a tenant token with a bad expires at."""

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -40,7 +40,7 @@ def test_generate_tenant_token_with_search_rules_on_one_index(get_private_key, e
 def test_generate_tenant_token_with_api_key(client, get_private_key, empty_index):
     """Tests create a tenant token with search rules and an api key."""
     empty_index()
-    token = client.generate_tenant_token(uid=get_private_key['uid'], search_rules=["*"], api_key=get_private_key['key'])
+    token = client.generate_tenant_token(api_key_uid=get_private_key['uid'], search_rules=["*"], api_key=get_private_key['key'])
 
     token_client = meilisearch.Client(BASE_URL, token)
     response = token_client.index('indexUID').search('')


### PR DESCRIPTION
as per the [spec](https://github.com/meilisearch/specifications/pull/148/files#diff-7b1a49daa5acb02c131aff3eb5fabb81c7e7c3d1b95adb60c4bf70cadcb488d4)


- [x] apiKeyPrefix claim is now named apiKeyUid and expects the uid of the signing API key as a value.
