### PR TITLE
Add get_task_documents method

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -83,6 +83,8 @@ get_all_tasks_1: |-
   client.get_tasks()
 get_task_1: |-
   client.get_task(1)
+get_task_documents_1: |-
+  client.get_task_documents(1)
 delete_tasks_1: |-
   client.delete_tasks({'uids': ['1', '2']})
 cancel_tasks_1: |-

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -783,6 +783,30 @@ class Client:
         """
         return self.task_handler.get_task(uid)
 
+    def get_task_documents(
+        self, uid: int, parameters: Optional[MutableMapping[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Get one task documents.
+
+        Parameters
+        ----------
+        uid:
+            Identifier of the task.
+        parameters (optional):
+            parameters accepted by the get task documents route: https://www.meilisearch.com/docs/reference/api/tasks#get-task-documents.
+
+        Returns
+        -------
+        task_documents:
+            Dict containing results, total, limit and offset for the documents linked to the task.
+
+        Raises
+        ------
+        MeilisearchApiError
+            An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
+        """
+        return self.task_handler.get_task_documents(uid, parameters)
+
     def cancel_tasks(
         self, parameters: MutableMapping[str, Any], *, metadata: Optional[str] = None
     ) -> TaskInfo:

--- a/meilisearch/task.py
+++ b/meilisearch/task.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 from time import sleep
-from typing import Any, Mapping, MutableMapping, Optional
+from typing import Any, Dict, Mapping, MutableMapping, Optional
 from urllib import parse
 
 from meilisearch._httprequests import HttpRequests
@@ -121,6 +121,35 @@ class TaskHandler:
         """
         task = self.http.get(f"{self.config.paths.task}/{uid}")
         return Task(**task)
+
+    def get_task_documents(
+        self, uid: int, parameters: Optional[MutableMapping[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """Get one task documents.
+
+        Parameters
+        ----------
+        uid:
+            Identifier of the task.
+        parameters (optional):
+            parameters accepted by the get task documents route: https://www.meilisearch.com/docs/reference/api/tasks#get-task-documents.
+
+        Returns
+        -------
+        task_documents:
+            Dict containing results, total, limit and offset for the documents linked to the task.
+
+        Raises
+        ------
+        MeilisearchApiError
+            An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
+        """
+        if parameters is None:
+            parameters = {}
+        for param in parameters:
+            if isinstance(parameters[param], (list, tuple)):
+                parameters[param] = ",".join(parameters[param])
+        return self.http.get(f"{self.config.paths.task}/{uid}/documents?{parse.urlencode(parameters)}")
 
     def cancel_tasks(
         self, parameters: MutableMapping[str, Any], *, metadata: Optional[str] = None

--- a/tests/client/test_client_task_meilisearch.py
+++ b/tests/client/test_client_task_meilisearch.py
@@ -80,6 +80,16 @@ def test_get_task(client):
     assert "started_at" in task_dict
 
 
+def test_get_task_documents(client, empty_index, small_movies):
+    """Tests getting the documents for a task."""
+    index = empty_index()
+    task = index.add_documents(small_movies)
+    client.wait_for_task(task.task_uid)
+    task_documents = client.get_task_documents(task.task_uid)
+
+    assert isinstance(task_documents["results"], list)
+
+
 def test_get_task_inexistent(client):
     """Tests getting a task that does not exists."""
     with pytest.raises(Exception):


### PR DESCRIPTION
## Summary

Adds `get_task_documents` to the Python SDK. Meilisearch v1.13 introduced `GET /tasks/{taskUid}/documents` but the SDK had no way to call it.

## Changes

- `meilisearch/task.py`: New `get_task_documents(uid, parameters)` method on `TaskHandler`. Follows the same parameter normalization pattern as `get_tasks`.
- `meilisearch/client.py`: Exposes `get_task_documents` on `Client`, delegating to the task handler.
- `.code-samples.meilisearch.yaml`: Adds `get_task_documents_1` code sample.
- `tests/client/test_client_task_meilisearch.py`: Test that creates an index, adds documents, and verifies the task documents endpoint returns results.

## Testing

Added `test_get_task_documents` covering the happy path.

Fixes #1221

This contribution was developed with AI assistance (Claude Code + Codex CLI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Retrieve documents associated with a specific task with metadata including results, total count, limit, and offset. Supports optional query parameters.

* **Documentation**
  * Added example code demonstrating task document retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->