### PR TITLE
Improve documentation for Index.add_documents() methods

### DIFF
--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -484,17 +484,17 @@ class Index:
 
     def add_documents_json(
         self,
-        str_documents: str,
+        str_documents: bytes,
         primary_key: Optional[str] = None,
         *,
         serializer: Optional[Type[JSONEncoder]] = None,
     ) -> TaskInfo:
-        """Add string documents from JSON file to the index.
+        """Add documents to the index from a byte-encoded JSON string.
 
         Parameters
         ----------
         str_documents:
-            String of document from a JSON file.
+            Byte-encoded JSON string.
         primary_key (optional):
             The primary-key used in index. Ignored if already set up.
         serializer (optional):
@@ -518,16 +518,16 @@ class Index:
 
     def add_documents_csv(
         self,
-        str_documents: str,
+        str_documents: bytes,
         primary_key: Optional[str] = None,
         csv_delimiter: Optional[str] = None,
     ) -> TaskInfo:
-        """Add string documents from a CSV file to the index.
+        """Add documents to the index from a byte-encoded CSV string.
 
         Parameters
         ----------
         str_documents:
-            String of document from a CSV file.
+            Byte-encoded CSV string.
         primary_key (optional):
             The primary-key used in index. Ignored if already set up.
         csv_delimiter:
@@ -548,15 +548,15 @@ class Index:
 
     def add_documents_ndjson(
         self,
-        str_documents: str,
+        str_documents: bytes,
         primary_key: Optional[str] = None,
     ) -> TaskInfo:
-        """Add string documents from a NDJSON file to the index.
+        """Add documents to the index from a byte-encoded NDJSON string.
 
         Parameters
         ----------
         str_documents:
-            String of document from a NDJSON file.
+            Byte-encoded NDJSON string.
         primary_key (optional):
             The primary-key used in index. Ignored if already set up.
 
@@ -575,24 +575,24 @@ class Index:
 
     def add_documents_raw(
         self,
-        str_documents: str,
+        str_documents: bytes,
+        content_type: str,
         primary_key: Optional[str] = None,
-        content_type: Optional[str] = None,
         csv_delimiter: Optional[str] = None,
         *,
         serializer: Optional[Type[JSONEncoder]] = None,
     ) -> TaskInfo:
-        """Add string documents to the index.
+        """Add documents to the index from a byte-encoded string.
 
         Parameters
         ----------
         str_documents:
-            String of document.
+            Byte-encoded string.
+        content_type:
+            The content MIME type: 'application/json', 'application/x-dnjson', or 'text/csv'.
         primary_key (optional):
             The primary-key used in index. Ignored if already set up.
-        type:
-            The type of document. Type available: 'csv', 'json', 'jsonl'.
-        csv_delimiter:
+        csv_delimiter (optional):
             One ASCII character used to customize the delimiter for CSV.
             Note: The csv delimiter can only be used with the Content-Type text/csv.
         serializer (optional):


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1056

## What does this PR do?
- Improves the documentation for `Index.add_documents_csv()`, `Index.add_documents_json()`, `Index.add_documents_ndjson()`, and `Index.add_documents_raw()`. These methods require a byte string as input, not a regular string (this wasn't documented clearly).
- Fixes incorrect documentation for `Index.add_documents_raw()`. Instead of a `type` variable, the method takes a `content_type` variable; and it's not optional (if it's left out, the server will give a 415 error).

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
