### PR TITLE
Apply key pagination parameters

### DIFF
--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -262,8 +262,13 @@ class Client():
         """
         return self.http.get(f'{self.config.paths.keys}/{key_or_uid}')
 
-    def get_keys(self) -> Dict[str, Any]:
+    def get_keys(self, parameters: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         """Gets the Meilisearch API keys.
+
+        Parameters
+        ----------
+        parameters (optional):
+            parameters accepted by the get keys route: https://docs.meilisearch.com/reference/api/keys.html#get-all-keys
 
         Returns
         -------
@@ -276,7 +281,11 @@ class Client():
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        return self.http.get(self.config.paths.keys)
+        if parameters is None:
+            parameters = {}
+        return self.http.get(
+            f'{self.config.paths.keys}?{parse.urlencode(parameters)}'
+        )
 
     def create_key(
         self,

--- a/tests/client/test_client_key_meilisearch.py
+++ b/tests/client/test_client_key_meilisearch.py
@@ -13,6 +13,12 @@ def test_get_keys_default(client):
     assert keys['results'][0]['key'] is not None
     assert keys['results'][1]['key'] is not None
 
+def test_get_keys_with_parameters(client):
+    """Tests if search and admin keys have been generated and can be retrieved."""
+    keys = client.get_keys({'limit': 1})
+    assert isinstance(keys, dict)
+    assert len(keys['results']) == 1
+
 def test_get_key(client, test_key):
     """Tests if a key can be retrieved."""
     key = client.get_key(test_key['key'])
@@ -65,7 +71,7 @@ def test_update_keys(client, test_key_info):
     """Tests updating a key."""
     key = client.create_key(test_key_info)
     assert key['name'] == test_key_info['name']
-    update_key = client.update_key(key=key['key'], options={ 'name': 'keyTest' })
+    update_key = client.update_key(key_or_uid=key['key'], options={ 'name': 'keyTest' })
     assert update_key['key'] is not None
     assert update_key['expiresAt'] is None
     assert update_key['name'] == 'keyTest'

--- a/tests/index/test_index_task_meilisearch.py
+++ b/tests/index/test_index_task_meilisearch.py
@@ -12,7 +12,7 @@ def test_get_tasks_default(index_with_documents):
 
 def test_get_tasks(empty_index, small_movies):
     """Tests getting the tasks list of a populated index."""
-    index = empty_index()
+    index = empty_index("test_task")
     current_tasks = index.get_tasks()
     pre_count = len(current_tasks['results'])
     response = index.add_documents(small_movies)

--- a/tests/index/test_index_task_meilisearch.py
+++ b/tests/index/test_index_task_meilisearch.py
@@ -12,7 +12,7 @@ def test_get_tasks_default(index_with_documents):
 
 def test_get_tasks(empty_index, small_movies):
     """Tests getting the tasks list of a populated index."""
-    index = empty_index("test_task")
+    index = empty_index()
     current_tasks = index.get_tasks()
     pre_count = len(current_tasks['results'])
     response = index.add_documents(small_movies)


### PR DESCRIPTION
# Pull Request

Related to: https://github.com/meilisearch/integration-guides/issues/205

## What does this PR do?

### Changes

- Add paginations parameters to `get_keys()` method