### PR TITLE
Support searching for similar documents

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -751,3 +751,5 @@ get_all_batches_1: |-
   client.get_batches()
 get_batch_1: |-
   client.get_batch(BATCH_UID)
+get_similar_post_1: |-
+  client.index("INDEX_NAME").get_similar_documents({"id": "TARGET_DOCUMENT_ID", "embedder": "default"})

--- a/meilisearch/config.py
+++ b/meilisearch/config.py
@@ -20,6 +20,7 @@ class Config:
         facet_search = "facet-search"
         multi_search = "multi-search"
         document = "documents"
+        similar = "similar"
         setting = "settings"
         ranking_rules = "ranking-rules"
         distinct_attribute = "distinct-attribute"

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -406,6 +406,30 @@ class Index:
         )
         return DocumentsResults(response)
 
+    def get_similar_documents(self, parameters: Mapping[str, Any]) -> Dict[str, Any]:
+        """Get the documents similar to a document.
+
+        Parameters
+        ----------
+        parameters:
+            parameters accepted by the get similar documents route: https://www.meilisearch.com/docs/reference/api/similar#body
+            "id" and "embedder" are required.
+
+        Returns
+        -------
+        results:
+            Dictionary with hits, offset, limit, processingTimeMs, and id
+
+        Raises
+        ------
+        MeilisearchApiError
+            An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
+        """
+        return self.http.post(
+            f"{self.config.paths.index}/{self.uid}/{self.config.paths.similar}",
+            body=parameters,
+        )
+
     def add_documents(
         self,
         documents: Sequence[Mapping[str, Any]],


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #988

Instructions were not to add the `GET` endpoint, it seems other integrations also do not have it.

I tried as closely as possible to match the documentation and the signature of the main `search` method. If I should wrap the results in a class, please let me know once again and I'll do it.