### PR TITLE
Rollback include py.typed in package build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
 ]
-include = ["meilisearch/py.typed"]
 dependencies = [
     "requests",
     "camel-converter[pydantic]",


### PR DESCRIPTION
# Pull Request

## Related issue
This PR #636 seems to have broken the deployment of the package on PyPI this PR rollback this commit
![Screenshot 2023-02-06 at 15 58 38](https://user-images.githubusercontent.com/16155041/217005848-50e228e1-7eae-421a-a311-06742b7040b0.png)

