### PR TITLE
Support boolean parameters in `Index.get_documents`

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ index.search(
 
 ## 🤖 Compatibility with Meilisearch
 
-This package guarantees compatibility with [version v1.x of Meilisearch](https://github.com/meilisearch/meilisearch/releases/latest), but some features may not be present. Please check the [issues](https://github.com/meilisearch/meilisearch-python/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3Aenhancement) for more info.
+This package guarantees compatibility with [version v1.2 and above of Meilisearch](https://github.com/meilisearch/meilisearch/releases/latest), but some features may not be present. Please check the [issues](https://github.com/meilisearch/meilisearch-python/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22+label%3Aenhancement) for more info.
 
 ## 💡 Learn more
 

--- a/meilisearch/_httprequests.py
+++ b/meilisearch/_httprequests.py
@@ -60,7 +60,12 @@ class HttpRequests:
                     data=body,
                 )
             else:
-                data = json.dumps(body, cls=serializer) if body else "" if body == "" else "null"
+                serialize_body = isinstance(body, dict) or body
+                data = (
+                    json.dumps(body, cls=serializer)
+                    if serialize_body
+                    else "" if body == "" else "null"
+                )
 
                 request = http_method(
                     request_path, timeout=self.config.timeout, headers=self.headers, data=data

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -397,17 +397,8 @@ class Index:
         MeilisearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
         """
-        if parameters is None or parameters.get("filter") is None:
-            if parameters is None:
-                parameters = {}
-            elif "fields" in parameters and isinstance(parameters["fields"], list):
-                parameters["fields"] = ",".join(parameters["fields"])
-
-            response = self.http.get(
-                f"{self.config.paths.index}/{self.uid}/{self.config.paths.document}?{parse.urlencode(parameters)}"
-            )
-            return DocumentsResults(response)
-
+        if parameters is None:
+            parameters = {}
         response = self.http.post(
             f"{self.config.paths.index}/{self.uid}/{self.config.paths.document}/fetch",
             body=parameters,

--- a/tests/index/test_index_document_meilisearch.py
+++ b/tests/index/test_index_document_meilisearch.py
@@ -224,7 +224,7 @@ def test_get_documents_offset_optional_params(index_with_documents):
     response = index.get_documents()
     assert isinstance(response.results, list)
     assert len(response.results) == 20
-    response_offset_limit = index.get_documents({"limit": 3, "offset": 1, "fields": "title"})
+    response_offset_limit = index.get_documents({"limit": 3, "offset": 1, "fields": ["title"]})
     assert len(response_offset_limit.results) == 3
     assert hasattr(response_offset_limit.results[0], "title")
     assert response_offset_limit.results[0].title == response.results[1].title


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1044

## What does this PR do?
- Remove deprecated `GET` in `Index.get_documents`. This solves the urlparse encoding problem described in the issues.
- Fix a syntax (Meili API syntax) error in `tests/index/test_index_document_meilisearch.py`

## Request for comments
I introduced the `serialize_body` variable because it made my life easier when figuring things out. I'm very much open for suggestions on how to handle that case.