### PR TITLE
Fix potential json_encoding date error and truncation in pydantic < 2

### DIFF
--- a/meilisearch/models/key.py
+++ b/meilisearch/models/key.py
@@ -38,7 +38,11 @@ class _KeyBase(CamelBase):
             json_encoders = {
                 datetime: lambda v: None
                 if not v
-                else f"{str(v).split('.', maxsplit=1)[0].replace(' ', 'T')}Z"
+                else (
+                    f"{str(v).split('+')[0].replace(' ', 'T')}Z"
+                    if "+" in str(v)
+                    else f"{str(v).replace(' ', 'T')}Z"
+                )
             }
 
 
@@ -103,7 +107,11 @@ class KeyUpdate(CamelBase):
             json_encoders = {
                 datetime: lambda v: None
                 if not v
-                else f"{str(v).split('.', maxsplit=1)[0].replace(' ', 'T')}Z"
+                else (
+                    f"{str(v).split('+')[0].replace(' ', 'T')}Z"
+                    if "+" in str(v)
+                    else f"{str(v).replace(' ', 'T')}Z"
+                )
             }
 
 

--- a/meilisearch/models/key.py
+++ b/meilisearch/models/key.py
@@ -39,7 +39,7 @@ class _KeyBase(CamelBase):
                 datetime: lambda v: None
                 if not v
                 else (
-                    f"{str(v).split('+')[0].replace(' ', 'T')}Z"
+                    f"{str(v).split('+', maxsplit=1)[0].replace(' ', 'T')}Z"
                     if "+" in str(v)
                     else f"{str(v).replace(' ', 'T')}Z"
                 )
@@ -108,7 +108,7 @@ class KeyUpdate(CamelBase):
                 datetime: lambda v: None
                 if not v
                 else (
-                    f"{str(v).split('+')[0].replace(' ', 'T')}Z"
+                    f"{str(v).split('+', maxsplit=1)[0].replace(' ', 'T')}Z"
                     if "+" in str(v)
                     else f"{str(v).replace(' ', 'T')}Z"
                 )


### PR DESCRIPTION
# Pull Request

I came across some instances that can cause the current `json_encoder` for dates to either error or return truncated values in Pydantic < 2. The encoder this is updating is the same one we have been using all along and no one reported issues so it seems as though I just stumbled upon this by chance.

## Related issue
Fixes #<issue_number>

## What does this PR do?
- Handles the date when it ends in `+00:00`
- Properly handle `Z` dates to prevent truncation

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
