### PR TITLE
Add ability to get documents with a filter

### DIFF
--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -324,15 +324,10 @@ class Index:
         MeilisearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        if parameters is None:
-            parameters = {}
-            response = self.http.get(
-                f"{self.config.paths.index}/{self.uid}/{self.config.paths.document}?{parse.urlencode(parameters)}"
-            )
-            return DocumentsResults(response)
-
-        if not parameters.get("filter"):
-            if "fields" in parameters and isinstance(parameters["fields"], list):
+        if parameters is None or parameters.get("filter") is None:
+            if parameters is None:
+                parameters = {}
+            elif "fields" in parameters and isinstance(parameters["fields"], list):
                 parameters["fields"] = ",".join(parameters["fields"])
 
             response = self.http.get(

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -301,10 +301,7 @@ class Index:
         )
         return Document(document)
 
-    def get_documents(
-        self,
-        parameters: Optional[Dict[str, Any]] = None,
-    ) -> DocumentsResults:
+    def get_documents(self, parameters: Optional[Dict[str, Any]] = None) -> DocumentsResults:
         """Get a set of documents from the index.
 
         Parameters

--- a/tests/index/test_index_document_meilisearch.py
+++ b/tests/index/test_index_document_meilisearch.py
@@ -103,6 +103,26 @@ def test_get_documents_offset_optional_params(index_with_documents):
     assert response_offset_limit.results[0].title == response.results[1].title
 
 
+def test_get_documents_filter(index_with_documents):
+    index = index_with_documents()
+    response = index.update_filterable_attributes(["genre"])
+    index.wait_for_task(response.task_uid)
+    response = index.get_documents({"filter": "genre=action"})
+    genres = set([x.genre for x in response.results])
+    assert len(genres) == 1
+    assert next(iter(genres)) == "action"
+
+
+def test_get_documents_filter_with_fields(index_with_documents):
+    index = index_with_documents()
+    response = index.update_filterable_attributes(["genre"])
+    index.wait_for_task(response.task_uid)
+    response = index.get_documents({"fields": ["genre"], "filter": "genre=action"})
+    genres = set([x.genre for x in response.results])
+    assert len(genres) == 1
+    assert next(iter(genres)) == "action"
+
+
 def test_update_documents(index_with_documents, small_movies):
     """Tests updating a single document and a set of documents."""
     index = index_with_documents()

--- a/tests/index/test_index_document_meilisearch.py
+++ b/tests/index/test_index_document_meilisearch.py
@@ -108,7 +108,7 @@ def test_get_documents_filter(index_with_documents):
     response = index.update_filterable_attributes(["genre"])
     index.wait_for_task(response.task_uid)
     response = index.get_documents({"filter": "genre=action"})
-    genres = set([x.genre for x in response.results])
+    genres = {x.genre for x in response.results}
     assert len(genres) == 1
     assert next(iter(genres)) == "action"
 
@@ -118,7 +118,7 @@ def test_get_documents_filter_with_fields(index_with_documents):
     response = index.update_filterable_attributes(["genre"])
     index.wait_for_task(response.task_uid)
     response = index.get_documents({"fields": ["genre"], "filter": "genre=action"})
-    genres = set([x.genre for x in response.results])
+    genres = {x.genre for x in response.results}
     assert len(genres) == 1
     assert next(iter(genres)) == "action"
 


### PR DESCRIPTION
# Pull Request

Note: There is still some [discussion](https://github.com/meilisearch/integration-guides/issues/261) about the best way to handle this so it may need some updates.

## Related issue
Fixes #<issue_number>

## What does this PR do?
- Adds `filter` to the parameters for `get_documents`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
