### PR TITLE
Remove huggingface setting in tests to fix flakiyness

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,7 +7,7 @@ from pytest import fixture
 
 import meilisearch
 from meilisearch.errors import MeilisearchApiError
-from meilisearch.models.index import HuggingFaceEmbedder, OpenAiEmbedder, UserProvidedEmbedder
+from meilisearch.models.index import OpenAiEmbedder, UserProvidedEmbedder
 from tests import common
 
 
@@ -235,5 +235,4 @@ def new_embedders():
     return {
         "default": UserProvidedEmbedder(dimensions=1).model_dump(by_alias=True),
         "open_ai": OpenAiEmbedder().model_dump(by_alias=True),
-        "hugging_face": HuggingFaceEmbedder().model_dump(by_alias=True),
     }

--- a/tests/settings/test_settings_embedders.py
+++ b/tests/settings/test_settings_embedders.py
@@ -1,7 +1,7 @@
 # pylint: disable=redefined-outer-name
 import pytest
 
-from meilisearch.models.index import HuggingFaceEmbedder, OpenAiEmbedder, UserProvidedEmbedder
+from meilisearch.models.index import OpenAiEmbedder, UserProvidedEmbedder
 
 
 @pytest.mark.usefixtures("enable_vector_search")
@@ -22,7 +22,6 @@ def test_update_embedders_with_user_provided_source(new_embedders, empty_index):
     assert update.status == "succeeded"
     assert isinstance(response_get.embedders["default"], UserProvidedEmbedder)
     assert isinstance(response_get.embedders["open_ai"], OpenAiEmbedder)
-    assert isinstance(response_get.embedders["hugging_face"], HuggingFaceEmbedder)
 
 
 @pytest.mark.usefixtures("enable_vector_search")
@@ -38,7 +37,6 @@ def test_reset_embedders(new_embedders, empty_index):
     response_get = index.get_embedders()
     assert isinstance(response_get.embedders["default"], UserProvidedEmbedder)
     assert isinstance(response_get.embedders["open_ai"], OpenAiEmbedder)
-    assert isinstance(response_get.embedders["hugging_face"], HuggingFaceEmbedder)
     # Reset the setting
     response_reset = index.reset_embedders()
     update2 = index.wait_for_task(response_reset.task_uid)
@@ -46,6 +44,5 @@ def test_reset_embedders(new_embedders, empty_index):
     assert update2.status == "succeeded"
     assert isinstance(response_get.embedders["default"], UserProvidedEmbedder)
     assert isinstance(response_get.embedders["open_ai"], OpenAiEmbedder)
-    assert isinstance(response_get.embedders["hugging_face"], HuggingFaceEmbedder)
     response_last = index.get_embedders()
     assert response_last is None


### PR DESCRIPTION
# Pull Request

The HuggingFace embedder was removed from tests in #978, but I found some more places it was being tested. I was able to get the tests to fail locally like they are in CI with HuggingFace present. Since removing the additional HuggingFace tests I haven't been able to get them to fail again locally.

## Related issue
Fixes #976

## What does this PR do?
- Removes HuggingFace embedder from tests to fix flakiness.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
