### PR TITLE
Add delete task api for v0.30.0

### DIFF
--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -14,7 +14,7 @@ from meilisearch.config import Config
 from meilisearch.errors import MeiliSearchError
 from meilisearch.index import Index
 from meilisearch.models.task import TaskInfo
-from meilisearch.task import cancel_tasks, get_task, get_tasks, wait_for_task
+from meilisearch.task import cancel_tasks, delete_tasks, get_task, get_tasks, wait_for_task
 
 
 class Client:
@@ -462,6 +462,25 @@ class Client:
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
         return cancel_tasks(self.config, parameters=parameters)
+
+    def delete_tasks(self, parameters: dict[str, Any]) -> TaskInfo:
+        """Delete a list of finished tasks.
+
+        Parameters
+        ----------
+        parameters (optional):
+            parameters accepted by the delete tasks route:https://docs.meilisearch.com/reference/api/tasks.html#delete-task.
+        Returns
+        -------
+        task_info:
+            TaskInfo instance containing information about a task to track the progress of an asynchronous process.
+            https://docs.meilisearch.com/reference/api/tasks.html#get-one-task
+        Raises
+        ------
+        MeiliSearchApiError
+            An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
+        """
+        return delete_tasks(self.config, parameters=parameters)
 
     def wait_for_task(
         self,

--- a/meilisearch/task.py
+++ b/meilisearch/task.py
@@ -99,6 +99,34 @@ def cancel_tasks(config: Config, parameters: dict[str, Any]) -> TaskInfo:
     return TaskInfo(**response)
 
 
+def delete_tasks(config: Config, parameters: dict[str, Any] | None = None) -> TaskInfo:
+    """Delete a list of enqueued or processing tasks.
+    Parameters
+    ----------
+    config:
+        Config object containing permission and location of Meilisearch.
+    parameters (optional):
+        parameters accepted by the delete tasks route:https://docs.meilisearch.com/reference/api/tasks.html#delete-task.
+    Returns
+    -------
+    task_info:
+        TaskInfo instance containing information about a task to track the progress of an asynchronous process.
+        https://docs.meilisearch.com/reference/api/tasks.html#get-one-task
+    Raises
+    ------
+    MeiliSearchApiError
+        An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
+    """
+    http = HttpRequests(config)
+    if parameters is None:
+        parameters = {}
+    for param in parameters:
+        if isinstance(parameters[param], list):
+            parameters[param] = ",".join(parameters[param])
+    response = http.delete(f"{config.paths.task}?{parse.urlencode(parameters)}")
+    return TaskInfo(**response)
+
+
 def wait_for_task(
     config: Config,
     uid: int,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,15 @@ def clear_indexes(client):
         client.wait_for_task(task["taskUid"])
 
 
+@fixture(autouse=True)
+def clear_all_tasks(client):
+    """
+    Auto-clears the tasks after each test function run.
+    Makes all the test functions independent.
+    """
+    client.delete_tasks({"statuses": ["succeeded", "failed", "canceled"]})
+
+
 @fixture(scope="function")
 def indexes_sample(client):
     indexes = []


### PR DESCRIPTION
Add the delete task API [see spec]( https://github.com/meilisearch/specifications/pull/198)

## Enhancement

It is now possible to delete your tasks: 

example:

```python
    client.delete_tasks({"status": "failed"})
```

## TODO
- [x] Implement `deletel_tasks()`
  - params: parameters: dict[str, Any]
  - returns: TaskInfo
- [x] Tests deletion with query parameters
  - [x] With `uid`
  - [x] Delete every task