### PR TITLE
Migrate docs to Meilisearch subdomain

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+python-sdk.meilisearch.com/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,3 +57,10 @@ html_static_path = []
 
 # This value contains a list of modules to be mocked up.
 autodoc_mock_imports = ["camel_converter"]
+
+html_title = 'Meilisearch Python | Documentation'
+
+# Add Fathom analytics script
+html_js_files = [
+    ("https://cdn.usefathom.com/script.js", { "data-site": "QNBPJXIV", "defer": "defer" })
+]


### PR DESCRIPTION
# Pull Request

The goal of this PR is to prepare the repository to have the docs migrated to `https://python-sdk.meilisearch.com`.

## What does this PR do?
- Inject the Fathom analytics script
- Add CNAME for Github Pages redirection (see [github docs](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site/about-custom-domains-and-github-pages))

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
