### PR TITLE
Add support for Pydantic v2

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,4 +23,4 @@ dill = {version = "*", markers="python_version < '3.11'"}
 
 [packages]
 requests = "*"
-camel-converter = {extras = ["pydantic"], version = "*"}
+camel-converter = {version = "*", extras = ["pydantic"]}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -14,16 +14,24 @@
         ]
     },
     "default": {
+        "annotated-types": {
+            "hashes": [
+                "sha256:47cdc3490d9ac1506ce92c7aaa76c579dc3509ff11e098fc867e5130ab7be802",
+                "sha256:58da39888f92c276ad970249761ebea80ba544b77acddaa1a4d6cf78287d45fd"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==0.5.0"
+        },
         "camel-converter": {
             "extras": [
                 "pydantic"
             ],
             "hashes": [
-                "sha256:07dcaf8b6c1be88a543015fb785603913fd95443d82500851a93b996a486a7e1",
-                "sha256:086d122ffd74d103816a862836fc4e74ae812b5c821f7419ccea9f312b8dee91"
+                "sha256:3b3d076e824ae979b271b4d497c90514c2b218811f76b0c368fb69da2556fe07",
+                "sha256:88e5d91be5b2dff9c0748ba515774c3421088922d9e77c39f8742eb41cb7db88"
             ],
             "index": "pypi",
-            "version": "==3.0.1"
+            "version": "==3.0.2"
         },
         "certifi": {
             "hashes": [
@@ -124,44 +132,97 @@
         },
         "pydantic": {
             "hashes": [
-                "sha256:07293ab08e7b4d3c9d7de4949a0ea571f11e4557d19ea24dd3ae0c524c0c334d",
-                "sha256:0a2aabdc73c2a5960e87c3ffebca6ccde88665616d1fd6d3db3178ef427b267a",
-                "sha256:0da48717dc9495d3a8f215e0d012599db6b8092db02acac5e0d58a65248ec5bc",
-                "sha256:128d9453d92e6e81e881dd7e2484e08d8b164da5507f62d06ceecf84bf2e21d3",
-                "sha256:2196c06484da2b3fded1ab6dbe182bdabeb09f6318b7fdc412609ee2b564c49a",
-                "sha256:2e9aec8627a1a6823fc62fb96480abe3eb10168fd0d859ee3d3b395105ae19a7",
-                "sha256:3283b574b01e8dbc982080d8287c968489d25329a463b29a90d4157de4f2baaf",
-                "sha256:3c52eb595db83e189419bf337b59154bdcca642ee4b2a09e5d7797e41ace783f",
-                "sha256:4b466a23009ff5cdd7076eb56aca537c745ca491293cc38e72bf1e0e00de5b91",
-                "sha256:517a681919bf880ce1dac7e5bc0c3af1e58ba118fd774da2ffcd93c5f96eaece",
-                "sha256:5f8bbaf4013b9a50e8100333cc4e3fa2f81214033e05ac5aa44fa24a98670a29",
-                "sha256:6257bb45ad78abacda13f15bde5886efd6bf549dd71085e64b8dcf9919c38b60",
-                "sha256:67195274fd27780f15c4c372f4ba9a5c02dad6d50647b917b6a92bf00b3d301a",
-                "sha256:6cafde02f6699ce4ff643417d1a9223716ec25e228ddc3b436fe7e2d25a1f305",
-                "sha256:73ef93e5e1d3c8e83f1ff2e7fdd026d9e063c7e089394869a6e2985696693766",
-                "sha256:7845b31959468bc5b78d7b95ec52fe5be32b55d0d09983a877cca6aedc51068f",
-                "sha256:7847ca62e581e6088d9000f3c497267868ca2fa89432714e21a4fb33a04d52e8",
-                "sha256:7e1d5290044f620f80cf1c969c542a5468f3656de47b41aa78100c5baa2b8276",
-                "sha256:7ee829b86ce984261d99ff2fd6e88f2230068d96c2a582f29583ed602ef3fc2c",
-                "sha256:83fcff3c7df7adff880622a98022626f4f6dbce6639a88a15a3ce0f96466cb60",
-                "sha256:939328fd539b8d0edf244327398a667b6b140afd3bf7e347cf9813c736211896",
-                "sha256:95c70da2cd3b6ddf3b9645ecaa8d98f3d80c606624b6d245558d202cd23ea3be",
-                "sha256:963671eda0b6ba6926d8fc759e3e10335e1dc1b71ff2a43ed2efd6996634dafb",
-                "sha256:970b1bdc6243ef663ba5c7e36ac9ab1f2bfecb8ad297c9824b542d41a750b298",
-                "sha256:9863b9420d99dfa9c064042304868e8ba08e89081428a1c471858aa2af6f57c4",
-                "sha256:ad428e92ab68798d9326bb3e5515bc927444a3d71a93b4a2ca02a8a5d795c572",
-                "sha256:b48d3d634bca23b172f47f2335c617d3fcb4b3ba18481c96b7943a4c634f5c8d",
-                "sha256:b9cd67fb763248cbe38f0593cd8611bfe4b8ad82acb3bdf2b0898c23415a1f82",
-                "sha256:d111a21bbbfd85c17248130deac02bbd9b5e20b303338e0dbe0faa78330e37e0",
-                "sha256:e1aa5c2410769ca28aa9a7841b80d9d9a1c5f223928ca8bec7e7c9a34d26b1d4",
-                "sha256:e692dec4a40bfb40ca530e07805b1208c1de071a18d26af4a2a0d79015b352ca",
-                "sha256:e7c9900b43ac14110efa977be3da28931ffc74c27e96ee89fbcaaf0b0fe338e1",
-                "sha256:eec39224b2b2e861259d6f3c8b6290d4e0fbdce147adb797484a42278a1a486f",
-                "sha256:f0b7628fb8efe60fe66fd4adadd7ad2304014770cdc1f4934db41fe46cc8825f",
-                "sha256:f50e1764ce9353be67267e7fd0da08349397c7db17a562ad036aa7c8f4adfdb6",
-                "sha256:fab81a92f42d6d525dd47ced310b0c3e10c416bbfae5d59523e63ea22f82b31e"
+                "sha256:6e313661b310eb5b2c45168ce05d8dd79f57563adaf3906162a917585576b846",
+                "sha256:8bf7355be5e1207c756dfbc8046236dadd4ce04101fb482e6c8834a06d9aa04f"
             ],
-            "version": "==1.10.9"
+            "version": "==2.0"
+        },
+        "pydantic-core": {
+            "hashes": [
+                "sha256:007cdcee7e1a40951768d0d250e566b603e25d0fa8b8302901e38560bc9badf9",
+                "sha256:03d12c44decb122d5feede5408cc6c67e506b64016ce4b59c825d1a8c90f288a",
+                "sha256:0872a1c52da4cfc494e23c83532c7fc1313de311a14334b7a58216a8dea828e0",
+                "sha256:0b154abef540a76bb2b7a641b3ae1e05e5c4b08eb9ad6c27a217b3c64ffcda0b",
+                "sha256:0c8877d9e0bd128f103a1b0f02899aa7d4be1104eef5dc35e2b633042b64a2d1",
+                "sha256:0fcdb43190588f6219709b43ffa679e562c0d4a44a50aafb6cc88978da4a84b7",
+                "sha256:10736490eacc426d681ae6f00f1d8ce01fc77c45086a597e829c3eed127179b1",
+                "sha256:1672c8c36414c56adf704753b2d7e22e7528d7bd21cd357f24edeff76d4fd4ca",
+                "sha256:16977790d69bac6034baa2349326db2ff465ad346c53b8d54c3674e05b070af2",
+                "sha256:176eb3ec03da4c36da7708d2398139e13d1130b3b3d1af4334a959f46278baa9",
+                "sha256:182a0e5ce9382a0a77aab8407ead303b6e310c673a46b18937fa1a90c22ccbc4",
+                "sha256:1bb6d1057c054056614aefeced05299d3590acf76768538b34ebec9cbbf26953",
+                "sha256:1c318bd2bdaa88ec078dc7932e108a9c43caeabc84d2cf545081fb6a99ed1b90",
+                "sha256:1c855ef11370eacff25556658fb7fa243e8c0bd4235fa20a0f473bded2ede252",
+                "sha256:3a85fde791e6567f879b50b59f1740afc55333060d93548d6bbb46bf1b6a1b49",
+                "sha256:4372e8fcb458aad1e155c04e663ff1840f36b859fb1422578372712a78866051",
+                "sha256:44c8cec1d74d74c29da59c86e8cd472851c85b44d75128096ef3751c5c87c204",
+                "sha256:46bb28295082a22f3c7f5fa5546d669aed7eb43151ec0032e8c352c59f5e36af",
+                "sha256:4eda2b350b02293c7060f2371ad3ce7b00342bd61c8654d2ba374bd10c6b6b66",
+                "sha256:5e4a918eeae2c566fdcad9ee89d8708a59dc5ec3d5083b61a886b19f82f69f5c",
+                "sha256:5e90b99b6aa9fd6eee6d6f86921d38252c6e55c319dc6c5e411922d0dc173825",
+                "sha256:5f3158cb4cda580f3b063b03257c7f5c2d9e66f9c2a93466c76056f7c4d5a3b7",
+                "sha256:6387c2956baf16891e7bc20d864a769c0f9f61799d4895c8f493e2de8f7b88aa",
+                "sha256:659f22427d653769d1b4c672fd2daf53e639a5a93b0dd6fc0b37ef822a6e77d7",
+                "sha256:6cf3e484bc8e8c8a568d572a6619696d7e2e2aef214b0be503f0814f8bafca9f",
+                "sha256:7176ffa02c45d557cceb75f1290a2ddf53da680c6878aae54e69aafb21c52efd",
+                "sha256:71cf43912edeae476f47d16520e48bddbf9af0ebdd98961c38ca8944f4f22b9d",
+                "sha256:722aa193ba1f587226991a789a3f098235b5f04e85cf815af9e8ad823a5a85e1",
+                "sha256:73c464afa0a959472045f242ef7cdaf6a38b76a6d7dfa1ef270de0967c04408d",
+                "sha256:76d5d18ef9065ecbf62d6ec82c45ddbb47174a7400eb780040a7ebdad1c0ead8",
+                "sha256:7727a4fcb93572d4e521b028f1c64f1eda2da49d506b1a6208576faa9e0acd64",
+                "sha256:79225132aa1fe97a5e947da820b323d63372fb3475d94ff81ca6f91669717a01",
+                "sha256:7a4fc3e8c788798739f4aa6772d994e4453a17dadb1b8eea4582a31cdfe683d2",
+                "sha256:7bd78c4f04794a8e527d32c8ec1a26682b35b5c9347bb6e3cc853ba1a43c72a5",
+                "sha256:88b56a4e7480f4f22fa2faefdb0a887d70420d9cd8cb160677e8abe46769e7b0",
+                "sha256:88fc72e60d818924cb3d32948b682bcea0dadd0fd2efae9a4d0b7a55e310908a",
+                "sha256:89123ab11a23fa9c332655933350dc231945ca6b1148c1e1960aad0a5a6de1c0",
+                "sha256:8927c166f20e3933cc9a9a68701acc8de22ee54b70d8c4044ad461b043b3cf9b",
+                "sha256:8945ba48644b45d4e66cc3e56b896e97fb1d7f166dd0ee1eb137bbfdf1285483",
+                "sha256:8ca5a743af642700fc69dc64e0b964dd7499dcabb399e5cc2223fbc9cb33965d",
+                "sha256:8daded5c64811da4bdc7d6792afa10328bff5c3514536f69457596d4a2646b49",
+                "sha256:92b01e166a3b69e8054308709acabec1bae65dae83ba6329f4fcc8448e170a06",
+                "sha256:958964a0ad0cea700b25037b21f5a2da38d19bddaa2f15ce36f51c048a9efe92",
+                "sha256:9cf1ba93657cad863d23ecb09227665c0abe26c131acd24abb5edc6249a36a70",
+                "sha256:9ee1c2d0cf5c92faf722ff366814859c764c82b30af7f91b9b1950e15efecb9e",
+                "sha256:a1dd1b182fde9f95f1cc28964612fb1b180fdd3ca2cac881c108db29906b2e01",
+                "sha256:a7d0de538719feda5cabf19c63cc17345df6a0ab579b95518925d2b25276daaf",
+                "sha256:aad8b177370002f73f08eafefa3d969d9c4498da6d67d8a43ffdeb4b4e560e1c",
+                "sha256:ab7eafb33fdc7aa8667634be58a3d1c8ed3fa8923c6bc5014657bf95b51b4a46",
+                "sha256:ac6a57d01c0b67563dd273f2b71e9aab643573b569a202bfff7dad502b0b8ee0",
+                "sha256:adbfc6c7ddd1cca6efe62a0292cae7cf2d05c9ebb139d0da10b0d44346e253c7",
+                "sha256:adc2efaf0c45135214dff4d18d4aaf2b692249cb369f921fe0fde3a13cf7ddad",
+                "sha256:ae53240f9f92f634b73a3e5ee87b9ec8ac38d5bee96ea65034af58f48d489a65",
+                "sha256:b23ae8b27b6eff72909a9a88123ac28b746d95f25927ce67d3b0f3dabe099a0a",
+                "sha256:b56f3758b82f26414a4dccd76f05c768df7bd2735e0ac43f3dfff2f5603d32a9",
+                "sha256:b83e11a68936f80ee92ef1001bf6b9fedf0602396acc417b16a9c136a9b3b7bd",
+                "sha256:bb2daa4e3d4efbf2e2dedc1a7cea3e48ff12d0c95ab2011e7f731bdc97d16ed0",
+                "sha256:bc99af5be239961d718bbf8e4d6bd1caa6de556e44ed08eb5135cfbefc958728",
+                "sha256:c04aa22ded4baf29c3c1ec3b76d5264dd91794b974a737251fdd0827abcc2c78",
+                "sha256:c3f8fea22690c6c33c4d36d2236732da29da560f815cd9aba1d3b5ab59dcb214",
+                "sha256:c5fef2dc7ed589ea83ac5ce526fcb8e8eb0ab79bfa67f958dafbda0a05ab3018",
+                "sha256:c656b8d4603af6744ed2f2c0be499790f0913a2186ef7214c88d47d42051ae4b",
+                "sha256:c8e53bae6e58a8ff8e93f9a77440cfe8fc017bb9a8430dc03beb6bdd648572d2",
+                "sha256:cbbefd38ef80b37d056592c366a164a37b4e87b12f0aba23c35087d890fb31ba",
+                "sha256:ccb06e1667a9784a96e0fc2500b989b8afbe9ac68a39a3c806c056ee228eff3c",
+                "sha256:d6e21da7f7e3935b24bfd17d7c3eefe4c1edca380edaec854a8593796d8d96f1",
+                "sha256:ddb23eaf427dbbde41b543d98a0c4a7aeb73bf649e3faa75b94a2fd882a669ba",
+                "sha256:ddbad540cba15b5262bd800bb6f0746a4ac719de0fe0a2acab8e0d50eb54ba9a",
+                "sha256:e0dd6bb98271519a309e96e927b52f8ca1323a99762bec87cda8fdaaa221e5cd",
+                "sha256:e0edd3c6762b3ff3fdbd90517a09808e5d67cce86d7c43ec6f5ca3f65bfe7fd9",
+                "sha256:e2e9025e132761e7ea8dab448923ccd8839c60199e863a6348d7e8b1a674edd1",
+                "sha256:e4785a8c5440e410394f88e30c3db862ed05841595311ddc969b3fde377f95ea",
+                "sha256:e4b4c836100e5f07189b0aea8b4afae326f169bfdef91e86fd90a0d3c27f0c75",
+                "sha256:e55fc76ce657208c0d7e21e2e96925993dd4063d5c5ee9227dcdf4e550c02a29",
+                "sha256:e76a9b0c2b2fb29a80764e106b1ea35c1b96a4e62e7ce7dde44f5df153fd5b66",
+                "sha256:ef349e4ac794559c1538787a0fbce378a1beb991ef4f7707a6cde3156294259d",
+                "sha256:f0f90928ed48b91d93add357fb1e81cef729bffaff3ab88882b76549434b4574",
+                "sha256:f9452d470012ee86a00a36f7673843038fd1a88661a28c72e65e7f3f084da8d8",
+                "sha256:f9fffcb5507bff84a1312d1616406cad157806f105d78bd184d1e6b3b00e6417",
+                "sha256:fa5a3d49ddbeaa80bb2a8927b90e9cdd43373616ba0b7b7a74a3ae33b5c9640c",
+                "sha256:ff015389ae4ca6869a2fdd16c21ee1ce7c134503f2148efd46db643ce27ca520"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.1"
         },
         "requests": {
             "hashes": [
@@ -173,11 +234,11 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:88a4153d8505aabbb4e13aacb7c486c2b4a33ca3b3f807914a9b4c844c471c26",
-                "sha256:d91d5919357fe7f681a9f2b5b4cb2a5f1ef0a1e9f59c4d8ff0d3491e05c0ffd5"
+                "sha256:440d5dd3af93b060174bf433bccd69b0babc3b15b1a8dca43789fd7f61514b36",
+                "sha256:b75ddc264f0ba5615db7ba217daeb99701ad295353c45f9e95963337ceeeffb2"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.6.3"
+            "version": "==4.7.1"
         },
         "urllib3": {
             "hashes": [

--- a/meilisearch/_utils.py
+++ b/meilisearch/_utils.py
@@ -12,10 +12,10 @@ def is_pydantic_2() -> bool:
         # Still check the version as a fail safe incase __version__ gets added to verion 1.
         if int(pydantic.__version__[:1]) >= 2:  # type: ignore[attr-defined]
             return True
-        else:  # pragma: no cover
-            # Raise an AttributeError to match the AttributeError on __version__ because in either
-            # case we need to get to the same place.
-            raise AttributeError
+
+        # Raise an AttributeError to match the AttributeError on __version__ because in either
+        # case we need to get to the same place.
+        raise AttributeError
     except AttributeError:  # pragma: no cover
         return False
 

--- a/meilisearch/_utils.py
+++ b/meilisearch/_utils.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+from functools import lru_cache
+from typing import Union
+
+import pydantic
+
+
+@lru_cache(maxsize=1)
+def is_pydantic_2() -> bool:
+    try:
+        # __version__ was added with Pydantic 2 so we know if this errors the version is < 2.
+        # Still check the version as a fail safe incase __version__ gets added to verion 1.
+        if int(pydantic.__version__[:1]) >= 2:  # type: ignore[attr-defined]
+            return True
+        else:  # pragma: no cover
+            # Raise an AttributeError to match the AttributeError on __version__ because in either
+            # case we need to get to the same place.
+            raise AttributeError
+    except AttributeError:  # pragma: no cover
+        return False
+
+
+def iso_to_date_time(iso_date: Union[datetime, str, None]) -> Union[datetime, None]:
+    """Handle conversion of iso string to datetime.
+
+    The microseconds from Meilisearch are sometimes too long for python to convert so this
+    strips off the last digits to shorten it when that happens.
+    """
+    if not iso_date:
+        return None
+
+    if isinstance(iso_date, datetime):
+        return iso_date
+
+    try:
+        return datetime.strptime(iso_date, "%Y-%m-%dT%H:%M:%S.%fZ")
+    except ValueError:
+        split = iso_date.split(".")
+        reduce = len(split[1]) - 6
+        reduced = f"{split[0]}.{split[1][:-reduce]}Z"
+        return datetime.strptime(reduced, "%Y-%m-%dT%H:%M:%S.%fZ")

--- a/meilisearch/models/key.py
+++ b/meilisearch/models/key.py
@@ -1,7 +1,10 @@
 from datetime import datetime
-from typing import List, Optional
+from typing import List, Optional, Union
 
+import pydantic
 from camel_converter.pydantic_base import CamelBase
+
+from meilisearch._utils import is_pydantic_2, iso_to_date_time
 
 
 class _KeyBase(CamelBase):
@@ -12,18 +15,65 @@ class _KeyBase(CamelBase):
     indexes: List[str]
     expires_at: Optional[datetime] = None
 
-    class Config:
-        json_encoders = {
-            datetime: lambda v: None
-            if not v
-            else f"{str(v).split('.', maxsplit=1)[0].replace(' ', 'T')}Z"
-        }
+    if is_pydantic_2():
+        model_config = pydantic.ConfigDict(ser_json_timedelta="iso8601")  # type: ignore[typeddict-unknown-key]
+
+        @pydantic.field_validator("expires_at", mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def validate_expires_at(cls, v: str) -> Union[datetime, None]:
+            return iso_to_date_time(v)
+
+    else:
+
+        @pydantic.validator("expires_at", pre=True)
+        @classmethod
+        def validate_expires_at(cls, v: str) -> Union[datetime, None]:
+            return iso_to_date_time(v)
+
+        class Config:
+            json_encoders = {
+                datetime: lambda v: None if not v else f"{str(v).split('.')[0].replace(' ', 'T')}Z"
+            }
 
 
 class Key(_KeyBase):
     key: str
     created_at: datetime
     updated_at: Optional[datetime] = None
+
+    if is_pydantic_2():
+
+        @pydantic.field_validator("created_at", mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def validate_created_at(cls, v: str) -> datetime:
+            converted = iso_to_date_time(v)
+
+            if not converted:
+                raise ValueError("created_at is required")
+
+            return converted
+
+        @pydantic.field_validator("updated_at", mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def validate_updated_at(cls, v: str) -> Union[datetime, None]:
+            return iso_to_date_time(v)
+
+    else:
+
+        @pydantic.validator("created_at", pre=True)
+        @classmethod
+        def validate_created_at(cls, v: str) -> datetime:
+            converted = iso_to_date_time(v)
+
+            if not converted:
+                raise ValueError("created_at is required")
+
+            return converted
+
+        @pydantic.validator("updated_at", pre=True)
+        @classmethod
+        def validate_updated_at(cls, v: str) -> Union[datetime, None]:
+            return iso_to_date_time(v)
 
 
 class KeyUpdate(CamelBase):
@@ -34,12 +84,15 @@ class KeyUpdate(CamelBase):
     indexes: Optional[List[str]] = None
     expires_at: Optional[datetime] = None
 
-    class Config:
-        json_encoders = {
-            datetime: lambda v: None
-            if not v
-            else f"{str(v).split('.', maxsplit=1)[0].replace(' ', 'T')}Z"
-        }
+    if is_pydantic_2():
+        model_config = pydantic.ConfigDict(ser_json_timedelta="iso8601")  # type: ignore[typeddict-unknown-key]
+
+    else:
+
+        class Config:
+            json_encoders = {
+                datetime: lambda v: None if not v else f"{str(v).split('.')[0].replace(' ', 'T')}Z"
+            }
 
 
 class KeysResults(CamelBase):

--- a/meilisearch/models/key.py
+++ b/meilisearch/models/key.py
@@ -20,19 +20,25 @@ class _KeyBase(CamelBase):
 
         @pydantic.field_validator("expires_at", mode="before")  # type: ignore[attr-defined]
         @classmethod
-        def validate_expires_at(cls, v: str) -> Union[datetime, None]:
+        def validate_expires_at(  # pylint: disable=invalid-name
+            cls, v: str
+        ) -> Union[datetime, None]:
             return iso_to_date_time(v)
 
     else:
 
         @pydantic.validator("expires_at", pre=True)
         @classmethod
-        def validate_expires_at(cls, v: str) -> Union[datetime, None]:
+        def validate_expires_at(  # pylint: disable=invalid-name
+            cls, v: str
+        ) -> Union[datetime, None]:
             return iso_to_date_time(v)
 
         class Config:
             json_encoders = {
-                datetime: lambda v: None if not v else f"{str(v).split('.')[0].replace(' ', 'T')}Z"
+                datetime: lambda v: None
+                if not v
+                else f"{str(v).split('.', maxsplit=1)[0].replace(' ', 'T')}Z"
             }
 
 
@@ -45,7 +51,7 @@ class Key(_KeyBase):
 
         @pydantic.field_validator("created_at", mode="before")  # type: ignore[attr-defined]
         @classmethod
-        def validate_created_at(cls, v: str) -> datetime:
+        def validate_created_at(cls, v: str) -> datetime:  # pylint: disable=invalid-name
             converted = iso_to_date_time(v)
 
             if not converted:
@@ -55,14 +61,16 @@ class Key(_KeyBase):
 
         @pydantic.field_validator("updated_at", mode="before")  # type: ignore[attr-defined]
         @classmethod
-        def validate_updated_at(cls, v: str) -> Union[datetime, None]:
+        def validate_updated_at(  # pylint: disable=invalid-name
+            cls, v: str
+        ) -> Union[datetime, None]:
             return iso_to_date_time(v)
 
     else:
 
         @pydantic.validator("created_at", pre=True)
         @classmethod
-        def validate_created_at(cls, v: str) -> datetime:
+        def validate_created_at(cls, v: str) -> datetime:  # pylint: disable=invalid-name
             converted = iso_to_date_time(v)
 
             if not converted:
@@ -72,7 +80,9 @@ class Key(_KeyBase):
 
         @pydantic.validator("updated_at", pre=True)
         @classmethod
-        def validate_updated_at(cls, v: str) -> Union[datetime, None]:
+        def validate_updated_at(  # pylint: disable=invalid-name
+            cls, v: str
+        ) -> Union[datetime, None]:
             return iso_to_date_time(v)
 
 
@@ -91,7 +101,9 @@ class KeyUpdate(CamelBase):
 
         class Config:
             json_encoders = {
-                datetime: lambda v: None if not v else f"{str(v).split('.')[0].replace(' ', 'T')}Z"
+                datetime: lambda v: None
+                if not v
+                else f"{str(v).split('.', maxsplit=1)[0].replace(' ', 'T')}Z"
             }
 
 

--- a/meilisearch/models/task.py
+++ b/meilisearch/models/task.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Union
 
+import pydantic
 from camel_converter.pydantic_base import CamelBase
+
+from meilisearch._utils import is_pydantic_2, iso_to_date_time
 
 
 class Task(CamelBase):
-    uid: str
+    uid: int
     index_uid: Union[str, None]
     status: str
     type: str
@@ -19,6 +22,50 @@ class Task(CamelBase):
     started_at: Optional[datetime]
     finished_at: Optional[datetime]
 
+    if is_pydantic_2():
+
+        @pydantic.field_validator("enqueued_at", mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def validate_enqueued_at(cls, v: str) -> datetime:
+            converted = iso_to_date_time(v)
+
+            if not converted:
+                raise ValueError("enqueued_at is required")
+
+            return converted
+
+        @pydantic.field_validator("started_at", mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def validate_started_at(cls, v: str) -> Union[datetime, None]:
+            return iso_to_date_time(v)
+
+        @pydantic.field_validator("finished_at", mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def validate_finished_at(cls, v: str) -> Union[datetime, None]:
+            return iso_to_date_time(v)
+
+    else:
+
+        @pydantic.validator("enqueued_at", pre=True)
+        @classmethod
+        def validate_enqueued_at(cls, v: str) -> datetime:
+            converted = iso_to_date_time(v)
+
+            if not converted:
+                raise ValueError("enqueued_at is required")
+
+            return converted
+
+        @pydantic.validator("started_at", pre=True)
+        @classmethod
+        def validate_started_at(cls, v: str) -> Union[datetime, None]:
+            return iso_to_date_time(v)
+
+        @pydantic.validator("finished_at", pre=True)
+        @classmethod
+        def validate_finished_at(cls, v: str) -> Union[datetime, None]:
+            return iso_to_date_time(v)
+
 
 class TaskInfo(CamelBase):
     task_uid: int
@@ -26,6 +73,30 @@ class TaskInfo(CamelBase):
     status: str
     type: str
     enqueued_at: datetime
+
+    if is_pydantic_2():
+
+        @pydantic.field_validator("enqueued_at", mode="before")  # type: ignore[attr-defined]
+        @classmethod
+        def validate_enqueued_at(cls, v: str) -> datetime:
+            converted = iso_to_date_time(v)
+
+            if not converted:
+                raise ValueError("enqueued_at is required")
+
+            return converted
+
+    else:
+
+        @pydantic.validator("enqueued_at", pre=True)
+        @classmethod
+        def validate_enqueued_at(cls, v: str) -> datetime:
+            converted = iso_to_date_time(v)
+
+            if not converted:
+                raise ValueError("enqueued_at is required")
+
+            return converted
 
 
 class TaskResults:

--- a/meilisearch/models/task.py
+++ b/meilisearch/models/task.py
@@ -26,7 +26,7 @@ class Task(CamelBase):
 
         @pydantic.field_validator("enqueued_at", mode="before")  # type: ignore[attr-defined]
         @classmethod
-        def validate_enqueued_at(cls, v: str) -> datetime:
+        def validate_enqueued_at(cls, v: str) -> datetime:  # pylint: disable=invalid-name
             converted = iso_to_date_time(v)
 
             if not converted:
@@ -36,19 +36,23 @@ class Task(CamelBase):
 
         @pydantic.field_validator("started_at", mode="before")  # type: ignore[attr-defined]
         @classmethod
-        def validate_started_at(cls, v: str) -> Union[datetime, None]:
+        def validate_started_at(  # pylint: disable=invalid-name
+            cls, v: str
+        ) -> Union[datetime, None]:
             return iso_to_date_time(v)
 
         @pydantic.field_validator("finished_at", mode="before")  # type: ignore[attr-defined]
         @classmethod
-        def validate_finished_at(cls, v: str) -> Union[datetime, None]:
+        def validate_finished_at(  # pylint: disable=invalid-name
+            cls, v: str
+        ) -> Union[datetime, None]:
             return iso_to_date_time(v)
 
     else:
 
         @pydantic.validator("enqueued_at", pre=True)
         @classmethod
-        def validate_enqueued_at(cls, v: str) -> datetime:
+        def validate_enqueued_at(cls, v: str) -> datetime:  # pylint: disable=invalid-name
             converted = iso_to_date_time(v)
 
             if not converted:
@@ -58,12 +62,16 @@ class Task(CamelBase):
 
         @pydantic.validator("started_at", pre=True)
         @classmethod
-        def validate_started_at(cls, v: str) -> Union[datetime, None]:
+        def validate_started_at(  # pylint: disable=invalid-name
+            cls, v: str
+        ) -> Union[datetime, None]:
             return iso_to_date_time(v)
 
         @pydantic.validator("finished_at", pre=True)
         @classmethod
-        def validate_finished_at(cls, v: str) -> Union[datetime, None]:
+        def validate_finished_at(  # pylint: disable=invalid-name
+            cls, v: str
+        ) -> Union[datetime, None]:
             return iso_to_date_time(v)
 
 
@@ -78,7 +86,7 @@ class TaskInfo(CamelBase):
 
         @pydantic.field_validator("enqueued_at", mode="before")  # type: ignore[attr-defined]
         @classmethod
-        def validate_enqueued_at(cls, v: str) -> datetime:
+        def validate_enqueued_at(cls, v: str) -> datetime:  # pylint: disable=invalid-name
             converted = iso_to_date_time(v)
 
             if not converted:
@@ -90,7 +98,7 @@ class TaskInfo(CamelBase):
 
         @pydantic.validator("enqueued_at", pre=True)
         @classmethod
-        def validate_enqueued_at(cls, v: str) -> datetime:
+        def validate_enqueued_at(cls, v: str) -> datetime:  # pylint: disable=invalid-name
             converted = iso_to_date_time(v)
 
             if not converted:

--- a/meilisearch/task.py
+++ b/meilisearch/task.py
@@ -73,6 +73,7 @@ class TaskHandler:
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
         """
         task = self.http.get(f"{self.config.paths.task}/{uid}")
+        print(task)
         return Task(**task)
 
     def cancel_tasks(self, parameters: Dict[str, Any]) -> TaskInfo:

--- a/meilisearch/task.py
+++ b/meilisearch/task.py
@@ -73,7 +73,6 @@ class TaskHandler:
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
         """
         task = self.http.get(f"{self.config.paths.task}/{uid}")
-        print(task)
         return Task(**task)
 
     def cancel_tasks(self, parameters: Dict[str, Any]) -> TaskInfo:

--- a/tests/client/test_client_key_meilisearch.py
+++ b/tests/client/test_client_key_meilisearch.py
@@ -54,7 +54,7 @@ def test_create_keys_with_options(client, test_key_info):
             "actions": test_key_info["actions"],
             "indexes": test_key_info["indexes"],
             "uid": "82acc342-d2df-4291-84bd-8400d3f05f06",
-            "expiresAt": datetime(2030, 6, 4, 21, 8, 12, 32).isoformat()[:-3] + "Z",
+            "expiresAt": datetime(2030, 6, 4, 21, 8, 12, 32).isoformat() + "Z",
         }
     )
     assert key.key is not None

--- a/tests/settings/test_settings_typo_tolerance_meilisearch.py
+++ b/tests/settings/test_settings_typo_tolerance_meilisearch.py
@@ -23,7 +23,7 @@ def test_get_typo_tolerance_default(empty_index):
     """Tests getting default typo_tolerance."""
     response = empty_index().get_typo_tolerance()
 
-    assert response.dict(by_alias=True) == DEFAULT_TYPO_TOLERANCE
+    assert response.model_dump(by_alias=True) == DEFAULT_TYPO_TOLERANCE
 
 
 def test_update_typo_tolerance(empty_index):
@@ -35,9 +35,10 @@ def test_update_typo_tolerance(empty_index):
 
     assert update.status == "succeeded"
     for typo_tolerance in NEW_TYPO_TOLERANCE:  # pylint: disable=consider-using-dict-items
-        assert typo_tolerance in response_get.dict(by_alias=True)
+        assert typo_tolerance in response_get.model_dump(by_alias=True)
         assert (
-            NEW_TYPO_TOLERANCE[typo_tolerance] == response_get.dict(by_alias=True)[typo_tolerance]
+            NEW_TYPO_TOLERANCE[typo_tolerance]
+            == response_get.model_dump(by_alias=True)[typo_tolerance]
         )
 
 
@@ -59,7 +60,8 @@ def test_reset_typo_tolerance(empty_index):
     assert update1.status == "succeeded"
     for typo_tolerance in NEW_TYPO_TOLERANCE:  # pylint: disable=consider-using-dict-items
         assert (
-            NEW_TYPO_TOLERANCE[typo_tolerance] == response_get.dict(by_alias=True)[typo_tolerance]
+            NEW_TYPO_TOLERANCE[typo_tolerance]
+            == response_get.model_dump(by_alias=True)[typo_tolerance]
         )
     assert update2.status == "succeeded"
-    assert response_last.dict(by_alias=True) == DEFAULT_TYPO_TOLERANCE
+    assert response_last.model_dump(by_alias=True) == DEFAULT_TYPO_TOLERANCE


### PR DESCRIPTION
# Pull Request

Pydantic v2 was released with several breaking changes. This PR allows users to use Pydantic 2 or Pydantic 1. I went this direction because Pydantic 2 is so new not all packages can use it yet. Because of this I don't think we can drop support for v1 since it would prevent people that still need v1 from using this package.

## Related issue
Fixes #789

## What does this PR do?
- Adds support for Pydantic v2

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
