### PR TITLE
Fix Python version error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.8.4-buster
+FROM python:3.9-buster
 
 COPY Pipfile .
 COPY Pipfile.lock .


### PR DESCRIPTION
# Pull Request

I couldn't successfully run the tests due to a missing import:

```bash
docker-compose run --rm package bash -c "pipenv install --dev && pipenv run mypy meilisearch && pipenv run pylint meilisearch tests && pipenv run pytest tests"
```

Gave the following output:

```
WARN[0000] /Users/strift/Code/Meili/meilisearch-python/docker-compose.yml: the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 
[+] Creating 1/1
 ✔ Container meilisearch-python-meilisearch-1  Running                                                                                                                             0.0s 
Creating a virtualenv for this project
Pipfile: /home/package/Pipfile
Using default python from /usr/local/bin/python3.8.4 to create virtualenv...
⠹ Creating virtual environment...created virtual environment CPython3.8.4.final.0-64 in 168ms
  creator CPython3Posix(dest=/root/.local/share/virtualenvs/package-3pJoT3Dw, clear=False, no_vcs_ignore=False, global=False)
  seeder FromAppData(download=False, pip=bundle, setuptools=bundle, wheel=bundle, via=copy, app_data_dir=/root/.local/share/virtualenv)
    added seed packages: pip==25.0, setuptools==75.3.0, wheel==0.45.1
  activators BashActivator,CShellActivator,FishActivator,NushellActivator,PowerShellActivator,PythonActivator

✔ Successfully created virtual environment!
Virtualenv location: /root/.local/share/virtualenvs/package-3pJoT3Dw
To activate this project's virtualenv, run pipenv shell.
Alternatively, run a command inside the virtualenv with pipenv run.
Installing dependencies from Pipfile.lock (5db2f5)...
Installing dependencies from Pipfile.lock (5db2f5)...
meilisearch/models/index.py:6: error: Cannot find implementation or library stub for module named "camel_converter"  [import-not-found]
meilisearch/models/index.py:7: error: Cannot find implementation or library stub for module named "camel_converter.pydantic_base"  [import-not-found]
meilisearch/models/index.py:7: note: See https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports
meilisearch/models/task.py:7: error: Cannot find implementation or library stub for module named "camel_converter.pydantic_base"  [import-not-found]
meilisearch/models/key.py:5: error: Cannot find implementation or library stub for module named "camel_converter.pydantic_base"  [import-not-found]
meilisearch/index.py:20: error: Cannot find implementation or library stub for module named "camel_converter"  [import-not-found]
Found 5 errors in 4 files (checked 14 source files)
```

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
