### PR TITLE
Add task cancel API for v0.30.0

### DIFF
--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -14,7 +14,10 @@ from meilisearch.config import Config
 from meilisearch.errors import MeiliSearchError
 from meilisearch.index import Index
 from meilisearch.models.task import TaskInfo
-from meilisearch.task import cancel_tasks, get_task, get_tasks, wait_for_task
+from meilisearch.task import cancel_tasks as cancel_tasks_func
+from meilisearch.task import get_task as get_task_func
+from meilisearch.task import get_tasks as get_tasks_func
+from meilisearch.task import wait_for_task as wait_for_task_func
 
 
 class Client:
@@ -420,7 +423,7 @@ class Client:
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        return get_tasks(self.config, parameters=parameters)
+        return get_tasks_func(self.config, parameters=parameters)
 
     def get_task(self, uid: int) -> dict[str, Any]:
         """Get one task.
@@ -440,7 +443,7 @@ class Client:
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        return get_task(self.config, uid)
+        return get_task_func(self.config, uid)
 
     def cancel_tasks(self, parameters: dict[str, Any]) -> TaskInfo:
         """Cancel a list of enqueued or processing tasks.
@@ -461,7 +464,7 @@ class Client:
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        return cancel_tasks(self.config, parameters=parameters)
+        return cancel_tasks_func(self.config, parameters=parameters)
 
     def wait_for_task(
         self,
@@ -490,7 +493,7 @@ class Client:
         MeiliSearchTimeoutError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        return wait_for_task(self.config, uid, timeout_in_ms, interval_in_ms)
+        return wait_for_task_func(self.config, uid, timeout_in_ms, interval_in_ms)
 
     def generate_tenant_token(
         self,

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -14,10 +14,7 @@ from meilisearch.config import Config
 from meilisearch.errors import MeiliSearchError
 from meilisearch.index import Index
 from meilisearch.models.task import TaskInfo
-from meilisearch.task import cancel_tasks as cancel_tasks_func
-from meilisearch.task import get_task as get_task_func
-from meilisearch.task import get_tasks as get_tasks_func
-from meilisearch.task import wait_for_task as wait_for_task_func
+from meilisearch.task import cancel_tasks, get_task, get_tasks, wait_for_task
 
 
 class Client:
@@ -423,7 +420,7 @@ class Client:
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        return get_tasks_func(self.config, parameters=parameters)
+        return get_tasks(self.config, parameters=parameters)
 
     def get_task(self, uid: int) -> dict[str, Any]:
         """Get one task.
@@ -443,7 +440,7 @@ class Client:
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        return get_task_func(self.config, uid)
+        return get_task(self.config, uid)
 
     def cancel_tasks(self, parameters: dict[str, Any]) -> TaskInfo:
         """Cancel a list of enqueued or processing tasks.
@@ -464,7 +461,7 @@ class Client:
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        return cancel_tasks_func(self.config, parameters=parameters)
+        return cancel_tasks(self.config, parameters=parameters)
 
     def wait_for_task(
         self,
@@ -493,7 +490,7 @@ class Client:
         MeiliSearchTimeoutError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        return wait_for_task_func(self.config, uid, timeout_in_ms, interval_in_ms)
+        return wait_for_task(self.config, uid, timeout_in_ms, interval_in_ms)
 
     def generate_tenant_token(
         self,

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -442,7 +442,7 @@ class Client:
         """
         return get_task(self.config, uid)
 
-    def cancel_tasks(self, parameters: dict[str, Any] | None = None) -> TaskInfo:
+    def cancel_tasks(self, parameters: dict[str, Any]) -> TaskInfo:
         """Cancel a list of enqueued or processing tasks.
 
         Parameters

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -13,7 +13,8 @@ from meilisearch._httprequests import HttpRequests
 from meilisearch.config import Config
 from meilisearch.errors import MeiliSearchError
 from meilisearch.index import Index
-from meilisearch.task import get_task, get_tasks, wait_for_task
+from meilisearch.models.task import TaskInfo
+from meilisearch.task import cancel_tasks, get_task, get_tasks, wait_for_task
 
 
 class Client:
@@ -440,6 +441,27 @@ class Client:
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
         return get_task(self.config, uid)
+
+    def cancel_tasks(self, parameters: dict[str, Any] | None = None) -> TaskInfo:
+        """Cancel a list of enqueued or processing tasks.
+
+        Parameters
+        ----------
+        parameters (optional):
+            parameters accepted by the cancel tasks route:https://docs.meilisearch.com/reference/api/tasks.html#cancel-tasks.
+
+        Returns
+        -------
+        task_info:
+            TaskInfo instance containing information about a task to track the progress of an asynchronous process.
+            https://docs.meilisearch.com/reference/api/tasks.html#get-one-task
+
+        Raises
+        ------
+        MeiliSearchApiError
+            An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
+        """
+        return cancel_tasks(self.config, parameters=parameters)
 
     def wait_for_task(
         self,

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -9,7 +9,9 @@ from meilisearch.config import Config
 from meilisearch.models.document import Document, DocumentsResults
 from meilisearch.models.index import IndexStats
 from meilisearch.models.task import Task, TaskInfo, TaskResults
-from meilisearch.task import get_task, get_tasks, wait_for_task
+from meilisearch.task import get_task as get_task_func
+from meilisearch.task import get_tasks as get_tasks_func
+from meilisearch.task import wait_for_task as wait_for_task_func
 
 
 # pylint: disable=too-many-public-methods
@@ -163,7 +165,7 @@ class Index:
         else:
             parameters = {"indexUids": [self.uid]}
 
-        tasks = get_tasks(self.config, parameters=parameters)
+        tasks = get_tasks_func(self.config, parameters=parameters)
         return TaskResults(tasks)
 
     def get_task(self, uid: int) -> Task:
@@ -184,7 +186,7 @@ class Index:
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        task = get_task(self.config, uid)
+        task = get_task_func(self.config, uid)
         return Task(**task)
 
     def wait_for_task(
@@ -214,7 +216,7 @@ class Index:
         MeiliSearchTimeoutError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        task = wait_for_task(self.config, uid, timeout_in_ms, interval_in_ms)
+        task = wait_for_task_func(self.config, uid, timeout_in_ms, interval_in_ms)
         return Task(**task)
 
     def get_stats(self) -> IndexStats:

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -9,9 +9,7 @@ from meilisearch.config import Config
 from meilisearch.models.document import Document, DocumentsResults
 from meilisearch.models.index import IndexStats
 from meilisearch.models.task import Task, TaskInfo, TaskResults
-from meilisearch.task import get_task as get_task_func
-from meilisearch.task import get_tasks as get_tasks_func
-from meilisearch.task import wait_for_task as wait_for_task_func
+from meilisearch.task import get_task, get_tasks, wait_for_task
 
 
 # pylint: disable=too-many-public-methods
@@ -165,7 +163,7 @@ class Index:
         else:
             parameters = {"indexUids": [self.uid]}
 
-        tasks = get_tasks_func(self.config, parameters=parameters)
+        tasks = get_tasks(self.config, parameters=parameters)
         return TaskResults(tasks)
 
     def get_task(self, uid: int) -> Task:
@@ -186,7 +184,7 @@ class Index:
         MeiliSearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        task = get_task_func(self.config, uid)
+        task = get_task(self.config, uid)
         return Task(**task)
 
     def wait_for_task(
@@ -216,7 +214,7 @@ class Index:
         MeiliSearchTimeoutError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        task = wait_for_task_func(self.config, uid, timeout_in_ms, interval_in_ms)
+        task = wait_for_task(self.config, uid, timeout_in_ms, interval_in_ms)
         return Task(**task)
 
     def get_stats(self) -> IndexStats:

--- a/meilisearch/models/task.py
+++ b/meilisearch/models/task.py
@@ -11,7 +11,7 @@ class Task(CamelBase):
     status: str
     type: str
     details: Dict[str, Any]
-    error: Dict[str, Any]
+    error: Union[Dict[str, Any], None]
     canceled_by: Union[int, None]
     duration: str
     enqueued_at: str

--- a/meilisearch/models/task.py
+++ b/meilisearch/models/task.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Dict, Optional, Union
+from typing import Any, Dict, Union
 
 from camel_converter.pydantic_base import CamelBase
 
@@ -11,7 +11,8 @@ class Task(CamelBase):
     status: str
     type: str
     details: Dict[str, Any]
-    error: Optional[Dict[str, Any]]
+    error: Dict[str, Any]
+    canceled_by: Union[int, None]
     duration: str
     enqueued_at: str
     started_at: str

--- a/meilisearch/task.py
+++ b/meilisearch/task.py
@@ -76,7 +76,7 @@ def cancel_tasks(config: Config, parameters: dict[str, Any]) -> TaskInfo:
     config:
         Config object containing permission and location of Meilisearch.
     parameters (optional):
-        parameters accepted by the cancel tasks route:https://docs.meilisearch.com/reference/api/tasks.html#cancel-task.
+        parameters accepted by the cancel tasks https://docs.meilisearch.com/reference/api/tasks.html#cancel-task.
 
     Returns
     -------

--- a/meilisearch/task.py
+++ b/meilisearch/task.py
@@ -68,7 +68,7 @@ def get_task(config: Config, uid: int) -> dict[str, Any]:
     return http.get(f"{config.paths.task}/{uid}")
 
 
-def cancel_tasks(config: Config, parameters: dict[str, Any] | None = None) -> TaskInfo:
+def cancel_tasks(config: Config, parameters: dict[str, Any]) -> TaskInfo:
     """Cancel a list of enqueued or processing tasks.
 
     Parameters

--- a/tests/client/test_client_task_meilisearch.py
+++ b/tests/client/test_client_task_meilisearch.py
@@ -103,6 +103,7 @@ def create_tasks(empty_index, small_movies):
     index.add_documents(small_movies)
     index.add_documents(small_movies)
 
+
 @pytest.mark.usefixtures("create_tasks")
 def test_cancel_tasks(client):
     """Tests cancel a task with uid 1."""

--- a/tests/client/test_client_task_meilisearch.py
+++ b/tests/client/test_client_task_meilisearch.py
@@ -96,15 +96,17 @@ def test_get_task_inexistent(client):
 
 def test_cancel_tasks(client):
     """Tests cancel a task with uid 1."""
-    task = client.cancel_tasks({"uids": ["1"]})
+    task = client.cancel_tasks({"uids": ["1", "2"]})
     tasks = client.get_tasks({"types": "taskCancelation"})
 
     assert isinstance(task, TaskInfo)
     assert task.task_uid is not None
     assert task.index_uid is None
-    assert task.status == "enqueued" or "processing" or "succeeded"
+    assert task.status in {"enqueued", "processing", "succeeded"}
     assert task.type == "taskCancelation"
-    assert "uids" in tasks["results"][0]["details"]["originalFilters"]
+    assert "uids" in tasks["results"][0]["details"]["originalFilter"]
+    assert "uids=1%2C2" in tasks["results"][0]["details"]["originalFilter"]
+
 
 def test_cancel_every_task(client):
     """Tests cancel every task."""
@@ -114,8 +116,6 @@ def test_cancel_every_task(client):
     assert isinstance(task, TaskInfo)
     assert task.task_uid is not None
     assert task.index_uid is None
-    assert task.status == "enqueued" or "processing" or "succeeded"
+    assert task.status in {"enqueued", "processing", "succeeded"}
     assert task.type == "taskCancelation"
-    assert "statuses" in tasks["results"][0]["details"]["originalFilters"]
-
-
+    assert "statuses=enqueued%2Cprocessing" in tasks["results"][0]["details"]["originalFilter"]

--- a/tests/client/test_client_task_meilisearch.py
+++ b/tests/client/test_client_task_meilisearch.py
@@ -94,6 +94,16 @@ def test_get_task_inexistent(client):
         client.get_task("abc")
 
 
+@pytest.fixture
+def create_tasks(empty_index, small_movies):
+    """Ensures there are some tasks present for testing."""
+    index = empty_index()
+    index.update_ranking_rules(["type", "exactness"])
+    index.reset_ranking_rules()
+    index.add_documents(small_movies)
+    index.add_documents(small_movies)
+
+@pytest.mark.usefixtures("create_tasks")
 def test_cancel_tasks(client):
     """Tests cancel a task with uid 1."""
     task = client.cancel_tasks({"uids": ["1", "2"]})

--- a/tests/client/test_client_task_meilisearch.py
+++ b/tests/client/test_client_task_meilisearch.py
@@ -97,12 +97,12 @@ def test_get_task_inexistent(client):
 def test_cancel_tasks(client):
     """Tests cancel a task with uid 1."""
     task = client.cancel_tasks({"uids": ["1", "2"]})
+    client.wait_for_task(task.task_uid)
     tasks = client.get_tasks({"types": "taskCancelation"})
 
     assert isinstance(task, TaskInfo)
     assert task.task_uid is not None
     assert task.index_uid is None
-    assert task.status in {"enqueued", "processing", "succeeded"}
     assert task.type == "taskCancelation"
     assert "uids" in tasks["results"][0]["details"]["originalFilter"]
     assert "uids=1%2C2" in tasks["results"][0]["details"]["originalFilter"]
@@ -111,11 +111,11 @@ def test_cancel_tasks(client):
 def test_cancel_every_task(client):
     """Tests cancel every task."""
     task = client.cancel_tasks({"statuses": ["enqueued", "processing"]})
+    client.wait_for_task(task.task_uid)
     tasks = client.get_tasks({"types": "taskCancelation"})
 
     assert isinstance(task, TaskInfo)
     assert task.task_uid is not None
     assert task.index_uid is None
-    assert task.status in {"enqueued", "processing", "succeeded"}
     assert task.type == "taskCancelation"
     assert "statuses=enqueued%2Cprocessing" in tasks["results"][0]["details"]["originalFilter"]

--- a/tests/client/test_client_task_meilisearch.py
+++ b/tests/client/test_client_task_meilisearch.py
@@ -2,6 +2,7 @@
 
 import pytest
 
+from meilisearch.models.task import TaskInfo
 from tests import common
 
 
@@ -91,3 +92,30 @@ def test_get_task_inexistent(client):
     """Tests getting a task that does not exists."""
     with pytest.raises(Exception):
         client.get_task("abc")
+
+
+def test_cancel_tasks(client):
+    """Tests cancel a task with uid 1."""
+    task = client.cancel_tasks({"uids": ["1"]})
+    tasks = client.get_tasks({"types": "taskCancelation"})
+
+    assert isinstance(task, TaskInfo)
+    assert task.task_uid is not None
+    assert task.index_uid is None
+    assert task.status == "enqueued" or "processing" or "succeeded"
+    assert task.type == "taskCancelation"
+    assert "uids" in tasks["results"][0]["details"]["originalFilters"]
+
+def test_cancel_every_task(client):
+    """Tests cancel every task."""
+    task = client.cancel_tasks({"statuses": ["enqueued", "processing"]})
+    tasks = client.get_tasks({"types": "taskCancelation"})
+
+    assert isinstance(task, TaskInfo)
+    assert task.task_uid is not None
+    assert task.index_uid is None
+    assert task.status == "enqueued" or "processing" or "succeeded"
+    assert task.type == "taskCancelation"
+    assert "statuses" in tasks["results"][0]["details"]["originalFilters"]
+
+

--- a/tests/client/test_client_task_meilisearch.py
+++ b/tests/client/test_client_task_meilisearch.py
@@ -118,6 +118,7 @@ def test_cancel_tasks(client):
     assert "uids=1%2C2" in tasks["results"][0]["details"]["originalFilter"]
 
 
+@pytest.mark.usefixtures("create_tasks")
 def test_cancel_every_task(client):
     """Tests cancel every task."""
     task = client.cancel_tasks({"statuses": ["enqueued", "processing"]})


### PR DESCRIPTION
Add the cancel task API [see spec](https://github.com/meilisearch/specifications/pull/195)

## Enhancement

It is now possible to delete your tasks: 

example:

```python
    client.cancel_tasks({"status": "enqueued"})
```

## TODO
- [x] Add `canceled_by` in Task class
- [x] Add `error` in Task class
- [x] Implement `cancel_tasks()`
  - params: parameters: dict[str, Any]
  - returns: TaskInfo
- [x] `index_uid` is now optional
- [x] Tests cancelation with query parameters
  - [x] With `uid`
  - [x] Cancel every task