### PR TITLE
Fix Document model: bad test, attribute bug, and field cleanup

### DIFF
--- a/meilisearch/models/document.py
+++ b/meilisearch/models/document.py
@@ -5,11 +5,10 @@ class Document:
     def __init__(self, doc: Dict[str, Any]) -> None:
         self.__dict__.update(**doc)
 
-    def __getattr__(self, attr: str) -> str:
-        try:
+    def __getattr__(self, attr: str) -> Any:
+        if attr in self.__dict__:
             return self.__dict__[attr]
-        except Exception as _:
-            raise AttributeError(f"{self.__class__.__name__} object has no attribute {attr}")
+        raise AttributeError(f"{self.__class__.__name__} object has no attribute {attr}")
 
     def __iter__(self) -> Iterator:
         return iter(self.__dict__.items())

--- a/meilisearch/models/document.py
+++ b/meilisearch/models/document.py
@@ -2,17 +2,14 @@ from typing import Any, Dict, Iterator, List
 
 
 class Document:
-    __doc: Dict
-
     def __init__(self, doc: Dict[str, Any]) -> None:
-        self.__doc = doc
-        for key in doc:
-            setattr(self, key, doc[key])
+        self.__dict__.update(**doc)
 
     def __getattr__(self, attr: str) -> str:
-        if attr in self.__doc.keys():
-            return attr
-        raise AttributeError(f"{self.__class__.__name__} object has no attribute {attr}")
+        try:
+            return self.__dict__[attr]
+        except Exception as _:
+            raise AttributeError(f"{self.__class__.__name__} object has no attribute {attr}")
 
     def __iter__(self) -> Iterator:
         return iter(self.__dict__.items())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,7 +114,6 @@ disable=[
   "too-few-public-methods",
   "line-too-long",
   "too-many-positional-arguments",
-  "raise-missing-from",
 ]
 enable=[
   "use-symbolic-message-instead",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,7 @@ disable=[
   "too-few-public-methods",
   "line-too-long",
   "too-many-positional-arguments",
+  "raise-missing-from",
 ]
 enable=[
   "use-symbolic-message-instead",

--- a/tests/models/test_document.py
+++ b/tests/models/test_document.py
@@ -6,9 +6,15 @@ import pytest
 from meilisearch.models.document import Document
 
 
+def test_doc_init():
+    d = {"field1": "test 1", "fiels2": "test 2"}
+    document = Document(d)
+    assert dict(document) == d
+
+
 def test_getattr():
     document = Document({"field1": "test 1", "fiels2": "test 2"})
-    assert document.__getattr__("field1") == "field1"
+    assert document.__getattr__("field1") == "test 1"
 
 
 def test_getattr_not_found():
@@ -18,11 +24,5 @@ def test_getattr_not_found():
 
 
 def test_iter():
-    # I wrote a test what what this does, but I have a feeling this isn't actually what it was
-    # expected to do when written as it doesn't really act like I would expect an iterator to act.
     document = Document({"field1": "test 1", "fiels2": "test 2"})
-
-    assert next(document.__iter__()) == (
-        "_Document__doc",
-        {"field1": "test 1", "fiels2": "test 2"},
-    )
+    assert list(iter(document)) == [("field1", "test 1"), ("fiels2", "test 2")]

--- a/tests/models/test_document.py
+++ b/tests/models/test_document.py
@@ -7,22 +7,22 @@ from meilisearch.models.document import Document
 
 
 def test_doc_init():
-    d = {"field1": "test 1", "fiels2": "test 2"}
+    d = {"field1": "test 1", "field2": "test 2"}
     document = Document(d)
     assert dict(document) == d
 
 
 def test_getattr():
-    document = Document({"field1": "test 1", "fiels2": "test 2"})
+    document = Document({"field1": "test 1", "field2": "test 2"})
     assert document.__getattr__("field1") == "test 1"
 
 
 def test_getattr_not_found():
-    document = Document({"field1": "test 1", "fiels2": "test 2"})
+    document = Document({"field1": "test 1", "field2": "test 2"})
     with pytest.raises(AttributeError):
         document.__getattr__("bad")
 
 
 def test_iter():
-    document = Document({"field1": "test 1", "fiels2": "test 2"})
-    assert list(iter(document)) == [("field1", "test 1"), ("fiels2", "test 2")]
+    document = Document({"field1": "test 1", "field2": "test 2"})
+    assert list(iter(document)) == [("field1", "test 1"), ("field2", "test 2")]


### PR DESCRIPTION
# Pull Request
Small bug fix & improvement.

The `Document` model stores twice as many fields needed through `Document.__doc` and doesn't properly implement `__getattr__`. 

An example of an assert that fails :
```python
doc = Document({"foo": "bar"})
assert getattr(doc, "foo") == "bar" # passes
assert doc.__getattr__("foo") == "bar" # fails, current implementation gives 'foo' again
```

### Duplicated data 
Currently  `dict(Document)` gives this:
```bash
  {
    "_Document__doc": {
      "id": 5,
      "title": "Hard Times",
      "genres": [
        "Classics",
        "Fiction",
        "Victorian",
        "Literature"
      ],
      "publisher": "Penguin Classics",
      "language": "English",
      "author": "Charles Dickens",
      "description": "Hard Times is a novel of social protest which attacks utilitarianism, Bentham's theory which only considered the practical aspects of happiness and ignored emotional, spiritual and moral values. It is set in Coketown, a fictious industrial city in northern England in the mid-1800s.",
      "format": "Hardcover",
      "rating": 3
    },
    "id": 5,
    "title": "Hard Times",
    "genres": [
      "Classics",
      "Fiction",
      "Victorian",
      "Literature"
    ],
    "publisher": "Penguin Classics",
    "language": "English",
    "author": "Charles Dickens",
    "description": "Hard Times is a novel of social protest which attacks utilitarianism, Bentham's theory which only considered the practical aspects of happiness and ignored emotional, spiritual and moral values. It is set in Coketown, a fictious industrial city in northern England in the mid-1800s.",
    "format": "Hardcover",
    "rating": 3
  }
```
This PR removes the __doc field so that it now looks like: 
```bash
  {
    "id": 5,
    "title": "Hard Times",
    "genres": [
      "Classics",
      "Fiction",
      "Victorian",
      "Literature"
    ],
    "publisher": "Penguin Classics",
    "language": "English",
    "author": "Charles Dickens",
    "description": "Hard Times is a novel of social protest which attacks utilitarianism, Bentham's theory which only considered the practical aspects of happiness and ignored emotional, spiritual and moral values. It is set in Coketown, a fictious industrial city in northern England in the mid-1800s.",
    "format": "Hardcover",
    "rating": 3
  }
```

## What does this PR do?
- Fixes the `__getattr__` implementation for `Document`
- Fixes erroneous test

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved attribute access in documents to return actual values instead of attribute names.
  - Iterating over documents now correctly yields key-value pairs from the document data.

- **Tests**
  - Added a new test to verify correct document initialization and conversion.
  - Updated existing tests to reflect improved attribute access and iteration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->