### PR TITLE
Return attribute value instead of attribute name in `FieldDistribution.__getattr__` 

### DIFF
--- a/meilisearch/models/index.py
+++ b/meilisearch/models/index.py
@@ -15,9 +15,9 @@ class FieldDistribution:
         for key in dist:
             setattr(self, key, dist[key])
 
-    def __getattr__(self, attr: str) -> str:
+    def __getattr__(self, attr: str) -> int:
         if attr in self.__dict.keys():
-            return attr
+            return self.__dict[attr]
         raise AttributeError(f"{self.__class__.__name__} object has no attribute {attr}")
 
     def __iter__(self) -> Iterator:


### PR DESCRIPTION
## What
The `__getattr__` method in `FieldDistribution` was returning the attribute name (a string) instead of the actual attribute value. This caused `stats.numberOfDocuments` to return the string `"numberOfDocuments"` rather than the integer value.

## Fix
Changed `return attr` to `return self.__dict[attr]` in `FieldDistribution.__getattr__`, and updated the return type annotation from `str` to `int` to reflect the actual value type stored in the distribution dict.

Closes #1094

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Fixed `FieldDistribution.__getattr__` to return the actual attribute value from the internal dictionary instead of returning the attribute name string. This makes index statistics accessible through the dataclass API.

## Changes

**meilisearch/models/index.py:**
- Modified `FieldDistribution.__getattr__` to return `self.__dict[attr]` instead of `attr`
- Updated return type annotation from `str` to `int` to reflect the actual value type

## Impact

Accessing statistics properties through `FieldDistribution` now correctly returns numeric values (e.g., `stats.numberOfDocuments` returns an integer count) instead of the property name string itself.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/meilisearch/meilisearch-python/pull/1236?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->