### PR TITLE
Fix: propagate custom_headers to Index instances

### DIFF
--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -66,6 +66,7 @@ class Index:
         primary_key: Optional[str] = None,
         created_at: Optional[Union[datetime, str]] = None,
         updated_at: Optional[Union[datetime, str]] = None,
+        custom_headers: Optional[Mapping[str, str]] = None,
     ) -> None:
         """
         Parameters
@@ -78,8 +79,8 @@ class Index:
             Primary-key of the index.
         """
         self.config = config
-        self.http = HttpRequests(config)
-        self.task_handler = TaskHandler(config)
+        self.http = HttpRequests(config, custom_headers)
+        self.task_handler = TaskHandler(config, custom_headers)
         self.uid = uid
         self.primary_key = primary_key
         self.created_at = iso_to_date_time(created_at)
@@ -175,7 +176,12 @@ class Index:
         return self.fetch_info().primary_key
 
     @staticmethod
-    def create(config: Config, uid: str, options: Optional[Mapping[str, Any]] = None) -> TaskInfo:
+    def create(
+        config: Config,
+        uid: str,
+        options: Optional[Mapping[str, Any]] = None,
+        custom_headers: Optional[Mapping[str, str]] = None,
+    ) -> TaskInfo:
         """Create the index.
 
         Parameters
@@ -199,7 +205,7 @@ class Index:
         if options is None:
             options = {}
         payload = {**options, "uid": uid}
-        task = HttpRequests(config).post(config.paths.index, payload)
+        task = HttpRequests(config, custom_headers).post(config.paths.index, payload)
 
         return TaskInfo(**task)
 

--- a/meilisearch/task.py
+++ b/meilisearch/task.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from time import sleep
-from typing import Any, MutableMapping, Optional
+from typing import Any, Mapping, MutableMapping, Optional
 from urllib import parse
 
 from meilisearch._httprequests import HttpRequests
@@ -19,13 +19,13 @@ class TaskHandler:
     https://www.meilisearch.com/docs/reference/api/tasks
     """
 
-    def __init__(self, config: Config):
+    def __init__(self, config: Config, custom_headers: Optional[Mapping[str, str]] = None):
         """Parameters
         ----------
             config: Config object containing permission and location of Meilisearch.
         """
         self.config = config
-        self.http = HttpRequests(config)
+        self.http = HttpRequests(config, custom_headers)
 
     def get_batches(self, parameters: Optional[MutableMapping[str, Any]] = None) -> BatchResults:
         """Get all task batches.

--- a/tests/client/test_client.py
+++ b/tests/client/test_client.py
@@ -58,3 +58,13 @@ def test_headers(api_key, custom_headers, expected):
     client = meilisearch.Client("127.0.0.1:7700", api_key=api_key, custom_headers=custom_headers)
 
     assert client.http.headers.items() >= expected.items()
+
+
+def test_index_inherits_custom_headers():
+    custom_headers = {"header_key_1": "header_value_1", "header_key_2": "header_value_2"}
+    client = meilisearch.Client("127.0.0.1:7700", api_key=None, custom_headers=custom_headers)
+
+    index = client.index("movies")
+
+    # Index-level HttpRequests instance should also include the custom headers
+    assert index.http.headers.items() >= custom_headers.items()


### PR DESCRIPTION
## Related issue

Fixes #1143

## What does this PR do?

- Ensure that `custom_headers` passed to `meilisearch.Client` are propagated to `Index` instances and task-related HTTP calls.
- Store `custom_headers` on the `Client` (`self._custom_headers`) so that it can be reused when instantiating sub-clients.
- Update `TaskHandler` to accept `custom_headers` and pass them to its internal `HttpRequests` instance.
- Update `Index`:
  - `__init__` now accepts an optional `custom_headers` parameter and uses it for both `HttpRequests` and `TaskHandler`.
  - `Index.create` now accepts an optional `custom_headers` parameter and forwards it to `HttpRequests`.
- Update `Client`:
  - Pass `self._custom_headers` when calling `Index.create` in `create_index`.
  - Pass `self._custom_headers` when creating `Index` instances in `get_indexes`, `get_index`, and `index`.
- Add a test (`test_index_inherits_custom_headers`) to verify that `Index.http.headers` includes the custom headers when they are provided to the `Client`.

## PR checklist

Please check if your PR fulfills the following requirements:

- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Custom headers now consistently propagate through all client operations, including index creation, retrieval, and task handling, ensuring uniform header application across the system.

* **Tests**
  * Added test coverage validating custom header propagation from client to index operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->