### PR TITLE
Fix potential type error in client_agents

### DIFF
--- a/meilisearch/_httprequests.py
+++ b/meilisearch/_httprequests.py
@@ -119,7 +119,7 @@ class HttpRequests:
 
 
 @lru_cache(maxsize=1)
-def _build_user_agent(client_agents: Optional[Tuple[str]] = None) -> str:
+def _build_user_agent(client_agents: Optional[Tuple[str, ...]] = None) -> str:
     user_agent = qualified_version()
     if not client_agents:
         return user_agent

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -33,7 +33,7 @@ class Client:
         url: str,
         api_key: Optional[str] = None,
         timeout: Optional[int] = None,
-        client_agents: Optional[Tuple[str]] = None,
+        client_agents: Optional[Tuple[str, ...]] = None,
     ) -> None:
         """
         Parameters

--- a/meilisearch/config.py
+++ b/meilisearch/config.py
@@ -43,7 +43,7 @@ class Config:
         url: str,
         api_key: Optional[str] = None,
         timeout: Optional[int] = None,
-        client_agents: Optional[Tuple[str]] = None,
+        client_agents: Optional[Tuple[str, ...]] = None,
     ) -> None:
         """
         Parameters


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #898

## What does this PR do?
- Allows for more than one string to be added to the tuple when sending `client_agents`.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
