### PR TITLE
Allow passing a custom serializer for documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,34 @@ index.update_filterable_attributes([
 ])
 ```
 
+#### Custom Serializer for documents <!-- omit in toc -->
+
+If your documents contain fields that the Python JSON serializer does not know how to handle you
+can use your own custom serializer.
+
+```py
+from datetime import datetime
+from json import JSONEncoder
+from uuid import uuid4
+
+
+class CustomEncoder(JSONEncoder):
+    def default(self, o):
+        if isinstance(o, (UUID, datetime)):
+            return str(o)
+
+        # Let the base class default method raise the TypeError
+        return super().default(o)
+
+
+documents = [
+    {"id": uuid4(), "title": "test 1", "when": datetime.now()},
+    {"id": uuid4(), "title": "Test 2", "when": datetime.now()},
+]
+index = empty_index()
+index.add_documents(documents, serializer=CustomEncoder)
+```
+
 You only need to perform this operation once.
 
 Note that Meilisearch will rebuild your index whenever you update `filterableAttributes`. Depending on the size of your dataset, this might take time. You can track the process using the [task](https://www.meilisearch.com/docs/reference/api/tasks#get-tasks).
@@ -204,7 +232,6 @@ index.search(
 ## 🤖 Compatibility with Meilisearch
 
 This package guarantees compatibility with [version v1.x of Meilisearch](https://github.com/meilisearch/meilisearch/releases/latest), but some features may not be present. Please check the [issues](https://github.com/meilisearch/meilisearch-python/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3Aenhancement) for more info.
-
 
 ## 💡 Learn more
 

--- a/meilisearch/_httprequests.py
+++ b/meilisearch/_httprequests.py
@@ -2,18 +2,7 @@ from __future__ import annotations
 
 import json
 from functools import lru_cache
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Callable,
-    List,
-    Mapping,
-    Optional,
-    Sequence,
-    Tuple,
-    Type,
-    Union,
-)
+from typing import Any, Callable, List, Mapping, Optional, Sequence, Tuple, Type, Union
 
 import requests
 
@@ -25,9 +14,6 @@ from meilisearch.errors import (
 )
 from meilisearch.models.index import ProximityPrecision
 from meilisearch.version import qualified_version
-
-if TYPE_CHECKING:
-    from json import JSONEncoder
 
 
 class HttpRequests:
@@ -54,7 +40,7 @@ class HttpRequests:
         ] = None,
         content_type: Optional[str] = None,
         *,
-        serializer: Optional[Type[JSONEncoder]] = None,
+        serializer: Optional[Type[json.JSONEncoder]] = None,
     ) -> Any:
         if content_type:
             self.headers["Content-Type"] = content_type
@@ -97,7 +83,7 @@ class HttpRequests:
         ] = None,
         content_type: Optional[str] = "application/json",
         *,
-        serializer: Optional[Type[JSONEncoder]] = None,
+        serializer: Optional[Type[json.JSONEncoder]] = None,
     ) -> Any:
         return self.send_request(requests.post, path, body, content_type, serializer=serializer)
 
@@ -126,7 +112,7 @@ class HttpRequests:
         ] = None,
         content_type: Optional[str] = "application/json",
         *,
-        serializer: Optional[Type[JSONEncoder]] = None,
+        serializer: Optional[Type[json.JSONEncoder]] = None,
     ) -> Any:
         return self.send_request(requests.put, path, body, content_type, serializer=serializer)
 

--- a/meilisearch/_httprequests.py
+++ b/meilisearch/_httprequests.py
@@ -2,7 +2,18 @@ from __future__ import annotations
 
 import json
 from functools import lru_cache
-from typing import Any, Callable, List, Mapping, Optional, Sequence, Tuple, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    Union,
+)
 
 import requests
 
@@ -14,6 +25,9 @@ from meilisearch.errors import (
 )
 from meilisearch.models.index import ProximityPrecision
 from meilisearch.version import qualified_version
+
+if TYPE_CHECKING:
+    from json import JSONEncoder
 
 
 class HttpRequests:
@@ -39,6 +53,8 @@ class HttpRequests:
             ]
         ] = None,
         content_type: Optional[str] = None,
+        *,
+        serializer: Optional[Type[JSONEncoder]] = None,
     ) -> Any:
         if content_type:
             self.headers["Content-Type"] = content_type
@@ -58,11 +74,10 @@ class HttpRequests:
                     data=body,
                 )
             else:
+                data = json.dumps(body, cls=serializer) if body else "" if body == "" else "null"
+
                 request = http_method(
-                    request_path,
-                    timeout=self.config.timeout,
-                    headers=self.headers,
-                    data=json.dumps(body) if body else "" if body == "" else "null",
+                    request_path, timeout=self.config.timeout, headers=self.headers, data=data
                 )
             return self.__validate(request)
 
@@ -81,8 +96,10 @@ class HttpRequests:
             Union[Mapping[str, Any], Sequence[Mapping[str, Any]], List[str], str]
         ] = None,
         content_type: Optional[str] = "application/json",
+        *,
+        serializer: Optional[Type[JSONEncoder]] = None,
     ) -> Any:
-        return self.send_request(requests.post, path, body, content_type)
+        return self.send_request(requests.post, path, body, content_type, serializer=serializer)
 
     def patch(
         self,
@@ -108,8 +125,10 @@ class HttpRequests:
             ]
         ] = None,
         content_type: Optional[str] = "application/json",
+        *,
+        serializer: Optional[Type[JSONEncoder]] = None,
     ) -> Any:
-        return self.send_request(requests.put, path, body, content_type)
+        return self.send_request(requests.put, path, body, content_type, serializer=serializer)
 
     def delete(
         self,

--- a/tests/index/test_index_document_meilisearch.py
+++ b/tests/index/test_index_document_meilisearch.py
@@ -1,12 +1,24 @@
 # pylint: disable=invalid-name
 
+from datetime import datetime
+from json import JSONEncoder
 from math import ceil
+from uuid import UUID, uuid4
 from warnings import catch_warnings
 
 import pytest
 
 from meilisearch.models.document import Document
 from meilisearch.models.task import TaskInfo
+
+
+class CustomEncoder(JSONEncoder):
+    def default(self, o):
+        if isinstance(o, (UUID, datetime)):
+            return str(o)
+
+        # Let the base class default method raise the TypeError
+        return super().default(o)
 
 
 def test_get_documents_default(empty_index):
@@ -58,6 +70,117 @@ def test_add_documents_in_batches(
         assert update.status == "succeeded"
 
     assert index.get_primary_key() == expected_primary_key
+
+
+def test_add_documents_custom_serializer(empty_index):
+    documents = [
+        {"id": uuid4(), "title": "test 1", "when": datetime.now()},
+        {"id": uuid4(), "title": "Test 2", "when": datetime.now()},
+    ]
+    index = empty_index()
+    response = index.add_documents(documents, serializer=CustomEncoder)
+    assert isinstance(response, TaskInfo)
+    assert response.task_uid is not None
+    update = index.wait_for_task(response.task_uid)
+    assert index.get_primary_key() == "id"
+    assert update.status == "succeeded"
+
+
+def test_add_documents_in_batches_custom_serializer(empty_index):
+    documents = [
+        {"id": uuid4(), "title": "test 1", "when": datetime.now()},
+        {"id": uuid4(), "title": "Test 2", "when": datetime.now()},
+    ]
+    index = empty_index()
+    response = index.add_documents_in_batches(documents, batch_size=1, serializer=CustomEncoder)
+    for task in response:
+        update = index.wait_for_task(task.task_uid)
+        assert update.status == "succeeded"
+    assert index.get_primary_key() == "id"
+
+
+def test_add_documents_json_custom_serializer(empty_index):
+    documents = [
+        {"id": uuid4(), "title": "test 1", "when": datetime.now()},
+        {"id": uuid4(), "title": "Test 2", "when": datetime.now()},
+    ]
+    index = empty_index()
+    response = index.add_documents_json(documents, serializer=CustomEncoder)
+    assert isinstance(response, TaskInfo)
+    assert response.task_uid is not None
+    update = index.wait_for_task(response.task_uid)
+    assert index.get_primary_key() == "id"
+    assert update.status == "succeeded"
+
+
+def test_add_documents_raw_custom_serializer(empty_index):
+    documents = [
+        {"id": uuid4(), "title": "test 1", "when": datetime.now()},
+        {"id": uuid4(), "title": "Test 2", "when": datetime.now()},
+    ]
+    index = empty_index()
+    response = index.add_documents_raw(documents, content_type="application/json", serializer=CustomEncoder)
+    assert isinstance(response, TaskInfo)
+    assert response.task_uid is not None
+    update = index.wait_for_task(response.task_uid)
+    assert index.get_primary_key() == "id"
+    assert update.status == "succeeded"
+
+
+def test_update_documents_custom_serializer(empty_index):
+    documents = [
+        {"id": uuid4(), "title": "test 1", "when": datetime.now()},
+        {"id": uuid4(), "title": "Test 2", "when": datetime.now()},
+    ]
+    index = empty_index()
+    response = index.update_documents(documents, serializer=CustomEncoder)
+    assert isinstance(response, TaskInfo)
+    assert response.task_uid is not None
+    update = index.wait_for_task(response.task_uid)
+    assert index.get_primary_key() == "id"
+    assert update.status == "succeeded"
+
+
+def test_update_documents_in_batches_custom_serializer(empty_index):
+    documents = [
+        {"id": uuid4(), "title": "test 1", "when": datetime.now()},
+        {"id": uuid4(), "title": "Test 2", "when": datetime.now()},
+    ]
+    index = empty_index()
+    response = index.update_documents_in_batches(documents, batch_size=1, serializer=CustomEncoder)
+    for task in response:
+        update = index.wait_for_task(task.task_uid)
+        assert update.status == "succeeded"
+    assert index.get_primary_key() == "id"
+
+
+def test_update_documents_json_custom_serializer(empty_index):
+    documents = [
+        {"id": uuid4(), "title": "test 1", "when": datetime.now()},
+        {"id": uuid4(), "title": "Test 2", "when": datetime.now()},
+    ]
+    index = empty_index()
+    response = index.update_documents_json(documents, serializer=CustomEncoder)
+    assert isinstance(response, TaskInfo)
+    assert response.task_uid is not None
+    update = index.wait_for_task(response.task_uid)
+    assert index.get_primary_key() == "id"
+    assert update.status == "succeeded"
+
+
+def test_update_documents_raw_custom_serializer(empty_index):
+
+    documents = [
+        {"id": uuid4(), "title": "test 1", "when": datetime.now()},
+        {"id": uuid4(), "title": "Test 2", "when": datetime.now()},
+    ]
+    index = empty_index()
+    response = index.update_documents_raw(documents, content_type="application/json", serializer=CustomEncoder)
+    assert isinstance(response, TaskInfo)
+    assert response.task_uid is not None
+    update = index.wait_for_task(response.task_uid)
+    assert index.get_primary_key() == "id"
+    assert update.status == "succeeded"
 
 
 def test_get_document(index_with_documents):

--- a/tests/index/test_index_document_meilisearch.py
+++ b/tests/index/test_index_document_meilisearch.py
@@ -119,7 +119,9 @@ def test_add_documents_raw_custom_serializer(empty_index):
         {"id": uuid4(), "title": "Test 2", "when": datetime.now()},
     ]
     index = empty_index()
-    response = index.add_documents_raw(documents, content_type="application/json", serializer=CustomEncoder)
+    response = index.add_documents_raw(
+        documents, content_type="application/json", serializer=CustomEncoder
+    )
     assert isinstance(response, TaskInfo)
     assert response.task_uid is not None
     update = index.wait_for_task(response.task_uid)
@@ -175,7 +177,9 @@ def test_update_documents_raw_custom_serializer(empty_index):
         {"id": uuid4(), "title": "Test 2", "when": datetime.now()},
     ]
     index = empty_index()
-    response = index.update_documents_raw(documents, content_type="application/json", serializer=CustomEncoder)
+    response = index.update_documents_raw(
+        documents, content_type="application/json", serializer=CustomEncoder
+    )
     assert isinstance(response, TaskInfo)
     assert response.task_uid is not None
     update = index.wait_for_task(response.task_uid)


### PR DESCRIPTION
# Pull Request

@LaundroMat FYI in case you want to test this to see if it solves your issue.

## Related issue
Fixes #973

## What does this PR do?
- Allows passing a custom JSONEncoder to serialize documents with types that the default encoder can't handle.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
