### PR TITLE
Add pipenv install in the CONTRIBUTING guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ You can set up your local environment natively or using `docker`, check out the 
 
 Example of running all the checks with docker:
 ```bash
-docker-compose run --rm package bash -c "pipenv run mypy meilisearch && pipenv run pylint meilisearch && pipenv run pytest tests"
+docker-compose run --rm package bash -c "pipenv install --dev && pipenv run mypy meilisearch && pipenv run pylint meilisearch && pipenv run pytest tests"
 ```
 
 To install dependencies:


### PR DESCRIPTION
If we don't add this command, it does not work :)

<img width="848" alt="image" src="https://user-images.githubusercontent.com/4116980/188239015-f115b51b-1f62-4c4d-8e1c-7fe529d23f8e.png">