### PR TITLE
Fix CI configuration issue for release-drafter template categories

### DIFF
--- a/.github/release-draft-template.yml
+++ b/.github/release-draft-template.yml
@@ -15,7 +15,7 @@ categories:
   - title: '🐛 Bug Fixes'
     label: 'bug'
   - title: '⚙️ Maintenance/misc'
-    label:
+    labels:
       - 'dependencies'
       - 'maintenance'
       - 'documentation'


### PR DESCRIPTION
### Description

Fixes the failing `update_release_draft` CI job.

See: https://github.com/meilisearch/meilisearch-python/actions/runs/27519150846/job/81333491220

**1. Issue**

<img width="1068" height="808" alt="ci-error-release-drafter" src="https://github.com/user-attachments/assets/64fd1c55-b269-4da6-a480-e2266fcbf7a3" />

**2. The cause**

Per the [release-drafter schema](https://raw.githubusercontent.com/release-drafter/release-drafter/master/schema.json):

- `categories.label` must be a string
- `categories.labels` must be an array

<img width="721" height="793" alt="meili-release-drafter" src="https://github.com/user-attachments/assets/ee42a94f-d8f8-4765-89a0-fcab6254d410" />

The config currently passes an array to `label`, which is invalid.

The current code: https://github.com/meilisearch/meilisearch-python/blob/22f481de49f7f17e8df760f73151d4812dcfe85f/.github/release-draft-template.yml#L18-L21

**3. Solution**

Renames the key from `categories.label` to `categories.labels`.

## PR checklist
Please check if your PR fulfills the following requirements:
- [ ] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Description

Fixed a failing CI job in the `update_release_draft` workflow caused by an incorrect configuration in the release-drafter template file. The release-drafter schema requires `categories.label` to be a single string value and `categories.labels` to be an array. The configuration was incorrectly passing an array to the `label` key, causing a schema validation error.

## Changes

Updated `.github/release-draft-template.yml` to rename the `⚙️ Maintenance/misc` category configuration from `label:` to `labels:`, aligning with the release-drafter schema requirements and allowing the workflow to execute successfully.

## Impact

- **Low effort review** - Single line change in configuration file
- **Fixes CI failure** - Resolves schema validation error in GitHub Actions workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->