### PR TITLE
docs: Use utf-8 encoding for reading movies.json

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -397,7 +397,7 @@ getting_started_search_md: |-
 getting_started_add_meteorites: |-
   import json
 
-  json_file = open('meteorites.json')
+  json_file = open('meteorites.json', encoding='utf-8')
   meteorites = json.load(json_file)
   client.index('meteorites').add_documents(meteorites)
 getting_started_update_ranking_rules: |-
@@ -672,7 +672,7 @@ async_guide_canceled_by_1: |-
 date_guide_index_1: |-
   import json
 
-  json_file = open('./games.json')
+  json_file = open('./games.json', encoding='utf-8')
   games = json.load(json_file)
   client.index('games').add_documents(games)
 date_guide_filterable_attributes_1: |-

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -397,7 +397,7 @@ typo_tolerance_guide_4: |-
 add_movies_json_1: |-
   import json
 
-  json_file = open('movies.json')
+  json_file = open('movies.json', encoding='utf-8')
   movies = json.load(json_file)
   client.index('movies').add_documents(movies)
 landing_getting_started_1: |-
@@ -429,7 +429,7 @@ getting_started_add_documents_md: |-
 
   client = meilisearch.Client('http://localhost:7700')
 
-  json_file = open('movies.json')
+  json_file = open('movies.json', encoding='utf-8')
   movies = json.load(json_file)
   client.index('movies').add_documents(movies)
   ```


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #708

## What does this PR do?
- Uses utf-8 encoding for reading movies.json file. Otherwise, it can crash in Windows. 

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
