### PR TITLE
Fix document and vector fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -131,6 +131,8 @@ def index_with_documents(empty_index, small_movies):
 @fixture(scope="function")
 def index_with_documents_and_vectors(empty_index, small_movies):
     small_movies[0]["_vectors"] = {"default": [0.1, 0.2]}
+    for movie in small_movies[1:]:
+        movie["_vectors"] = {"default": [0.9, 0.9]}
 
     def index_maker(index_uid=common.INDEX_UID, documents=small_movies):
         index = empty_index(index_uid)

--- a/tests/index/test_index_search_meilisearch.py
+++ b/tests/index/test_index_search_meilisearch.py
@@ -462,6 +462,6 @@ def test_attributes_to_search_on_search_no_match(index_with_documents):
 @pytest.mark.usefixtures("enable_vector_search")
 def test_vector_search(index_with_documents_and_vectors):
     response = index_with_documents_and_vectors().search(
-        "", opt_params={"vector": [0.1, 0.2], "hybrid": {"semanticRatio": 1.0}}
+        "Shazam", opt_params={"vector": [0.1, 0.2], "hybrid": {"semanticRatio": 1.0}}
     )
-    assert response["hits"] == []
+    assert len(response["hits"]) > 0

--- a/tests/index/test_index_search_meilisearch.py
+++ b/tests/index/test_index_search_meilisearch.py
@@ -462,6 +462,6 @@ def test_attributes_to_search_on_search_no_match(index_with_documents):
 @pytest.mark.usefixtures("enable_vector_search")
 def test_vector_search(index_with_documents_and_vectors):
     response = index_with_documents_and_vectors().search(
-        "Shazam", opt_params={"vector": [0.1, 0.2], "hybrid": {"semanticRatio": 1.0}}
+        "", opt_params={"vector": [0.1, 0.2], "hybrid": {"semanticRatio": 1.0}}
     )
     assert len(response["hits"]) > 0


### PR DESCRIPTION
# Pull Request

In looking at #962 I noticed that the `index_with_documents_and_vectors` fixture was not working as expected and therefore the `test_vector_search` test was not testing what was expected. Because only one document had vectors the document addition task was failing and no documents were added to the index. So `test_vector_search` was returning no hits because there were no documents in the index. This updates the fixutre to add vectors to all documents, and updates the test to pass with the new results.

## Related issue
Fixes #<issue_number>

## What does this PR do?
- Fixes the `test_vector_search` test.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
