### PR TITLE
Make params required in cancel_task

### DIFF
--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -512,7 +512,7 @@ class Client:
 
         Parameters
         ----------
-        parameters (optional):
+        parameters:
             parameters accepted by the cancel tasks route:https://docs.meilisearch.com/reference/api/tasks.html#cancel-tasks.
 
         Returns

--- a/meilisearch/task.py
+++ b/meilisearch/task.py
@@ -75,12 +75,12 @@ class TaskHandler:
         task = self.http.get(f"{self.config.paths.task}/{uid}")
         return Task(**task)
 
-    def cancel_tasks(self, parameters: Optional[Dict[str, Any]] = None) -> TaskInfo:
+    def cancel_tasks(self, parameters: Dict[str, Any]) -> TaskInfo:
         """Cancel a list of enqueued or processing tasks.
 
         Parameters
         ----------
-        parameters (optional):
+        parameters:
             parameters accepted by the cancel tasks https://docs.meilisearch.com/reference/api/tasks.html#cancel-task.
 
         Returns
@@ -94,8 +94,6 @@ class TaskHandler:
         MeilisearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://docs.meilisearch.com/errors/#meilisearch-errors
         """
-        if parameters is None:
-            parameters = {}
         for param in parameters:
             if isinstance(parameters[param], list):
                 parameters[param] = ",".join(parameters[param])


### PR DESCRIPTION
# Pull Request

I went this direction because I figure most people are using `cancel_tasks` from the `Client`. With that I made `TaskHandler` match what is done in `Client`. If you think another direction would be better I can make changes.

## Related issue
Fixes #760

## What does this PR do?
- Makes `parms` required in `cancel_tasks` for `TaskHandler`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
