### PR TITLE
Remove extra line from readme example

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,6 @@ documents = [
     {"id": uuid4(), "title": "test 1", "when": datetime.now()},
     {"id": uuid4(), "title": "Test 2", "when": datetime.now()},
 ]
-index = empty_index()
 index.add_documents(documents, serializer=CustomEncoder)
 ```
 


### PR DESCRIPTION
# Pull Request

I just noticed that when I was updating the readme with a seriaizer example I accidentally include a line from a test that doesn't make sense in the context of the example. This removes that line.

## Related issue
Fixes #<issue_number>

## What does this PR do?
- ...

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
