### PR TITLE
fix(ci): use setup-python version for pipenv virtualenv

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -42,7 +42,7 @@ jobs:
           pipx install pipenv
       - name: Install dependencies
         run: |
-          pipenv install --dev
+          pipenv --python $(which python) install --dev
           pipenv install sphinx
           pipenv install sphinx_rtd_theme
       - name: Build docs


### PR DESCRIPTION
## Summary

Fixes #1193 - The documentation workflow was failing.

## Problem

The documentation workflow failed because pipenv was using the system Python 3.12.3 instead of the Python 3.10 installed by `actions/setup-python`. This caused an `ImportError` when pipdeptree tried to run in the virtualenv with a different Python version:

```
ImportError: cannot import name 'InterpreterQueryError' from 'pipenv.vendor.pipdeptree._discovery'
```

## Solution

Explicitly specify `--python $(which python)` when creating the pipenv virtualenv to ensure it uses the Python version installed by `actions/setup-python`.

## Testing

The fix ensures the virtualenv uses Python 3.10 as intended by the workflow configuration.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Enhanced the documentation build workflow to explicitly configure the Python interpreter during dependency installation. This improvement ensures more reliable and consistent documentation builds across different development and deployment environments by properly specifying which Python version is used throughout the entire dependency resolution and installation process.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->