### PR TITLE
Increase timeout window when awaiting tasks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,11 @@
-FROM python:3.9-buster
+FROM python:3.9-slim-trixie
+
+COPY --from=ghcr.io/astral-sh/uv:0.11.19 /uv /uvx /bin/
+
+WORKDIR /home/package
 
 COPY pyproject.toml .
 COPY uv.lock .
-
-RUN apt-get update -y
-
-# Install uv
-COPY --from=ghcr.io/astral-sh/uv:0.11.16 /uv /uvx /bin/
 
 # Install dependencies
 RUN uv sync --frozen --no-install-project

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,6 +11,8 @@ from meilisearch.errors import MeilisearchApiError
 from meilisearch.models.embedders import OpenAiEmbedder, UserProvidedEmbedder
 from tests import common
 
+TEST_TASK_TIMEOUT_MS = 30_000
+
 
 @fixture(scope="session")
 def client():
@@ -30,7 +32,7 @@ def _clear_indexes(meilisearch_client):
     indexes = meilisearch_client.get_indexes()
     for index in indexes["results"]:
         task = meilisearch_client.index(index.uid).delete()
-        meilisearch_client.wait_for_task(task.task_uid)
+        meilisearch_client.wait_for_task(task.task_uid, timeout_in_ms=TEST_TASK_TIMEOUT_MS)
 
 
 @fixture(autouse=True)
@@ -143,7 +145,7 @@ def empty_index(client, index_uid: Optional[str] = None):
 
     def index_maker(index_uid=index_uid):
         task = client.create_index(uid=index_uid)
-        client.wait_for_task(task.task_uid)
+        client.wait_for_task(task.task_uid, timeout_in_ms=TEST_TASK_TIMEOUT_MS)
         return client.get_index(uid=index_uid)
 
     return index_maker

--- a/tests/settings/test_settings_embedders.py
+++ b/tests/settings/test_settings_embedders.py
@@ -211,7 +211,7 @@ def test_composite_embedder_format(empty_index):
     }
 
     response = index.update_embedders(composite_embedder)
-    update = index.wait_for_task(response.task_uid)
+    update = index.wait_for_task(response.task_uid, timeout_in_ms=60000)
     embedders = index.get_embedders()
     assert update.status == "succeeded"
 

--- a/tests/settings/test_settings_facet_search.py
+++ b/tests/settings/test_settings_facet_search.py
@@ -1,6 +1,7 @@
 DEFAULT_FACET_SEARCH_SETTINGS_STATUS = True
 ENABLED_FACET_SEARCH_SETTINGS_STATUS = True
 DISABLED_FACET_SEARCH_SETTINGS_STATUS = False
+TEST_TASK_TIMEOUT_MS = 30_000
 
 
 def test_get_facet_search_settings(empty_index):
@@ -13,12 +14,12 @@ def test_update_facet_search_settings(empty_index):
     index = empty_index()
 
     response = index.update_facet_search_settings(DISABLED_FACET_SEARCH_SETTINGS_STATUS)
-    index.wait_for_task(response.task_uid)
+    index.wait_for_task(response.task_uid, timeout_in_ms=TEST_TASK_TIMEOUT_MS)
     response = index.get_facet_search_settings()
     assert DISABLED_FACET_SEARCH_SETTINGS_STATUS == response
 
     response = index.update_facet_search_settings(ENABLED_FACET_SEARCH_SETTINGS_STATUS)
-    index.wait_for_task(response.task_uid)
+    index.wait_for_task(response.task_uid, timeout_in_ms=TEST_TASK_TIMEOUT_MS)
     response = index.get_facet_search_settings()
     assert ENABLED_FACET_SEARCH_SETTINGS_STATUS == response
 
@@ -27,12 +28,12 @@ def test_reset_facet_search_settings(empty_index):
     index = empty_index()
 
     response = index.update_facet_search_settings(DISABLED_FACET_SEARCH_SETTINGS_STATUS)
-    index.wait_for_task(response.task_uid)
+    index.wait_for_task(response.task_uid, timeout_in_ms=TEST_TASK_TIMEOUT_MS)
     response = index.get_facet_search_settings()
     assert DISABLED_FACET_SEARCH_SETTINGS_STATUS == response
     assert DEFAULT_FACET_SEARCH_SETTINGS_STATUS != response
 
     response = index.reset_facet_search_settings()
-    index.wait_for_task(response.task_uid)
+    index.wait_for_task(response.task_uid, timeout_in_ms=TEST_TASK_TIMEOUT_MS)
     response = index.get_facet_search_settings()
     assert DEFAULT_FACET_SEARCH_SETTINGS_STATUS == response


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #1239 

## What does this PR do?
- Increase timeout window when awaiting tasks

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

Increases the timeout window for awaiting Meilisearch tasks in the test suite to address compatibility with Meilisearch v1.46.0, which has stricter timing requirements.

## Changes

**Dockerfile**
- Updated base image from `python:3.9-buster` to `python:3.9-slim-trixie`
- Updated `uv` tooling image from `ghcr.io/astral-sh/uv:0.11.16` to `ghcr.io/astral-sh/uv:0.11.19`
- Reordered build steps to copy dependency files earlier and set `WORKDIR` before dependency installation

**Test Configuration and Fixtures**
- Added `TEST_TASK_TIMEOUT_MS = 30_000` constant in `tests/conftest.py` and `tests/settings/test_settings_facet_search.py`
- Updated `_clear_indexes` in `conftest.py` to explicitly pass timeout when waiting for task completion
- Updated `empty_index` fixture to wait for index creation tasks with explicit timeout
- Updated `test_composite_embedder_format` in `tests/settings/test_settings_embedders.py` to use 60-second timeout for composite embedder updates
- Updated facet search settings tests (`test_update_facet_search_settings` and `test_reset_facet_search_settings`) to use explicit timeouts when waiting for background tasks

These changes ensure tests reliably complete before timing out when running against Meilisearch v1.46.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->