### PR TITLE
Fix failing publication of the documentation 

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,8 +2,7 @@ name: Documentation
 
 on:
   push:
-    tags:
-      - v*
+    branches: [main]
   # Allows to run the workflow manually
   workflow_dispatch:
 

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,8 +1,9 @@
 name: Documentation
 
 on:
-  push:
-    branches: [main]
+  release:
+    types:
+      - published
   # Allows to run the workflow manually
   workflow_dispatch:
 


### PR DESCRIPTION
The documentation should be deployed when new PRs are merged into the main branch

### Related issue
#816 
