### PR TITLE
Add a creation key use case with wildcards in the action field

### DIFF
--- a/tests/client/test_client_key_meilisearch.py
+++ b/tests/client/test_client_key_meilisearch.py
@@ -62,6 +62,13 @@ def test_create_keys_with_options(client, test_key_info):
     assert key['actions'] == test_key_info['actions']
     assert key['indexes'] == test_key_info['indexes']
 
+def test_create_keys_with_wildcarded_actions(client, test_key_info):
+    """Tests the creation of a key with an action which contains a wildcard."""
+    key = client.create_key(options={'description': test_key_info['description'], 'actions': ['documents.*'], 'indexes': test_key_info['indexes'], 'expiresAt': None })
+
+    assert isinstance(key, dict)
+    assert key['actions'] == ['documents.*']
+
 def test_create_keys_without_actions(client):
     """Tests the creation of a key with missing arguments."""
     with pytest.raises(MeiliSearchApiError):

--- a/tests/index/test_index_document_meilisearch.py
+++ b/tests/index/test_index_document_meilisearch.py
@@ -1,7 +1,6 @@
 # pylint: disable=invalid-name
 
 from math import ceil
-from time import sleep
 from meilisearch.client import Client
 from meilisearch.models.document import Document
 from meilisearch.models.task import TaskInfo

--- a/tests/index/test_index_document_meilisearch.py
+++ b/tests/index/test_index_document_meilisearch.py
@@ -1,6 +1,7 @@
 # pylint: disable=invalid-name
 
 from math import ceil
+from time import sleep
 from meilisearch.client import Client
 from meilisearch.models.document import Document
 from meilisearch.models.task import TaskInfo


### PR DESCRIPTION
Ensure support to keys with wildcarded actions.

- `actions` field during key creation now accepts wildcards on actions. For example, `indexes.*` provides rights to `indexes.create`, `indexes.get`,`indexes.delete`, `indexes.delete`, and `indexes.update`.