### PR TITLE
Adds documentation for search parameter reference distinct

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -372,6 +372,8 @@ search_parameter_guide_attributes_to_search_on_1: |-
   client.index('movies').search('adventure', {
     'attributesToSearchOn': ['overview']
   })
+search_parameter_reference_distinct_1: |-
+  client.index('INDEX_NAME').search('QUERY_TERMS', { distinct: 'ATTRIBUTE_A' })
 distinct_attribute_guide_filterable_1: |-
   client.index('products').update_filterable_attributes(['product_id', 'sku', 'url'])
 distinct_attribute_guide_distinct_parameter_1: |-


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #989

## What does this PR do?
- Adds search_parameter_reference_distinct_1 key and “translates” the following curl example by using the newly added methods: https://github.com/meilisearch/documentation/blob/04f26a35771305378ed0a506f4d60ef06d07bd7e/.code-samples.meilisearch.yaml#L1308

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
