### PR TITLE
Modification of documentation deployment launch

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,9 +1,9 @@
 name: Documentation
 
 on:
-  release:
-    types:
-      - published
+  push:
+    tags:
+      - 'v*'
   # Allows to run the workflow manually
   workflow_dispatch:
 


### PR DESCRIPTION
# Pull Request

Github action on documentation deployment is failing:
https://github.com/meilisearch/meilisearch-python/actions/runs/6299217011
![Screenshot 2023-09-26 at 15 04 49](https://github.com/meilisearch/meilisearch-python/assets/16155041/e0477f28-d94c-4932-b695-798700084e59)


## What does this PR do?
- This PR ensures that documentation is published when a release tag is newly published.

