### PR TITLE
Add keys parameter in missing routes v0.28.x

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -589,6 +589,7 @@ authorization_header_1: |-
   client = Client('http://127.0.0.1:7700', 'masterKey')
   client.get_keys()
 tenant_token_guide_generate_sdk_1: |-
+  uid = '85c3c2f9-bdd6-41f1-abd8-11fcf80e0f76';
   api_key = 'B5KdX2MY2jV6EXfUs6scSfmC...'
   expires_at = datetime(2025, 12, 20)
   search_rules = {
@@ -596,7 +597,7 @@ tenant_token_guide_generate_sdk_1: |-
       'filter': 'user_id = 1'
     }
   }
-  token = client.generate_tenant_token(search_rules=search_rules, api_key=api_key, expires_at=expires_at)
+  token = client.generate_tenant_token(api_key_uid=uid, search_rules=search_rules, api_key=api_key, expires_at=expires_at)
 tenant_token_guide_search_sdk_1: |-
   front_end_client = Client('http://127.0.0.1:7700', token)
   front_end_client.index('patient_medical_records').search('blood test')

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -6,7 +6,6 @@ import json
 import datetime
 from urllib import parse
 from typing import Any, Dict, List, Optional, Union
-from xmlrpc.client import Boolean
 from meilisearch.index import Index
 from meilisearch.config import Config
 from meilisearch.task import get_task, get_tasks, wait_for_task
@@ -309,7 +308,7 @@ class Client():
 
     def update_key(
         self,
-        key: str,
+        key_or_uid: str,
         options: Dict[str, Any]
     ) -> Dict[str, Any]:
         """Update an API key.
@@ -318,7 +317,7 @@ class Client():
 
         ----------
         key:
-            The key for which to update the information.
+            The key or the uid of the key for which to update the information.
         options:
             The information to use in creating the key (ex: { 'description': 'Search Key', 'expiresAt': '22-01-01' }). Note that if an
             expires_at value is included it should be in UTC time.
@@ -334,16 +333,16 @@ class Client():
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        url = f'{self.config.paths.keys}/{key}'
+        url = f'{self.config.paths.keys}/{key_or_uid}'
         return self.http.patch(url, options)
 
-    def delete_key(self, key: str) -> Dict[str, int]:
+    def delete_key(self, key_or_uid: str) -> Dict[str, int]:
         """Deletes an API key.
 
         Parameters
         ----------
         key:
-            The key to delete.
+            The key or the uid of the key to delete.
 
         Returns
         -------
@@ -356,7 +355,7 @@ class Client():
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        return self.http.delete(f'{self.config.paths.keys}/{key}')
+        return self.http.delete(f'{self.config.paths.keys}/{key_or_uid}')
 
     def get_version(self) -> Dict[str, str]:
         """Get version Meilisearch


### PR DESCRIPTION
- `delete_key` and `update_key` are also able to be recognizable by either the `uid` or the `key`.