### PR TITLE
Add missing parameters from client __init__ docstring

### DIFF
--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -42,6 +42,12 @@ class Client:
             The url to the Meilisearch API (ex: http://localhost:7700)
         api_key:
             The optional API key for Meilisearch
+        timeout (optional):
+            The amount of time in seconds that the client will wait for a response before timing
+            out.
+        client_agents (optional):
+            Used to send additional client agent information for clients extending the functionality
+            of this client.
         """
         self.config = Config(url, api_key, timeout=timeout, client_agents=client_agents)
 


### PR DESCRIPTION
# Pull Request

I noticed a couple of parameters missing for the `Client`'s `__init__` docstring.

## Related issue
Fixes #<issue_number>

## What does this PR do?
- Adds missing parameters to the `Client` `__init_` docstring

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
