### PR TITLE
Add new docs links to pypi.org

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://github.com/meilisearch/meilisearch-python",
     packages=find_packages(exclude=("tests*",)),
-    project_urls={"Documentation": "https://docs.meilisearch.com/",},
+    project_urls={"Meilisearch Documentation": "https://docs.meilisearch.com/", "Documentation": "https://meilisearch.github.io/meilisearch-python/",},
     keywords="search python meilisearch",
     platform="any",
     classifiers=[


### PR DESCRIPTION
After https://github.com/meilisearch/meilisearch-python/pull/546 we have now an automated documentation link, we should be able to say that to the user.