### PR TITLE
Add `disableOnNumbers` to typo tolerance settings

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -360,6 +360,10 @@ typo_tolerance_guide_4: |-
       'twoTypos': 10
     }
   })
+typo_tolerance_guide_5: |-
+  client.index('movies').update_typo_tolerance({
+    'disableOnNumbers': True
+  })
 search_parameter_guide_show_ranking_score_1: |-
   client.index('movies').search('dragon', {
     'showRankingScore': True

--- a/meilisearch/models/index.py
+++ b/meilisearch/models/index.py
@@ -44,6 +44,7 @@ class MinWordSizeForTypos(CamelBase):
 
 class TypoTolerance(CamelBase):
     enabled: bool = True
+    disable_on_numbers: bool = False
     disable_on_attributes: Optional[List[str]] = None
     disable_on_words: Optional[List[str]] = None
     min_word_size_for_typos: Optional[MinWordSizeForTypos] = None

--- a/tests/settings/test_settings_typo_tolerance_meilisearch.py
+++ b/tests/settings/test_settings_typo_tolerance_meilisearch.py
@@ -1,6 +1,5 @@
 from meilisearch.models.index import TypoTolerance
 
-
 DEFAULT_TYPO_TOLERANCE = {
     "enabled": True,
     "disableOnNumbers": False,

--- a/tests/settings/test_settings_typo_tolerance_meilisearch.py
+++ b/tests/settings/test_settings_typo_tolerance_meilisearch.py
@@ -1,5 +1,9 @@
+from meilisearch.models.index import TypoTolerance
+
+
 DEFAULT_TYPO_TOLERANCE = {
     "enabled": True,
+    "disableOnNumbers": False,
     "minWordSizeForTypos": {
         "oneTypo": 5,
         "twoTypos": 9,
@@ -10,6 +14,7 @@ DEFAULT_TYPO_TOLERANCE = {
 
 NEW_TYPO_TOLERANCE = {
     "enabled": True,
+    "disableOnNumbers": False,
     "minWordSizeForTypos": {
         "oneTypo": 6,
         "twoTypos": 10,
@@ -65,3 +70,16 @@ def test_reset_typo_tolerance(empty_index):
         )
     assert update2.status == "succeeded"
     assert response_last.model_dump(by_alias=True) == DEFAULT_TYPO_TOLERANCE
+
+
+def test_disable_numbers_true(empty_index):
+    index = empty_index()
+
+    # Update settings
+    response_update = index.update_typo_tolerance({"disableOnNumbers": True})
+    update = index.wait_for_task(response_update.task_uid)
+    assert update.status == "succeeded"
+
+    # Fetch updated settings
+    tolerance: TypoTolerance = index.get_typo_tolerance()
+    assert tolerance.disable_on_numbers


### PR DESCRIPTION
# Pull Request
Allow disabling of typo tolerance for numbers in meilisearch 1.15

## Related issue
Fixes #1114 

## What does this PR do?
- Adds `disable_on_numbers` to `TypoTolerance` class
- Adds tests to ensure the setting updates meilisearch as expected

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new option to typo tolerance settings that allows disabling typo tolerance on numbers.

- **Tests**
  - Introduced a test to verify the behavior of the new setting for disabling typo tolerance on numbers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->