### PR TITLE
Supports typing around documents with `Mapping`

### DIFF
--- a/meilisearch/_httprequests.py
+++ b/meilisearch/_httprequests.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from functools import lru_cache
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
 
 import requests
 
@@ -27,7 +27,7 @@ class HttpRequests:
         self,
         http_method: Callable,
         path: str,
-        body: Optional[Union[Dict[str, Any], List[Dict[str, Any]], List[str], str]] = None,
+        body: Optional[Union[Dict[str, Any], Sequence[Mapping[str, Any]], List[str], str]] = None,
         content_type: Optional[str] = None,
     ) -> Any:
         if content_type:
@@ -67,7 +67,7 @@ class HttpRequests:
     def post(
         self,
         path: str,
-        body: Optional[Union[Dict[str, Any], List[Dict[str, Any]], List[str], str]] = None,
+        body: Optional[Union[Dict[str, Any], Sequence[Mapping[str, Any]], List[str], str]] = None,
         content_type: Optional[str] = "application/json",
     ) -> Any:
         return self.send_request(requests.post, path, body, content_type)
@@ -75,7 +75,7 @@ class HttpRequests:
     def patch(
         self,
         path: str,
-        body: Optional[Union[Dict[str, Any], List[Dict[str, Any]], List[str], str]] = None,
+        body: Optional[Union[Dict[str, Any], Sequence[Mapping[str, Any]], List[str], str]] = None,
         content_type: Optional[str] = "application/json",
     ) -> Any:
         return self.send_request(requests.patch, path, body, content_type)
@@ -83,7 +83,7 @@ class HttpRequests:
     def put(
         self,
         path: str,
-        body: Optional[Union[Dict[str, Any], List[Dict[str, Any]], List[str], str]] = None,
+        body: Optional[Union[Dict[str, Any], Sequence[Mapping[str, Any]], List[str], str]] = None,
         content_type: Optional[str] = "application/json",
     ) -> Any:
         return self.send_request(requests.put, path, body, content_type)
@@ -91,7 +91,7 @@ class HttpRequests:
     def delete(
         self,
         path: str,
-        body: Optional[Union[Dict[str, Any], List[Dict[str, Any]], List[str]]] = None,
+        body: Optional[Union[Dict[str, Any], Sequence[Mapping[str, Any]], List[str]]] = None,
     ) -> Any:
         return self.send_request(requests.delete, path, body)
 

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Any, Dict, Generator, List, Optional, Union
+from typing import Any, Dict, Generator, List, Mapping, Optional, Sequence, Union
 from urllib import parse
 from warnings import warn
 
@@ -387,7 +387,7 @@ class Index:
 
     def add_documents(
         self,
-        documents: List[Dict[str, Any]],
+        documents: Sequence[Mapping[str, Any]],
         primary_key: Optional[str] = None,
     ) -> TaskInfo:
         """Add documents to the index.
@@ -416,7 +416,7 @@ class Index:
 
     def add_documents_in_batches(
         self,
-        documents: List[Dict[str, Any]],
+        documents: Sequence[Mapping[str, Any]],
         batch_size: int = 1000,
         primary_key: Optional[str] = None,
     ) -> List[TaskInfo]:
@@ -573,7 +573,7 @@ class Index:
         return TaskInfo(**response)
 
     def update_documents(
-        self, documents: List[Dict[str, Any]], primary_key: Optional[str] = None
+        self, documents: Sequence[Mapping[str, Any]], primary_key: Optional[str] = None
     ) -> TaskInfo:
         """Update documents in the index.
 
@@ -721,7 +721,7 @@ class Index:
 
     def update_documents_in_batches(
         self,
-        documents: List[Dict[str, Any]],
+        documents: Sequence[Mapping[str, Any]],
         batch_size: int = 1000,
         primary_key: Optional[str] = None,
     ) -> List[TaskInfo]:
@@ -1757,8 +1757,8 @@ class Index:
 
     @staticmethod
     def _batch(
-        documents: List[Dict[str, Any]], batch_size: int
-    ) -> Generator[List[Dict[str, Any]], None, None]:
+        documents: Sequence[Mapping[str, Any]], batch_size: int
+    ) -> Generator[Sequence[Mapping[str, Any]], None, None]:
         total_len = len(documents)
         for i in range(0, total_len, batch_size):
             yield documents[i : i + batch_size]


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #888 

## What does this PR do?
- This PR changes the type hinting for documents in function parameters of functions like `update_documents` with `typing.Mapping`.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
