### PR TITLE
Add showInternalDatabaseSizes and sizeFormat params to stats endpoints

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -253,9 +253,9 @@ update_sortable_attributes_1: |-
 reset_sortable_attributes_1: |-
   client.index('books').reset_sortable_attributes()
 get_index_stats_1: |-
-  client.index('movies').get_stats()
+  client.index('movies').get_stats(show_internal_database_sizes=True, size_format='human')
 get_indexes_stats_1: |-
-  client.get_all_stats()
+  client.get_all_stats(show_internal_database_sizes=True, size_format='human')
 get_health_1: |-
   client.health()
 get_version_1: |-

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -322,11 +322,25 @@ class Client:
             body=dict(queries),
         )
 
-    def get_all_stats(self) -> Dict[str, Any]:
+    def get_all_stats(
+        self,
+        *,
+        show_internal_database_sizes: Optional[bool] = None,
+        size_format: Optional[str] = None,
+    ) -> Dict[str, Any]:
         """Get all stats of Meilisearch
 
         Get information about database size and all indexes
         https://www.meilisearch.com/docs/reference/api/stats
+
+        Parameters
+        ----------
+        show_internal_database_sizes (optional):
+            When true, index stat objects contain an additional internalDatabaseSizes key
+            with the size of each internal database. Defaults to false.
+        size_format (optional):
+            When set to "human", database sizes are returned as strings with units (e.g. "1.5 GiB").
+            When set to "raw" or omitted, sizes are returned as numbers in bytes.
 
         Returns
         -------
@@ -338,7 +352,16 @@ class Client:
         MeilisearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
         """
-        return self.http.get(self.config.paths.stat)
+        params: Dict[str, Any] = {}
+        if show_internal_database_sizes is not None:
+            params["showInternalDatabaseSizes"] = show_internal_database_sizes
+        if size_format is not None:
+            params["sizeFormat"] = size_format
+
+        path = self.config.paths.stat
+        if params:
+            path = f"{path}?{parse.urlencode(params)}"
+        return self.http.get(path)
 
     def health(self) -> Dict[str, str]:
         """Get health of the Meilisearch server.

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -313,11 +313,25 @@ class Index:
         """
         return self.task_handler.wait_for_task(uid, timeout_in_ms, interval_in_ms)
 
-    def get_stats(self) -> IndexStats:
+    def get_stats(
+        self,
+        *,
+        show_internal_database_sizes: Optional[bool] = None,
+        size_format: Optional[str] = None,
+    ) -> IndexStats:
         """Get stats of the index.
 
         Get information about the number of documents, field frequencies, ...
         https://www.meilisearch.com/docs/reference/api/stats
+
+        Parameters
+        ----------
+        show_internal_database_sizes (optional):
+            When true, the response contains an additional internalDatabaseSizes key
+            with the size of each internal database. Defaults to false.
+        size_format (optional):
+            When set to "human", database sizes are returned as strings with units (e.g. "1.5 GiB").
+            When set to "raw" or omitted, sizes are returned as numbers in bytes.
 
         Returns
         -------
@@ -329,7 +343,16 @@ class Index:
         MeilisearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
         """
-        stats = self.http.get(f"{self.config.paths.index}/{self.uid}/{self.config.paths.stat}")
+        params: Dict[str, Any] = {}
+        if show_internal_database_sizes is not None:
+            params["showInternalDatabaseSizes"] = show_internal_database_sizes
+        if size_format is not None:
+            params["sizeFormat"] = size_format
+
+        path = f"{self.config.paths.index}/{self.uid}/{self.config.paths.stat}"
+        if params:
+            path = f"{path}?{parse.urlencode(params)}"
+        stats = self.http.get(path)
         return IndexStats(**stats)
 
     @version_error_hint_message

--- a/meilisearch/models/index.py
+++ b/meilisearch/models/index.py
@@ -30,6 +30,7 @@ class IndexStats(CamelBase):
     number_of_documents: int
     is_indexing: bool
     field_distribution: FieldDistribution
+    internal_database_sizes: Optional[Dict[str, Any]] = None
 
     @field_validator("field_distribution", mode="before")
     @classmethod

