### PR TITLE
Allow None for the body when updating settings

### DIFF
--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -858,7 +858,7 @@ class Index:
         """
         return self.http.get(self.__settings_url_for(self.config.paths.ranking_rules))
 
-    def update_ranking_rules(self, body: List[str]) -> TaskInfo:
+    def update_ranking_rules(self, body: Union[List[str], None]) -> TaskInfo:
         """Update ranking rules of the index.
 
         Parameters
@@ -918,7 +918,7 @@ class Index:
         """
         return self.http.get(self.__settings_url_for(self.config.paths.distinct_attribute))
 
-    def update_distinct_attribute(self, body: Dict[str, Any]) -> TaskInfo:
+    def update_distinct_attribute(self, body: Union[Dict[str, Any], None]) -> TaskInfo:
         """Update distinct attribute of the index.
 
         Parameters
@@ -978,7 +978,7 @@ class Index:
         """
         return self.http.get(self.__settings_url_for(self.config.paths.searchable_attributes))
 
-    def update_searchable_attributes(self, body: List[str]) -> TaskInfo:
+    def update_searchable_attributes(self, body: Union[List[str], None]) -> TaskInfo:
         """Update searchable attributes of the index.
 
         Parameters
@@ -1038,7 +1038,7 @@ class Index:
         """
         return self.http.get(self.__settings_url_for(self.config.paths.displayed_attributes))
 
-    def update_displayed_attributes(self, body: List[str]) -> TaskInfo:
+    def update_displayed_attributes(self, body: Union[List[str], None]) -> TaskInfo:
         """Update displayed attributes of the index.
 
         Parameters
@@ -1098,7 +1098,7 @@ class Index:
         """
         return self.http.get(self.__settings_url_for(self.config.paths.stop_words))
 
-    def update_stop_words(self, body: List[str]) -> TaskInfo:
+    def update_stop_words(self, body: Union[List[str], None]) -> TaskInfo:
         """Update stop words of the index.
 
         Parameters
@@ -1158,7 +1158,7 @@ class Index:
         """
         return self.http.get(self.__settings_url_for(self.config.paths.synonyms))
 
-    def update_synonyms(self, body: Dict[str, List[str]]) -> TaskInfo:
+    def update_synonyms(self, body: Union[Dict[str, List[str]], None]) -> TaskInfo:
         """Update synonyms of the index.
 
         Parameters
@@ -1218,7 +1218,7 @@ class Index:
         """
         return self.http.get(self.__settings_url_for(self.config.paths.filterable_attributes))
 
-    def update_filterable_attributes(self, body: List[str]) -> TaskInfo:
+    def update_filterable_attributes(self, body: Union[List[str], None]) -> TaskInfo:
         """Update filterable attributes of the index.
 
         Parameters
@@ -1278,7 +1278,7 @@ class Index:
         """
         return self.http.get(self.__settings_url_for(self.config.paths.sortable_attributes))
 
-    def update_sortable_attributes(self, body: List[str]) -> TaskInfo:
+    def update_sortable_attributes(self, body: Union[List[str], None]) -> TaskInfo:
         """Update sortable attributes of the index.
 
         Parameters
@@ -1340,7 +1340,7 @@ class Index:
 
         return TypoTolerance(**typo_tolerance)
 
-    def update_typo_tolerance(self, body: Dict[str, Any]) -> TaskInfo:
+    def update_typo_tolerance(self, body: Union[Dict[str, Any], None]) -> TaskInfo:
         """Update typo tolerance of the index.
 
         Parameters
@@ -1400,7 +1400,7 @@ class Index:
 
         return Pagination(**pagination)
 
-    def update_pagination_settings(self, body: Dict[str, Any]) -> TaskInfo:
+    def update_pagination_settings(self, body: Union[Dict[str, Any], None]) -> TaskInfo:
         """Update the pagination settings of the index.
 
         Parameters
@@ -1462,7 +1462,7 @@ class Index:
 
         return Faceting(**faceting)
 
-    def update_faceting_settings(self, body: Dict[str, Any]) -> TaskInfo:
+    def update_faceting_settings(self, body: Union[Dict[str, Any], None]) -> TaskInfo:
         """Update the faceting settings of the index.
 
         Parameters


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes the `None` typing issue discussed [here](https://github.com/meilisearch/meilisearch-python/issues/762#issuecomment-1559304152)

## What does this PR do?
- Allows `None` to be sent in the `body` parameter for settings updates.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
