### PR TITLE
Fix CI pipeline security issues reported by zizmor

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     labels:
       - 'dependencies'
     rebase-strategy: disabled
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: pip
     directory: "/"
@@ -17,3 +19,5 @@ updates:
     labels:
       - dependencies
     rebase-strategy: disabled
+    cooldown:
+      default-days: 7

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -7,11 +7,8 @@ on:
   # Allows to run the workflow manually
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -30,41 +27,48 @@ jobs:
       UV_PYTHON: "3.9"
       UV_LOCKED: 1
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
           fetch-depth: 0
           lfs: true
+          persist-credentials: false
 
       - name: Setup Github Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d  # v6.0.0
 
-      - name: Install Python
-        uses: actions/setup-python@v5
+      - name: Install Python ${{ env.UV_PYTHON }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
-          python-version: "3.9"
+          python-version: ${{ env.UV_PYTHON }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
-          version: "0.11.16"
+          version: "0.11.21"
+          enable-cache: false
 
       - name: Build docs
         run: |
           uv run --only-group docs sphinx-apidoc -f -o docs meilisearch/
           uv run --only-group docs sphinx-build docs ./docs/_build/html/
-        # CNAME file is required for GitHub pages custom domain
+
+      # CNAME file is required for GitHub pages custom domain
       - name: Create CNAME file
         run: |
           echo "$CUSTOM_DOMAIN" > ./docs/_build/html/CNAME
           echo "Created CNAME in ./docs/_build/html/: $CUSTOM_DOMAIN"
 
       - name: Upload artifacts
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9  # v5.0.0
         with:
           path: "./docs/_build/html"
 
   deploy:
     needs: build
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
@@ -72,4 +76,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128  # v5.0.0

--- a/.github/workflows/pre-release-tests.yml
+++ b/.github/workflows/pre-release-tests.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: bump-meilisearch-v*
 
+permissions:
+  contents: read
+
 jobs:
   integration_tests:
     strategy:
@@ -21,23 +24,26 @@ jobs:
       UV_PYTHON: ${{ matrix.python-version }}
       UV_LOCKED: 1
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
-          version: "0.11.16"
+          version: "0.11.21"
 
       - name: Get the latest Meilisearch RC
         run: echo "MEILISEARCH_VERSION=$(curl https://raw.githubusercontent.com/meilisearch/integration-guides/main/scripts/get-latest-meilisearch-rc.sh | bash)" >> $GITHUB_ENV
 
       - name: Meilisearch (${{ env.MEILISEARCH_VERSION }}) setup with Docker
-        run: docker run -d -p 7700:7700 getmeili/meilisearch-enterprise:${{ env.MEILISEARCH_VERSION }} meilisearch --master-key=masterKey --no-analytics
+        run: docker run -d -p 7700:7700 getmeili/meilisearch-enterprise:${MEILISEARCH_VERSION} meilisearch --master-key=masterKey --no-analytics
 
       - name: Test with pytest
         run: uv run pytest

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - v*
 
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -12,20 +15,23 @@ jobs:
       PYTHONUNBUFFERED: 1
       UV_PYTHON: "3.9"
     steps:
-      - uses: actions/checkout@v6
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
         with:
-          python-version: "3.9"
+          persist-credentials: false
+
+      - name: Set up Python ${{ env.UV_PYTHON }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: ${{ env.UV_PYTHON }}
 
       - name: Check release validity
         run: sh .github/scripts/check-release.sh
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
-          version: "0.11.16"
+          version: "0.11.21"
           enable-cache: false
 
       - name: Build and publish

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -8,8 +8,11 @@ on:
 jobs:
   update_release_draft:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: release-drafter/release-drafter@v6
+      - uses: release-drafter/release-drafter@693d20e7c1ce1a81d3a41962f85914253b518449  # v7.3.1
         with:
           config-name: release-draft-template.yml
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,9 @@ on:
       - main
   merge_group:
 
+permissions:
+  contents: read
+
 jobs:
   integration_tests:
     # Will not run if the event is a PR to bump-meilisearch-v* (so a pre-release PR)
@@ -23,17 +26,20 @@ jobs:
       UV_PYTHON: ${{ matrix.python-version }}
       UV_LOCKED: 1
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
-          version: "0.11.16"
+          version: "0.11.21"
 
       - name: Meilisearch (latest version) setup with Docker
         run: docker run -d -p 7700:7700 getmeili/meilisearch-enterprise:latest meilisearch --no-analytics --master-key=masterKey
@@ -49,17 +55,20 @@ jobs:
       UV_PYTHON: "3.9"
       UV_LOCKED: 1
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: "3.9"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
-          version: "0.11.16"
+          version: "0.11.21"
 
       - name: Linter with pylint
         run: uv run pylint meilisearch tests
@@ -72,17 +81,20 @@ jobs:
       UV_PYTHON: "3.9"
       UV_LOCKED: 1
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.9
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
-          version: "0.11.16"
+          version: "0.11.21"
 
       - name: mypy type check
         run: uv run mypy meilisearch
@@ -95,17 +107,20 @@ jobs:
       UV_PYTHON: "3.9"
       UV_LOCKED: 1
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.9
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
-          version: "0.11.16"
+          version: "0.11.21"
 
       - name: black
         run: uv run black meilisearch tests --check
@@ -118,17 +133,20 @@ jobs:
       UV_PYTHON: "3.9"
       UV_LOCKED: 1
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
         with:
           python-version: 3.9
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b  # v8.1.0
+        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39  # v8.2.0
         with:
-          version: "0.11.16"
+          version: "0.11.21"
 
       - name: isort
         run: uv run isort meilisearch tests --check-only
@@ -137,8 +155,11 @@ jobs:
     name: Yaml linting check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
       - name: Yaml lint check
-        uses: ibiqlik/action-yamllint@v3
+        uses: ibiqlik/action-yamllint@2576378a8e339169678f9939646ee3ee325e845c  # v3.1.1
         with:
           config_file: .yamllint.yml

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -12,22 +12,31 @@ env:
   NEW_BRANCH: update-version-${{ github.event.inputs.new_version }}
   GH_TOKEN: ${{ secrets.MEILI_BOT_GH_PAT }}
 
+permissions:
+  contents: read
+
 jobs:
   update-version:
     name: Update version in version.py
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - name: Checkout the repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
       - name: Update version.py file
         run: |
           raw_new_version=$(echo $NEW_VERSION | cut -d 'v' -f 2)
           new_string="__version__ = \"$raw_new_version\""
           sed -i "s/^__version__ = .*/$new_string/" meilisearch/version.py
+
       - name: Commit and push the changes to the ${{ env.NEW_BRANCH }} branch
-        uses: EndBug/add-and-commit@v9
+        uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321  # v10.0.0
         with:
           message: "Update version for the next release (${{ env.NEW_VERSION }}) in version.py"
           new_branch: ${{ env.NEW_BRANCH }}
+
       - name: Create the PR pointing to ${{ github.ref_name }}
         run: |
           gh pr create \

--- a/.github/workflows/update-version.yml
+++ b/.github/workflows/update-version.yml
@@ -33,6 +33,8 @@ jobs:
 
       - name: Commit and push the changes to the ${{ env.NEW_BRANCH }} branch
         uses: EndBug/add-and-commit@290ea2c423ad77ca9c62ae0f5b224379612c0321  # v10.0.0
+        env:
+          GITHUB_TOKEN: ${{ env.GH_TOKEN }}
         with:
           message: "Update version for the next release (${{ env.NEW_VERSION }}) in version.py"
           new_branch: ${{ env.NEW_BRANCH }}


### PR DESCRIPTION
## Description

Fixes all CI pipeline security issues reported by [zizmor](https://docs.zizmor.sh/)

### % uvx zizmor .
<img width="806" height="524" alt="meilli" src="https://github.com/user-attachments/assets/95ff1f23-ca9a-46c4-8235-e99f51d91077" />


## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

This PR addresses CI pipeline security issues identified by the Zizmor security audit tool. It hardens GitHub Actions workflows and related configuration by tightening GitHub token permissions, pinning third-party action references to commit SHAs, and reducing credential exposure in workflow runs.

## Changes

### Workflow Security Hardening
**Permission scoping (least privilege):**
- Added or tightened explicit `permissions` blocks to restrict token access, including:
  - `documentation.yml`, `tests.yml`, `pypi-publish.yml`, `update-version.yml`: top-level `contents: read`
  - `documentation.yml`: job-level permissions for Pages deployment
  - `release-drafter.yml`: job-level `contents: write` and `pull-requests: write`
  - `pre-release-tests.yml`: job-level `contents: read`

**Action pinning (remove tag-based references):**
- Updated multiple workflows to pin GitHub Actions (e.g., `actions/checkout`, `actions/setup-python`, `astral-sh/setup-uv`, and other actions) to specific commit SHAs instead of version tags.

**Credential handling:**
- Set `persist-credentials: false` on `actions/checkout` steps in the affected workflows to avoid unintended credential/token persistence.

**Tooling/version updates:**
- Bumped `astral-sh/setup-uv` usage to a newer pinned revision and updated the installed `uv` version to `0.11.21` across applicable workflows.
- Updated the `ibiqlik/action-yamllint` action to a pinned revision in `tests.yml`.
- Updated `EndBug/add-and-commit` and `release-drafter/release-drafter` to pinned revisions in `update-version.yml` and `release-drafter.yml` respectively.

### Configuration Updates
**Dependabot:**
- Updated `.github/dependabot.yml` to add a `cooldown` configuration with `default-days: 7` for the relevant dependency update entries.

**Pre-release tests:**
- Adjusted the Meilisearch RC Docker command to use `${MEILISEARCH_VERSION}` (shell environment variable syntax) instead of `${{ env.MEILISEARCH_VERSION }}`.

## Impact

Overall, these changes reduce CI/CD attack surface by enforcing least-privilege permissions, preventing action supply-chain risks via commit pinning, and limiting token/credential exposure during checkout—directly addressing Zizmor’s GitHub Actions workflow security findings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->