### PR TITLE
Revert dictionary parameter back to optional

### DIFF
--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -1594,7 +1594,7 @@ class Index:
         """
         return self.http.get(self.__settings_url_for(self.config.paths.dictionary))
 
-    def update_dictionary(self, body: List[str]) -> TaskInfo:
+    def update_dictionary(self, body: Union[List[str], None]) -> TaskInfo:
         """Update the dictionary of the index.
 
         Parameters


### PR DESCRIPTION
This reverts commit 52d352dbf3a7ecca9bf30814580d264871bcdfc9. See: https://github.com/meilisearch/meilisearch-python/pull/870#discussion_r1370167947
