### PR TITLE
Fix type of from field in TaskResults so get_tasks doesn't crash

### DIFF
--- a/meilisearch/models/task.py
+++ b/meilisearch/models/task.py
@@ -110,7 +110,7 @@ class TaskResults(CamelBase):
     results: List[Task]
     limit: int
     total: int
-    from_: int
+    from_: Optional[int]
     next_: Optional[int]
 
 


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1125

## What does this PR do?
- Updates the type of TaskResults.from to match the type returned by rust

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!
