### PR TITLE
feat: Add support for Dynamic Search Rules (v1.41)

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -622,3 +622,25 @@ update_embedders_1: |-
   })
 reset_embedders_1: |-
   client.index('INDEX_NAME').reset_embedders()
+
+list_dynamic_search_rules_1: |-
+  client.index('movies').list_dynamic_search_rules()
+
+get_dynamic_search_rule_1: |-
+  client.index('movies').get_dynamic_search_rule('promote-new')
+
+patch_dynamic_search_rule_1: |-
+  client.index('movies').upsert_dynamic_search_rule('promote-new', {
+    'condition': "query = 'new'",
+    'match_condition': 'all',
+    'actions': [
+      {
+        'action': 'promote',
+        'document_ids': ['1', '2'],
+        'position': 1
+      }
+    ]
+  })
+
+delete_dynamic_search_rule_1: |-
+  client.index('movies').delete_dynamic_search_rule('promote-new')

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -631,16 +631,20 @@ get_dynamic_search_rule_1: |-
 
 patch_dynamic_search_rule_1: |-
   client.index('movies').upsert_dynamic_search_rule('promote-new', {
-    'condition': "query = 'new'",
-    'match_condition': 'all',
+    'conditions': [
+      {
+        'scope': ['title'],
+        'operator': 'contains',
+        'value': 'new'
+      }
+    ],
     'actions': [
       {
         'action': 'promote',
-        'document_ids': ['1', '2'],
-        'position': 1
+        'documentIds': ['1', '2'],
+        'matchCondition': 'all'
       }
     ]
   })
-
 delete_dynamic_search_rule_1: |-
   client.index('movies').delete_dynamic_search_rule('promote-new')

--- a/meilisearch/config.py
+++ b/meilisearch/config.py
@@ -51,6 +51,7 @@ class Config:
         experimental_features = "experimental-features"
         webhooks = "webhooks"
         export = "export"
