### PR TITLE
Change utcnow to now with time zone

### DIFF
--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -615,7 +615,7 @@ class Client:
             raise ValueError("An uid is required and must comply to the uuid4 format.")
         if not search_rules or search_rules == [""]:
             raise ValueError("The search_rules field is mandatory and should be defined.")
-        if expires_at and expires_at < datetime.datetime.utcnow():
+        if expires_at and expires_at < datetime.datetime.now(tz=datetime.timezone.utc):
             raise ValueError("The date expires_at should be in the future.")
 
         # Standard JWT header for encryption with SHA256/HS256 algorithm

--- a/tests/client/test_client_tenant_token.py
+++ b/tests/client/test_client_tenant_token.py
@@ -58,7 +58,7 @@ def test_generate_tenant_token_with_expires_at(client, get_private_key, empty_in
     """Tests create a tenant token with search rules and expiration date."""
     empty_index()
     client = meilisearch.Client(BASE_URL, get_private_key.key)
-    tomorrow = datetime.datetime.utcnow() + datetime.timedelta(days=1)
+    tomorrow = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(days=1)
 
     token = client.generate_tenant_token(
         api_key_uid=get_private_key.uid, search_rules=["*"], expires_at=tomorrow
@@ -106,7 +106,7 @@ def test_generate_tenant_token_with_bad_expires_at(client, get_private_key):
     """Tests create a tenant token with a bad expires at."""
     client = meilisearch.Client(BASE_URL, get_private_key.key)
 
-    yesterday = datetime.datetime.utcnow() + datetime.timedelta(days=-1)
+    yesterday = datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(days=-1)
 
     with pytest.raises(Exception):
         client.generate_tenant_token(


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #753

## What does this PR do?
- Changes `utcnow()` to `now()` with a utc time zone.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
