### PR TITLE
Improve release drafter template

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -14,6 +14,8 @@ categories:
     label: 'enhancement'
   - title: '🐛 Bug Fixes'
     label: 'bug'
+  - title: '⚙️ Maintenance'
+    label: 'maintenance'
   - title: '🔒 Security'
     label: 'security'
 template: |
@@ -30,4 +32,6 @@ replacers:
   - search: '/(?:and )?@bors(?:\[bot\])?,?/g'
     replace: ''
   - search: '/(?:and )?@meili-bot,?/g'
+    replace: ''
+  - search: '/(?:and )?@meili-bot(?:\[bot\])?,?/g'
     replace: ''


### PR DESCRIPTION
Add a `maintenance` section in the automatically created changelog. We were missing this section for all PRs that are not related to enhancement or bug fixes

This will avoid this kind of situation when doing a release:

<img width="1123" alt="Capture d’écran 2023-10-25 à 18 47 53" src="https://github.com/meilisearch/meilisearch-python/assets/20380692/5723d04f-c47a-4b12-a7a9-fdaa61a4af8d">

<img width="1218" alt="Capture d’écran 2023-10-25 à 18 48 16" src="https://github.com/meilisearch/meilisearch-python/assets/20380692/c3b171c3-a462-4795-99b5-33971a1a305f">

-> the PR was well-labeled but the automation did not take it into consideration
