### PR TITLE
Add federated search code-sample

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -742,3 +742,8 @@ update_localized_attribute_settings_1: |-
   ])
 reset_localized_attribute_settings_1: |-
   client.index('INDEX_NAME').reset_localized_attributes()
+multi_search_federated_1: |-
+  client.multi_search(
+    [{"indexUid": "movies", "q": "batman"}, {"indexUid": "comics", "q": "batman"}],
+    {}
+  )


### PR DESCRIPTION
There is a code sample at https://www.meilisearch.com/docs/reference/api/multi_search#federated-multi-search which most integrations don't seem to have.

Noticed this today and reported on integration-guides: https://github.com/meilisearch/integration-guides/issues/313