### PR TITLE
Add codecoverage token

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,6 +40,8 @@ jobs:
         uses: codecov/codecov-action@v3
         with:
           fail_ci_if_error: true
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   pylint:
     name: pylint


### PR DESCRIPTION
I added `CODECOV_TOKEN` in the repo settings

Could reduce flaky tests with codecoverage: https://github.com/meilisearch/meilisearch-python/pull/843#issuecomment-1715837393