+        dynamic_search_rules = "dynamic-search-rules"
 
     def __init__(
         self,

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -1384,7 +1384,7 @@ class Index:
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
         """
         task = self.http.patch(
-            f"{self.config.paths.index}/{self.uid}/{self.config.paths.dynamic_search_rules}/{uid}",
+            f"{self.config.paths.dynamic_search_rules}/{uid}",
             body,
         )
 

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -1384,7 +1384,7 @@ class Index:
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
         """
         task = self.http.patch(
-            f"{self.config.paths.dynamic_search_rules}/{uid}",
+            f"{self.config.paths.index}/{self.uid}/{self.config.paths.dynamic_search_rules}/{uid}",
             body,
         )
 

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -1309,6 +1309,112 @@ class Index:
 
         return TaskInfo(**task)
 
+
+    # DYNAMIC SEARCH RULES SUB-ROUTES
+
+    def list_dynamic_search_rules(
+        self, parameters: Optional[MutableMapping[str, Any]] = None
+    ) -> Dict[str, Any]:
+        """List all dynamic search rules of the index.
+
+        Parameters
+        ----------
+        parameters (optional):
+            parameters accepted by the list dynamic search rules route, including pagination and filtering options.
+
+        Returns
+        -------
+        rules: dict
+            Dictionary containing the list of dynamic search rules and pagination info.
+
+        Raises
+        ------
+        MeilisearchApiError
+            An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
+        """
+        if parameters is None:
+            parameters = {}
+
+        return self.http.post(
+            f"{self.config.paths.index}/{self.uid}/{self.config.paths.dynamic_search_rules}/fetch",
+            body=parameters,
+        )
+
+    def get_dynamic_search_rule(self, uid: str) -> Dict[str, Any]:
+        """Get a single dynamic search rule by uid.
+
+        Parameters
+        ----------
+        uid: str
+            Unique identifier of the dynamic search rule.
+
+        Returns
+        -------
+        rule: dict
+            Dictionary containing the dynamic search rule data.
+
+        Raises
+        ------
+        MeilisearchApiError
+            An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
+        """
+        return self.http.get(
+            f"{self.config.paths.index}/{self.uid}/{self.config.paths.dynamic_search_rules}/{uid}"
+        )
+
+    def upsert_dynamic_search_rule(self, uid: str, body: Dict[str, Any]) -> TaskInfo:
+        """Create or update a dynamic search rule.
+
+        Parameters
+        ----------
+        uid: str
+            Unique identifier of the dynamic search rule.
+        body: dict
+            Dictionary containing the dynamic search rule configuration.
+
+        Returns
+        -------
+        task_info:
+            TaskInfo instance containing information about a task to track the progress of an asynchronous process.
+            https://www.meilisearch.com/docs/reference/api/tasks#get-one-task
+
+        Raises
+        ------
+        MeilisearchApiError
+            An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
+        """
+        task = self.http.patch(
+            f"{self.config.paths.index}/{self.uid}/{self.config.paths.dynamic_search_rules}/{uid}",
+            body,
+        )
+
+        return TaskInfo(**task)
+
+    def delete_dynamic_search_rule(self, uid: str) -> TaskInfo:
+        """Delete a dynamic search rule by uid.
+
+        Parameters
+        ----------
+        uid: str
+            Unique identifier of the dynamic search rule to delete.
+
+        Returns
+        -------
+        task_info:
+            TaskInfo instance containing information about a task to track the progress of an asynchronous process.
+            https://www.meilisearch.com/docs/reference/api/tasks#get-one-task
+
+        Raises
+        ------
+        MeilisearchApiError
+            An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
+        """
+        task = self.http.delete(
+            f"{self.config.paths.index}/{self.uid}/{self.config.paths.dynamic_search_rules}/{uid}"
+        )
+
+        return TaskInfo(**task)
+
     # RANKING RULES SUB-ROUTES
 
     def get_ranking_rules(self) -> List[str]:

--- a/tests/index/test_index_dynamic_search_rules_meilisearch.py
+++ b/tests/index/test_index_dynamic_search_rules_meilisearch.py
@@ -20,24 +20,28 @@ def test_list_dynamic_search_rules(test_index):
 
 def test_get_dynamic_search_rule(test_index):
     """Test getting a single dynamic search rule"""
-    # Create a rule first
     rule_uid = "test-rule-1"
     rule_body = {
-        "condition": "query = 'new'",
-        "matchCondition": "all",
+        "conditions": [
+            {
+                "scope": ["title"],
+                "operator": "contains",
+                "value": "new"
+            }
+        ],
         "actions": [
             {
                 "action": "promote",
                 "documentIds": ["1"],
+                "matchCondition": "all",
                 "position": 1
             }
         ]
     }
-    
+
     create_response = test_index.upsert_dynamic_search_rule(rule_uid, rule_body)
     test_index.wait_for_task(create_response.task_uid)
-    
-    # Now retrieve it
+
     response = test_index.get_dynamic_search_rule(rule_uid)
     assert isinstance(response, dict)
     assert response.get("uid") == rule_uid
@@ -47,23 +51,28 @@ def test_upsert_dynamic_search_rule(test_index):
     """Test creating or updating a dynamic search rule"""
     rule_uid = "test-rule-2"
     rule_body = {
-        "condition": "query = 'hello'",
-        "matchCondition": "all",
+        "conditions": [
+            {
+                "scope": ["title"],
+                "operator": "contains",
+                "value": "hello"
+            }
+        ],
         "actions": [
             {
                 "action": "promote",
                 "documentIds": ["2"],
+                "matchCondition": "all",
                 "position": 1
             }
         ]
     }
-    
+
     response = test_index.upsert_dynamic_search_rule(rule_uid, rule_body)
     assert response.task_uid is not None
-    
+
     test_index.wait_for_task(response.task_uid)
-    
-    # Verify it was created
+
     retrieved = test_index.get_dynamic_search_rule(rule_uid)
     assert retrieved.get("uid") == rule_uid
 
@@ -72,27 +81,30 @@ def test_delete_dynamic_search_rule(test_index):
     """Test deleting a dynamic search rule"""
     rule_uid = "test-rule-3"
     rule_body = {
-        "condition": "query = 'delete-me'",
-        "matchCondition": "all",
+        "conditions": [
+            {
+                "scope": ["title"],
+                "operator": "contains",
+                "value": "delete-me"
+            }
+        ],
         "actions": [
             {
                 "action": "promote",
                 "documentIds": ["3"],
+                "matchCondition": "all",
                 "position": 1
             }
         ]
     }
-    
-    # Create rule
+
     create_response = test_index.upsert_dynamic_search_rule(rule_uid, rule_body)
     test_index.wait_for_task(create_response.task_uid)
-    
-    # Delete it
+
     delete_response = test_index.delete_dynamic_search_rule(rule_uid)
     assert delete_response.task_uid is not None
-    
+
     test_index.wait_for_task(delete_response.task_uid)
-    
-    # Verify it's deleted - should raise error or return empty
+
     with pytest.raises(MeilisearchApiError):
         test_index.get_dynamic_search_rule(rule_uid)

--- a/tests/index/test_index_dynamic_search_rules_meilisearch.py
+++ b/tests/index/test_index_dynamic_search_rules_meilisearch.py
@@ -24,11 +24,11 @@ def test_get_dynamic_search_rule(test_index):
     rule_uid = "test-rule-1"
     rule_body = {
         "condition": "query = 'new'",
-        "match_condition": "all",
+        "matchCondition": "all",
         "actions": [
             {
                 "action": "promote",
-                "document_ids": ["1"],
+                "documentIds": ["1"],
                 "position": 1
             }
         ]
@@ -48,11 +48,11 @@ def test_upsert_dynamic_search_rule(test_index):
     rule_uid = "test-rule-2"
     rule_body = {
         "condition": "query = 'hello'",
-        "match_condition": "all",
+        "matchCondition": "all",
         "actions": [
             {
                 "action": "promote",
-                "document_ids": ["2"],
+                "documentIds": ["2"],
                 "position": 1
             }
         ]
@@ -73,11 +73,11 @@ def test_delete_dynamic_search_rule(test_index):
     rule_uid = "test-rule-3"
     rule_body = {
         "condition": "query = 'delete-me'",
-        "match_condition": "all",
+        "matchCondition": "all",
         "actions": [
             {
                 "action": "promote",
-                "document_ids": ["3"],
+                "documentIds": ["3"],
                 "position": 1
             }
         ]

--- a/tests/index/test_index_dynamic_search_rules_meilisearch.py
+++ b/tests/index/test_index_dynamic_search_rules_meilisearch.py
@@ -1,0 +1,99 @@
+import pytest
+
+
+@pytest.fixture
+def test_index(client_with_index):
+    index = client_with_index()
+    yield index
+    index.delete()
+
+
+def test_list_dynamic_search_rules(test_index):
+    """Test listing dynamic search rules"""
+    response = test_index.list_dynamic_search_rules()
+    assert isinstance(response, dict)
+    assert "results" in response or "results" not in response  # May be empty
+
+
+def test_get_dynamic_search_rule(test_index):
+    """Test getting a single dynamic search rule"""
+    # Create a rule first
+    rule_uid = "test-rule-1"
+    rule_body = {
+        "condition": "query = 'new'",
+        "match_condition": "all",
+        "actions": [
+            {
+                "action": "promote",
+                "document_ids": ["1"],
+                "position": 1
+            }
+        ]
+    }
+    
+    create_response = test_index.upsert_dynamic_search_rule(rule_uid, rule_body)
+    test_index.wait_for_task(create_response.task_uid)
+    
+    # Now retrieve it
+    response = test_index.get_dynamic_search_rule(rule_uid)
+    assert isinstance(response, dict)
+    assert response.get("uid") == rule_uid
+
+
+def test_upsert_dynamic_search_rule(test_index):
+    """Test creating or updating a dynamic search rule"""
+    rule_uid = "test-rule-2"
+    rule_body = {
+        "condition": "query = 'hello'",
+        "match_condition": "all",
+        "actions": [
+            {
+                "action": "promote",
+                "document_ids": ["2"],
+                "position": 1
+            }
+        ]
+    }
+    
+    response = test_index.upsert_dynamic_search_rule(rule_uid, rule_body)
+    assert response.task_uid is not None
+    
+    test_index.wait_for_task(response.task_uid)
+    
+    # Verify it was created
+    retrieved = test_index.get_dynamic_search_rule(rule_uid)
+    assert retrieved.get("uid") == rule_uid
+
+
+def test_delete_dynamic_search_rule(test_index):
+    """Test deleting a dynamic search rule"""
+    rule_uid = "test-rule-3"
+    rule_body = {
+        "condition": "query = 'delete-me'",
+        "match_condition": "all",
+        "actions": [
+            {
+                "action": "promote",
+                "document_ids": ["3"],
+                "position": 1
+            }
+        ]
+    }
+    
+    # Create rule
+    create_response = test_index.upsert_dynamic_search_rule(rule_uid, rule_body)
+    test_index.wait_for_task(create_response.task_uid)
+    
+    # Delete it
+    delete_response = test_index.delete_dynamic_search_rule(rule_uid)
+    assert delete_response.task_uid is not None
+    
+    test_index.wait_for_task(delete_response.task_uid)
+    
+    # Verify it's deleted - should raise error or return empty
+    try:
+        test_index.get_dynamic_search_rule(rule_uid)
+        assert False, "Rule should have been deleted"
+    except Exception:
+        # Expected - rule doesn't exist
+        pass

--- a/tests/index/test_index_dynamic_search_rules_meilisearch.py
+++ b/tests/index/test_index_dynamic_search_rules_meilisearch.py
@@ -108,3 +108,45 @@ def test_delete_dynamic_search_rule(test_index):
 
     with pytest.raises(MeilisearchApiError):
         test_index.get_dynamic_search_rule(rule_uid)
+
+
+def test_upsert_dynamic_search_rule_index_isolation(client_with_index):
+    """Test that upsert on one index does not affect another index"""
+    index_a = client_with_index()
+    index_b = client_with_index()
+
+    rule_uid = "isolation-rule"
+    body_a = {
+        "conditions": [
+            {"scope": ["title"], "operator": "contains", "value": "foo"}
+        ],
+        "actions": [
+            {"action": "promote", "documentIds": ["1"], "matchCondition": "all", "position": 1}
+        ],
+    }
+    body_b = {
+        "conditions": [
+            {"scope": ["title"], "operator": "contains", "value": "bar"}
+        ],
+        "actions": [
+            {"action": "promote", "documentIds": ["2"], "matchCondition": "all", "position": 2}
+        ],
+    }
+
+    try:
+        task_a = index_a.upsert_dynamic_search_rule(rule_uid, body_a)
+        index_a.wait_for_task(task_a.task_uid)
+
+        task_b = index_b.upsert_dynamic_search_rule(rule_uid, body_b)
+        index_b.wait_for_task(task_b.task_uid)
+
+        rule_a = index_a.get_dynamic_search_rule(rule_uid)
+        rule_b = index_b.get_dynamic_search_rule(rule_uid)
+
+        assert rule_a.get("uid") == rule_uid
+        assert rule_b.get("uid") == rule_uid
+        # Rules should be independent per index
+        assert rule_a != rule_b
+    finally:
+        index_a.delete()
+        index_b.delete()

--- a/tests/index/test_index_dynamic_search_rules_meilisearch.py
+++ b/tests/index/test_index_dynamic_search_rules_meilisearch.py
@@ -1,4 +1,5 @@
 import pytest
+from meilisearch.errors import MeilisearchApiError
 
 
 @pytest.fixture
@@ -12,7 +13,9 @@ def test_list_dynamic_search_rules(test_index):
     """Test listing dynamic search rules"""
     response = test_index.list_dynamic_search_rules()
     assert isinstance(response, dict)
-    assert "results" in response or "results" not in response  # May be empty
+    assert "results" in response or "meta" in response
+    if "results" in response:
+        assert isinstance(response["results"], list)
 
 
 def test_get_dynamic_search_rule(test_index):
@@ -91,9 +94,5 @@ def test_delete_dynamic_search_rule(test_index):
     test_index.wait_for_task(delete_response.task_uid)
     
     # Verify it's deleted - should raise error or return empty
-    try:
+    with pytest.raises(MeilisearchApiError):
         test_index.get_dynamic_search_rule(rule_uid)
-        assert False, "Rule should have been deleted"
-    except Exception:
-        # Expected - rule doesn't exist
-        pass


### PR DESCRIPTION
## Summary

Implements support for Meilisearch v1.41 Dynamic Search Rules API as requested in issue #1227.

## Changes

### 1. Configuration (config.py)
- Added `dynamic_search_rules = 'dynamic-search-rules'` path to Config.Paths

### 2. Index Methods (index.py)
Added 4 new methods to the Index class:

- **list_dynamic_search_rules(parameters)** - POST /indexes/{uid}/dynamic-search-rules
  - Lists all dynamic search rules with pagination support
  
- **get_dynamic_search_rule(uid)** - GET /indexes/{uid}/dynamic-search-rules/{uid}
  - Retrieves a specific rule by uid
  
- **upsert_dynamic_search_rule(uid, body)** - PATCH /indexes/{uid}/dynamic-search-rules/{uid}
  - Creates or updates a rule
  
- **delete_dynamic_search_rule(uid)** - DELETE /indexes/{uid}/dynamic-search-rules/{uid}
  - Deletes a rule by uid

### 3. Tests (test_index_dynamic_search_rules_meilisearch.py)
Added comprehensive test cases covering:
- Listing rules
- Getting a specific rule
- Creating/updating rules
- Deleting rules

### 4. Code Samples (.code-samples.meilisearch.yaml)
Added examples for:
- `list_dynamic_search_rules_1`
- `get_dynamic_search_rule_1`
- `patch_dynamic_search_rule_1`
- `delete_dynamic_search_rule_1`

## Checklist
- [x] New methods handle all API endpoints from issue #1227
- [x] Test cases for all new methods  
- [x] Code examples in .code-samples.meilisearch.yaml
- [x] Proper docstrings with parameters, returns, and error documentation
- [x] Follows existing code patterns in the SDK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dynamic search rules management for indexes: list rules, retrieve by UID, create/update rules with conditions and actions (e.g., promote specific documents), and delete rules.

* **Documentation**
  * Added code samples demonstrating the full dynamic search rules lifecycle on the movies index, including condition-based promote examples.

* **Tests**
  * Added end-to-end tests covering listing, upserting, retrieving, deleting, and index-isolation scenarios for dynamic search rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->