--- a/tests/client/test_client_stats_meilisearch.py
+++ b/tests/client/test_client_stats_meilisearch.py
@@ -12,3 +12,15 @@ def test_get_all_stats(client):
     assert "indexes" in response
     assert "indexUID" in response["indexes"]
     assert "indexUID2" in response["indexes"]
+
+
+@pytest.mark.usefixtures("indexes_sample")
+def test_get_all_stats_with_params(client):
+    """Tests getting all stats with query parameters."""
+    response = client.get_all_stats(show_internal_database_sizes=True, size_format="human")
+    assert isinstance(response, dict)
+    assert "databaseSize" in response
+    assert "indexes" in response
+    for index_stats in response["indexes"].values():
+        if "internalDatabaseSizes" in index_stats:
+            assert isinstance(index_stats["internalDatabaseSizes"], dict)

--- a/tests/index/test_index_stats_meilisearch.py
+++ b/tests/index/test_index_stats_meilisearch.py
@@ -15,3 +15,26 @@ def test_get_stats_default(index_with_documents):
     assert response.number_of_documents == 31
     assert hasattr(response.field_distribution, "genre")
     assert response.field_distribution.genre == 11
+
+
+def test_get_stats_with_internal_database_sizes(empty_index):
+    """Tests getting stats with showInternalDatabaseSizes parameter."""
+    response = empty_index().get_stats(show_internal_database_sizes=True)
+    assert isinstance(response, IndexStats)
+    assert response.number_of_documents == 0
+
+
+def test_get_stats_with_size_format(empty_index):
+    """Tests getting stats with sizeFormat parameter."""
+    response = empty_index().get_stats(size_format="human")
+    assert isinstance(response, IndexStats)
+    assert response.number_of_documents == 0
+
+
+def test_get_stats_with_all_params(empty_index):
+    """Tests getting stats with both query parameters."""
+    response = empty_index().get_stats(
+        show_internal_database_sizes=True, size_format="human"
+    )
+    assert isinstance(response, IndexStats)
+    assert response.number_of_documents == 0


### PR DESCRIPTION
## Related issue
Fixes #1234

## What does this PR do?
- Adds `showInternalDatabaseSizes` and `sizeFormat` optional keyword-only parameters to `Client.get_all_stats()` and `Index.get_stats()`
- Updates `IndexStats` model to include optional `internal_database_sizes` field
- Adds test cases for the new parameters
- Updates `.code-samples.meilisearch.yaml` with examples for `get_index_stats_1` and `get_indexes_stats_1`

## PR checklist
- [x] Add/update methods to handle interacting with the stats API endpoints
- [x] Add/update test cases for the new/updated methods
- [x] Update .code-samples.meilisearch.yaml

Note: AI assistance was used (GitHub Copilot) for autocompletion during development.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This PR adds support for two new query parameters introduced in Meilisearch v1.44.0 to the stats endpoints: `showInternalDatabaseSizes` and `sizeFormat`. These parameters allow clients to request internal database size breakdowns and human-readable size formatting.

## Changes

### API Updates

- **Client.get_all_stats()**: Added optional keyword-only parameters:
  - `show_internal_database_sizes: Optional[bool]` - includes internal database sizes in the response
  - `size_format: Optional[str]` - specifies "human" for readable sizes or "raw" for byte counts
  
- **Index.get_stats()**: Added the same optional keyword-only parameters with matching behavior

### Model Updates

- **IndexStats**: Added optional `internal_database_sizes: Optional[Dict[str, Any]]` field to represent dynamically-keyed internal database size mappings

### Tests

- Added `test_get_all_stats_with_params()` to verify client stats calls with query parameters
- Added multiple test cases to cover:
  - `show_internal_database_sizes` parameter
  - `size_format` parameter  
  - Combined parameter usage
- All new tests verify proper response structure and validate that internal database sizes are returned as dictionaries when present

### Documentation

- Updated `.code-samples.meilisearch.yaml` with examples for `get_index_stats_1` and `get_indexes_stats_1` demonstrating the new parameters (`show_internal_database_sizes=True, size_format='human'`)

## Related Issues

Fixes `#1234`: Add human-formatted sizes and detailed DB sizes in stats

## Notes

AI assistance (GitHub Copilot) was used for autocompletion during development.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meilisearch/meilisearch-python/pull/1235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->