### PR TITLE
Include py.typed in package build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
+include = ["meilisearch/py.typed"]
 dependencies = [
     "requests",
     "camel-converter[pydantic]",

--- a/setup.py
+++ b/setup.py
@@ -5,4 +5,5 @@ from meilisearch.version import __version__
 setup(
     packages=find_packages(exclude=("tests*",)),
     include_package_data=True,
+    package_data={"meilisearch": ["py.typed"]},
 )


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #636

## What does this PR do?
- Adds the py.typed file to the package

I know this works when using poetry so I think it will work here. In a "normal" `setup.py` situation  the file would be included in the `setup.py` so there is a chance the file will need to be added there instead/also as it used to be.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
