### PR TITLE
Fix reported type of decorator

### DIFF
--- a/meilisearch/errors.py
+++ b/meilisearch/errors.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 from functools import wraps
-from typing import TYPE_CHECKING, Any, Callable
+from typing import TYPE_CHECKING, Any, Callable, TypeVar
 
 from requests import Response
 
@@ -10,6 +10,8 @@ if TYPE_CHECKING:  # pragma: no cover
     from meilisearch.client import Client
     from meilisearch.index import Index
     from meilisearch.task import TaskHandler
+
+T = TypeVar("T")
 
 
 class MeilisearchError(Exception):  # pragma: no cover
@@ -63,7 +65,7 @@ class MeilisearchTimeoutError(MeilisearchError):
         return f"MeilisearchTimeoutError, {self.message}"
 
 
-def version_error_hint_message(func: Callable) -> Any:
+def version_error_hint_message(func: Callable[..., T]) -> Callable[..., T]:
     @wraps(func)
     def wrapper(*args: Any, **kwargs: Any) -> Any:
         try:


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #<issue_number>

Reported on Discord https://discord.com/channels/1006923006964154428/1006923007559729154/1235605897418506401

The Return type is getting swallowed by the `version_error_hint_message` decorator.

![image](https://github.com/meilisearch/meilisearch-python/assets/25045024/1467c6b1-3d86-449a-ba6c-15b2a7c33777)

## What does this PR do?
- Uses a generic instead of `Any` for the decorator.

After the update:

![image](https://github.com/meilisearch/meilisearch-python/assets/25045024/3eb434a2-08ab-46fd-8bd1-24db11e8ce64)

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
