### PR TITLE
Add multiple searches

### DIFF
--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -213,7 +213,7 @@ class Client:
         Parameters
         ----------
         queries:
-            Dictionary containing the query searched word(s) and the query parameters
+            List of dictionaries containing the query searched word(s) and the query parameters
             https://docs.meilisearch.com/reference/api/search.html#search-in-an-index
 
         Returns

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -213,13 +213,13 @@ class Client:
         Parameters
         ----------
         queries:
-            List of dictionaries containing the query searched word(s) and the query parameters
+            List of dictionaries containing the specified indexes and their search queries
             https://docs.meilisearch.com/reference/api/search.html#search-in-an-index
 
         Returns
         -------
         results:
-            Dictionary of results for each index with hits, offset, limit, processingTime and initial query
+            Dictionary of results for each index
 
         Raises
         ------

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -207,7 +207,7 @@ class Client:
             return Index(self.config, uid=uid)
         raise ValueError("The index UID should not be None")
 
-    def multi_search(self, queries: Dict[str, Any]) -> Dict[str, Any]:
+    def multi_search(self, queries: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]:
         """Multi Search in the index.
 
         Parameters

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -1,3 +1,5 @@
+# pylint: disable=too-many-public-methods
+
 from __future__ import annotations
 
 import base64
@@ -204,6 +206,30 @@ class Client:
         if uid is not None:
             return Index(self.config, uid=uid)
         raise ValueError("The index UID should not be None")
+
+    def multi_search(self, queries: Dict[str, Any]) -> Dict[str, Any]:
+        """Multi Search in the index.
+
+        Parameters
+        ----------
+        queries:
+            Dictionary containing the query searched word(s) and the query parameters
+            https://docs.meilisearch.com/reference/api/search.html#search-in-an-index
+
+        Returns
+        -------
+        results:
+            Dictionary of results for each index with hits, offset, limit, processingTime and initial query
+
+        Raises
+        ------
+        MeiliSearchApiError
+            An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
+        """
+        return self.http.post(
+            f"{self.config.paths.multi_search}",
+            body={"queries": queries},
+        )
 
     def get_all_stats(self) -> Dict[str, Any]:
         """Get all stats of Meilisearch

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -207,7 +207,7 @@ class Client:
             return Index(self.config, uid=uid)
         raise ValueError("The index UID should not be None")
 
-    def multi_search(self, queries: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]:
+    def multi_search(self, queries: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
         """Multi Search in the index.
 
         Parameters

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -208,7 +208,7 @@ class Client:
         raise ValueError("The index UID should not be None")
 
     def multi_search(self, queries: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
-        """Multi Search in the index.
+        """Multi-index search.
 
         Parameters
         ----------

--- a/meilisearch/config.py
+++ b/meilisearch/config.py
@@ -16,6 +16,7 @@ class Config:
         task = "tasks"
         stat = "stats"
         search = "search"
+        multi_search = "multi-search"
         document = "documents"
         setting = "settings"
         ranking_rules = "ranking-rules"

--- a/tests/client/test_client_multi_search_meilisearch.py
+++ b/tests/client/test_client_multi_search_meilisearch.py
@@ -2,6 +2,7 @@ import pytest
 
 from meilisearch.errors import MeiliSearchApiError
 
+
 def test_basic_multi_search(client, empty_index):
     """Tests multi-search on two indexes."""
     empty_index("indexA")

--- a/tests/client/test_client_multi_search_meilisearch.py
+++ b/tests/client/test_client_multi_search_meilisearch.py
@@ -1,0 +1,32 @@
+import pytest
+
+
+def test_basic_multi_search(client, empty_index):
+    """Tests multi-search on two indexes."""
+    empty_index("indexA")
+    empty_index("indexB")
+    response = client.multi_search(
+        [{"indexUid": "indexA", "q": ""}, {"indexUid": "indexB", "q": ""}]
+    )
+
+    assert isinstance(response, dict)
+    assert response["results"][0]["indexUid"] == "indexA"
+    assert response["results"][1]["indexUid"] == "indexB"
+    assert response["results"][0]["limit"] == 20
+    assert response["results"][1]["limit"] == 20
+
+
+def test_multi_search_one_index(client, empty_index):
+    """Tests multi-search on a simple query."""
+    empty_index("indexA")
+    response = client.multi_search([{"indexUid": "indexA", "q": ""}])
+
+    assert isinstance(response, dict)
+    assert response["results"][0]["indexUid"] == "indexA"
+    assert response["results"][0]["limit"] == 20
+
+
+def test_multi_search_on_no_index(client):
+    """Tests multi-search on a non existing index."""
+    with pytest.raises(Exception):
+        client.multi_search([{"indexUid": "indexDoesNotExist", "q": ""}])

--- a/tests/client/test_client_multi_search_meilisearch.py
+++ b/tests/client/test_client_multi_search_meilisearch.py
@@ -1,5 +1,6 @@
 import pytest
 
+from meilisearch.errors import MeiliSearchApiError
 
 def test_basic_multi_search(client, empty_index):
     """Tests multi-search on two indexes."""
@@ -28,5 +29,5 @@ def test_multi_search_one_index(client, empty_index):
 
 def test_multi_search_on_no_index(client):
     """Tests multi-search on a non existing index."""
-    with pytest.raises(Exception):
+    with pytest.raises(MeiliSearchApiError):
         client.multi_search([{"indexUid": "indexDoesNotExist", "q": ""}])


### PR DESCRIPTION
Now Meilisearch can perform multiple searches in one single HTTP request.
A new method has been added as [specifications](https://github.com/meilisearch/specifications/pull/225):
`multi_search(self, queries: Dict[str, Any]) -> Dict[str, Any]`

It's take a `List` as:
`[{"indexUid": "indexA", "q": ""}, {"indexUid": "indexB", "q": ""}]`

SDK requirements: https://github.com/meilisearch/integration-guides/issues/251