### PR TITLE
Fix IndexStats returning attribute names instead of values

### DIFF
--- a/meilisearch/models/index.py
+++ b/meilisearch/models/index.py
@@ -21,7 +21,7 @@ class IndexStats:
 
     def __getattr__(self, attr: str) -> Any:
         if attr in self.__dict.keys():
-            return attr
+            return self.__dict[attr]
         raise AttributeError(f"{self.__class__.__name__} object has no attribute {attr}")
 
     def __iter__(self) -> Iterator:
@@ -120,7 +120,5 @@ class UserProvidedEmbedder(CamelBase):
 class Embedders(CamelBase):
     embedders: Dict[
         str,
-        Union[
-            OpenAiEmbedder, HuggingFaceEmbedder, OllamaEmbedder, RestEmbedder, UserProvidedEmbedder
-        ],
+        Union[OpenAiEmbedder, HuggingFaceEmbedder, OllamaEmbedder, RestEmbedder, UserProvidedEmbedder],
     ]

--- a/tests/models/test_index.py
+++ b/tests/models/test_index.py
@@ -7,7 +7,7 @@ from meilisearch.models.index import IndexStats
 
 def test_getattr():
     document = IndexStats({"field1": "test 1", "fiels2": "test 2"})
-    assert document.__getattr__("field1") == "field1"
+    assert document.__getattr__("field1") == "test 1"
 
 
 def test_getattr_not_found():


### PR DESCRIPTION
## Related issue
Fixes #1094 

## What does this PR do?
- make the `__getattr__` method of the [`IndexStats`](https://github.com/meilisearch/meilisearch-python/blob/a90ddf81643ef41d48a14bab9b9fe8b839e89845/meilisearch/models/index.py#L10) class return the attribute _value_ not its _name_
- update incorrect tests for this behavior 

## PR checklist
Please check if your PR fulfills the following requirements:
- [X] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [X] Have you read the contributing guidelines?
- [X] Have you made sure that the title is accurate and descriptive of the changes?

