### PR TITLE
Fix - modules documentation are not generated properly

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -31,15 +31,3 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/_build/html
         force_orphan: true
-
-
-
-
-
-
-
-
-
-
-
-

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,8 +1,7 @@
 name: Documentation
 on:
-  push:
-    tags:
-      - v*
+  pull_request:
+    types: [opened, reopened]
 
 jobs:
   docs:
@@ -19,8 +18,8 @@ jobs:
     - name: Install pipenv
       uses: dschep/install-pipenv-action@v1
     - name: Install dependencies
-      run: pipenv install --dev    
-    - name: Build docs      
+      run: pipenv install --dev
+    - name: Build docs
       uses: ammaraskar/sphinx-action@master
       with:
         pre-build-command: "pip install sphinx_rtd_theme && sphinx-apidoc -f -o docs meilisearch/"
@@ -30,7 +29,7 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: docs/_build/html
-        force_orphan: true   
+        force_orphan: true
 
 
 
@@ -38,7 +37,7 @@ jobs:
 
 
 
-      
+
 
 
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,7 +1,8 @@
 name: Documentation
 on:
-  pull_request:
-    types: [opened, reopened]
+  push:
+    tags:
+      - v*
 
 jobs:
   docs:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,3 +53,6 @@ html_theme = 'sphinx_rtd_theme'
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = []
+
+# This value contains a list of modules to be mocked up.
+autodoc_mock_imports = ["camel_converter"]

--- a/docs/meilisearch.models.rst
+++ b/docs/meilisearch.models.rst
@@ -4,6 +4,14 @@ meilisearch.models package
 Submodules
 ----------
 
+meilisearch.models.client module
+--------------------------------
+
+.. automodule:: meilisearch.models.client
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
 meilisearch.models.document module
 ----------------------------------
 
@@ -16,6 +24,14 @@ meilisearch.models.index module
 -------------------------------
 
 .. automodule:: meilisearch.models.index
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+meilisearch.models.ressource module
+-----------------------------------
+
+.. automodule:: meilisearch.models.ressource
    :members:
    :undoc-members:
    :show-inheritance:


### PR DESCRIPTION
Some module wasn't generated because of this error:
```bash
WARNING: autodoc: failed to import module 'client' from module 'meilisearch'; the following exception was raised:
No module named 'camel_converter'
```