### PR TITLE
Add code samples and remove useless ones

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -355,6 +355,14 @@ typo_tolerance_guide_4: |-
       'twoTypos': 10
     }
   })
+search_parameter_guide_show_ranking_score_1: |-
+  client.index('movies').search('dragon', {
+    'showRankingScore': true
+  })
+search_parameter_guide_attributes_to_search_on_1: |-
+  client.index('movies').search('adventure', {
+    'attributesToSearchOn': ['overview']
+  })
 add_movies_json_1: |-
   import json
 
@@ -372,11 +380,6 @@ landing_getting_started_1: |-
     { 'id': 5, 'title': 'Moana' },
     { 'id': 6, 'title': 'Philadelphia'}
   ])
-documents_guide_add_movie_1: |-
-  client.index('movies').add_documents([{
-    'movie_id': '123sq178',
-    'title': 'Amélie Poulain'
-  }])
 getting_started_check_task_status: |-
   client.get_task(0)
 getting_started_add_documents_md: |-
@@ -464,11 +467,13 @@ getting_started_configure_settings: |-
         '_geo'
     ]
   })
-getting_started_communicating_with_a_protected_instance: |-
-  client = Client('http://localhost:7700', 'apiKey')
-  client.index('movies').search()
 getting_started_faceting: |-
-  client.index('movies').update_faceting_settings({'maxValuesPerFacet': 2})
+  client.index('movies').update_faceting_settings({
+    'maxValuesPerFacet': 2,
+    'sortFacetValuesBy': {
+      '*': 'count'
+    }
+  })
 getting_started_pagination: |-
   client.index('movies').update_pagination_settings({'maxTotalHits': 500})
 filtering_update_settings_1: |-
@@ -476,10 +481,6 @@ filtering_update_settings_1: |-
       'director',
       'genres',
   ])
-faceted_search_facets_1: |-
-  client.index('movies').search('Batman', {
-    'facets': ['genres']
-  })
 faceted_search_walkthrough_filter_1: |-
   client.index('movies').search('thriller', {
     'filter': [['genres = Horror', 'genres = Mystery'], 'director = "Jordan Peele"']
@@ -494,26 +495,6 @@ faceted_search_1: |-
   client.index('books').search('classic', {
     'facets': ['genres', 'rating', 'language']
   })
-faceted_search_2: |-
-  client.multi_search(
-    [
-      {
-        'indexUid': 'books',
-        'facets': ['language', 'genres', 'author', 'format'],
-        'filter': '(language = English AND language = French) OR genres = Fiction'
-      },
-      {
-        'indexUid': 'books',
-        'facets': ['language'],
-        'filter': 'genres = Fiction'
-      },
-      {
-        'indexUid': 'books',
-        'facets': ['genres'],
-        'filter': 'language = English OR language = French'
-      },
-    ]
-  )
 post_dump_1: |-
   client.create_dump()
 phrase_search_1: |-
@@ -644,10 +625,11 @@ update_faceting_settings_1: |-
   params = {
     'maxValuesPerFacet': 2,
     'sortFacetValuesBy': {
-        '*': 'count'
+        '*': 'count',
+        'genres': 'count'
       }
   }
-  client.index('movies').update_faceting_settings(params)
+  client.index('books').update_faceting_settings(params)
 reset_faceting_settings_1: |-
   client.index('books').reset_faceting_settings()
 synonyms_guide_1: |-
@@ -697,5 +679,7 @@ facet_search_1: |-
   client.index('books').facet_search('fiction', 'genres', {
     'filter': 'rating > 3'
   })
+facet_search_2: |-
+  client.index('books').update_faceting_settings({ 'sortFacetValuesBy': { 'genres': 'count' } })
 facet_search_3: |-
   client.index('books').facet_search('c', 'genres')


### PR DESCRIPTION
I created [scripts to manage code samples](https://github.com/meilisearch/integration-automations/pull/164) (internal only).

The script mostly compare the code samples of the SDK with the [one in the docs](https://github.com/meilisearch/documentation/blob/main/.code-samples.meilisearch.yaml)

1. I found out the following code samples are still in this repo but not used by the documentation anymore, so I removed them:

```bash
meilisearch-python
- 'facet_search_2' not found
- 'search_parameter_guide_show_ranking_score_1' not found
- 'search_parameter_guide_attributes_to_search_on_1' not found
```

2. I found the following code samples were missing:

```bash
meilisearch-python
- 'documents_guide_add_movie_1' not found in documentation
- 'getting_started_communicating_with_a_protected_instance' not found in documentation
- 'faceted_search_facets_1' not found in documentation
- 'faceted_search_2' not found in documentation
```