### PR TITLE
fix: Added tests and docstrings for showPerformanceDetails

### DIFF
--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -273,8 +273,11 @@ class Client:
             https://www.meilisearch.com/docs/reference/api/search#search-in-an-index
             It can also include remote options in federationOptions for each query
             https://www.meilisearch.com/docs/reference/api/network
+            Each query may include showPerformanceDetails to request a performance
+            trace in the response (results[].performanceDetails, returned as raw data).
         federation: (optional):
-            Dictionary containing offset and limit
+            Dictionary containing offset, limit, and optionally showPerformanceDetails
+            for federated search (top-level performanceDetails in the response).
             https://www.meilisearch.com/docs/reference/api/multi_search
 
         Returns

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -351,11 +351,14 @@ class Index:
             - filter: Filter queries by an attribute's value
             - limit: Maximum number of documents returned
             - offset: Number of documents to skip
+            - showPerformanceDetails: If true, the response includes a
+              performanceDetails object (raw data; fields may change in future API versions)
 
         Returns
         -------
         results:
-            Dictionary with hits, offset, limit, processingTime and initial query
+            Dictionary with hits, offset, limit, processingTime and initial query.
+            When showPerformanceDetails is true, may include a performanceDetails object.
 
         Raises
         ------
@@ -485,12 +488,14 @@ class Index:
         ----------
         parameters:
             parameters accepted by the get similar documents route: https://www.meilisearch.com/docs/reference/api/similar#body
-            "id" and "embedder" are required.
+            "id" and "embedder" are required. May include showPerformanceDetails to
+            request a performance trace in the response (performanceDetails, raw data).
 
         Returns
         -------
         results:
-            Dictionary with hits, offset, limit, processingTimeMs, and id
+            Dictionary with hits, offset, limit, processingTimeMs, and id.
+            When showPerformanceDetails is true, may include a performanceDetails object.
 
         Raises
         ------

--- a/tests/client/test_client_multi_search_meilisearch.py
+++ b/tests/client/test_client_multi_search_meilisearch.py
@@ -30,6 +30,16 @@ def test_multi_search_one_index(client, empty_index):
     assert response["results"][0]["limit"] == 20
 
 
+def test_multi_search_show_performance_details(client, empty_index):
+    """Tests multi-search with showPerformanceDetails (Meilisearch 1.35+)."""
+    empty_index("indexA")
+    response = client.multi_search(
+        [{"indexUid": "indexA", "q": "", "showPerformanceDetails": True}]
+    )
+    assert response["results"][0]["indexUid"] == "indexA"
+    assert isinstance(response["results"][0]["performanceDetails"], dict)
+
+
 def test_multi_search_on_no_index(client):
     """Tests multi-search on a non existing index."""
     with pytest.raises(MeilisearchApiError):


### PR DESCRIPTION
# Pull Request
 Added tests and docstrings for showPerformanceDetails
 
## Related issue
Fixes #1205 

## What does this PR do?
- ...
This PR solves issue #1205. Implementation was already there, this PR adds docstrings and tests for showPerformanceDetails.

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `showPerformanceDetails` parameter support in search, multi-search, and similar documents operations to retrieve performance metrics in responses (Meilisearch 1.35+).

* **Documentation**
  * Updated documentation for the new parameter and its response format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->