### PR TITLE
fix: remove duplicate key on code-samples

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -540,10 +540,6 @@ sorting_guide_sort_nested_1: |-
   client.index('books').search('science fiction', {
     'sort': ['rating.users:asc']
   })
-search_parameter_guide_sort_1: |-
-  client.index('books').search('science fiction', {
-    'sort': ['price:asc']
-  })
 geosearch_guide_filter_settings_1: |-
   client.index('restaurants').update_filterable_attributes([
     '_geo'


### PR DESCRIPTION
# Pull Request
Discovered debugging the following error:
```bash
Error: The sample file of Python SDK cannot be converted to JSON
Project: meilisearch-python
---
get_one_index_1: |-
  client.get_ind
        ------ ↓ ORIGINAL ERROR ↓ ------
        duplicated mapping key (543:1)

 540 |   client.index('books').search( ...
 541 |     'sort': ['rating.users:asc']
 542 |   })
 543 | search_parameter_guide_sort_1: |-
-------^
 544 |   client.index('books').search( ...
 545 |     'sort': ['price:asc']
```

## What does this PR do?
- Removes duplicate key on the .code-samples.meilisearch.yml. 
 _This avoids the sampleYamlToJs function failure when trying to parse the content to a JS object._

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?
