### PR TITLE
Reset content-type when sending request

### DIFF
--- a/meilisearch/_httprequests.py
+++ b/meilisearch/_httprequests.py
@@ -49,6 +49,8 @@ class HttpRequests:
     ) -> Any:
         if content_type:
             self.headers["Content-Type"] = content_type
+        else:
+            self.headers.pop("Content-Type", None)
         try:
             request_path = self.config.url + "/" + path
             if http_method.__name__ == "get":
@@ -162,6 +164,8 @@ class HttpRequests:
         """
         if content_type:
             self.headers["Content-Type"] = content_type
+        else:
+            self.headers.pop("Content-Type", None)
         try:
             request_path = self.config.url + "/" + path
 

--- a/tests/client/test_http_requests.py
+++ b/tests/client/test_http_requests.py
@@ -1,3 +1,5 @@
+import requests
+
 from meilisearch._httprequests import HttpRequests
 from meilisearch.config import Config
 from meilisearch.version import qualified_version
@@ -28,3 +30,16 @@ def test_get_headers_with_multiple_user_agent():
         http.headers["User-Agent"]
         == qualified_version() + ";Meilisearch Package1 (v1.1.1);Meilisearch Package2 (v2.2.2)"
     )
+
+
+def test_reset_content_type_header():
+    """Tests that the content type header is reset when no content type is provided."""
+    config = Config(BASE_URL, MASTER_KEY, timeout=None)
+    http = HttpRequests(config=config)
+
+    http.headers["Content-Type"] = "application/json"
+    assert http.headers["Content-Type"] == "application/json"
+
+    http.send_request(http_method=requests.get, path="health")
+
+    assert "Content-Type" not in http.headers


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes https://github.com/meilisearch/meilisearch/issues/6188

## What does this PR do?
- reset content-type when sending request to meilisearch; for example, when chaining two requests like `swap_indexes` and `delete_index`, the first request set content-type to `application/json` and the delete request use it with incorrect `null` body for this type.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [ ] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [ ] Have you read the contributing guidelines?
- [ ] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Changes

- Updated `HttpRequests.send_request()` and `HttpRequests.post_stream()` to remove any existing `Content-Type` header from a reused `HttpRequests` instance when the `content_type` parameter is falsy/omitted.
- Added a regression test `test_reset_content_type_header` in `tests/client/test_http_requests.py` to verify the header is cleared after a request that doesn’t specify a content type.

## Rationale

When chaining multiple requests with the same HTTP client, a prior request (e.g., one that sets `Content-Type: application/json` such as `swap_indexes`) could leave the header in place. A subsequent request without a body (e.g., deleting the temporary index) could be sent with a stale `Content-Type`, leading to server errors.

## Impact

- Prevents stale `Content-Type` headers from being carried across sequential requests
- Fixes the failure scenario reported in issue `#6188` where deleting an index right after `swap_indexes` could return a 500 on remote Meilisearch instances
<!-- end of auto-generated comment: release notes by coderabbit.ai -->