### PR TITLE
Test getting tasks in reverse

### DIFF
--- a/tests/client/test_client_task_meilisearch.py
+++ b/tests/client/test_client_task_meilisearch.py
@@ -156,3 +156,12 @@ def test_delete_tasks_by_filter(client):
     assert (
         "statuses=succeeded%2Cfailed%2Ccanceled" in tasks_after.results[0].details["originalFilter"]
     )
+
+
+@pytest.mark.usefixtures("create_tasks")
+def test_get_tasks_in_reverse(client):
+    """Tests getting the global tasks list in reverse."""
+    tasks = client.get_tasks({})
+    reverse_tasks = client.get_tasks({"reverse": "true"})
+
+    assert reverse_tasks.results[0] == tasks.results[-1]


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1049


It's more a test of meilisearch itself than the integration with python, but it was required in the issue, and I suppose it would prevent a regression if the `get_tasks` parameters changed somehow.
