### PR TITLE
feat: add personalize parameter to Index.search

### DIFF
--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -333,7 +333,12 @@ class Index:
         return IndexStats(**stats)
 
     @version_error_hint_message
-    def search(self, query: str, opt_params: Optional[Mapping[str, Any]] = None) -> Dict[str, Any]:
+    def search(
+        self,
+        query: str,
+        opt_params: Optional[Mapping[str, Any]] = None,
+        personalize: Optional[Dict[str, Any]] = None,
+    ) -> Dict[str, Any]:
         """Search in the index.
 
         https://www.meilisearch.com/docs/reference/api/search
@@ -348,13 +353,14 @@ class Index:
             - hybrid: Dict with 'semanticRatio' and 'embedder' fields for hybrid search
             - vector: Array of numbers for vector search
             - retrieveVectors: Boolean to include vector data in search results
-            - personalize: Dict with a 'userContext' string to personalize the
-              results (experimental; requires Meilisearch >= v1.47)
             - filter: Filter queries by an attribute's value
             - limit: Maximum number of documents returned
             - offset: Number of documents to skip
             - showPerformanceDetails: If true, the response includes a
               performanceDetails object (raw data; fields may change in future API versions)
+        personalize (optional):
+            Dict with a 'userContext' string to personalize the search results
+            (experimental; requires Meilisearch >= v1.47).
 
         Returns
         -------
@@ -371,6 +377,8 @@ class Index:
             opt_params = {}
 
         body = {"q": query, **opt_params}
+        if personalize is not None:
+            body["personalize"] = personalize
 
         return self.http.post(
             f"{self.config.paths.index}/{self.uid}/{self.config.paths.search}",

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -348,6 +348,8 @@ class Index:
             - hybrid: Dict with 'semanticRatio' and 'embedder' fields for hybrid search
             - vector: Array of numbers for vector search
             - retrieveVectors: Boolean to include vector data in search results
+            - personalize: Dict with a 'userContext' string to personalize the
+              results (experimental; requires Meilisearch >= v1.47)
             - filter: Filter queries by an attribute's value
             - limit: Maximum number of documents returned
             - offset: Number of documents to skip

--- a/tests/index/test_index_search_meilisearch.py
+++ b/tests/index/test_index_search_meilisearch.py
@@ -1,6 +1,7 @@
 # pylint: disable=invalid-name
 
 from collections import Counter
+from unittest.mock import patch
 
 import pytest
 
@@ -12,6 +13,17 @@ def test_basic_search(index_with_documents):
     assert response["hits"][0]["id"] == "166428"
     assert response["estimatedTotalHits"] is not None
     assert "hitsPerPage" is not response
+
+
+def test_search_serializes_personalize(client):
+    """The `personalize` parameter must be forwarded in the search request body."""
+    index = client.index("books")
+    with patch.object(index.http, "post", return_value={"hits": []}) as mock_post:
+        index.search("prince", personalize={"userContext": "user-123"})
+
+    _, kwargs = mock_post.call_args
+    assert kwargs["body"]["q"] == "prince"
+    assert kwargs["body"]["personalize"] == {"userContext": "user-123"}
 
 
 def test_basic_search_with_empty_params(index_with_documents):


### PR DESCRIPTION
## Summary

Meilisearch v1.47.0 adds experimental personalized search (a `personalize` object
with a `userContext` string). `Index.search` forwards `opt_params` to the API
as-is, so the parameter already works at runtime — this documents it in the
`search` docstring alongside the other common options. Closes #1245.

## Notes

- The Python SDK passes search parameters straight through
  (`body = {"q": query, **opt_params}`), so no code change is required for
  `personalize` to be sent to Meilisearch.
- Integration coverage for the experimental personalization feature needs it
  enabled on the test backend (via `update_experimental_features`) plus the
  matching setup; happy to add a test if you confirm the preferred fixture.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

Adds support for Meilisearch v1.47.0’s experimental personalized search to the Python SDK. The `Index.search` method now accepts an explicit, typed `personalize` parameter (containing a `userContext` string) and forwards it to the Meilisearch API request body as `"personalize"`. Documentation is updated accordingly, and a new unit test verifies the parameter is serialized in the outgoing request.

## Changes

- Updated `Index.search` signature to include `personalize: Optional[...] = None`.
- When provided, `personalize` is added to the POST request body (alongside existing `q` / `opt_params`).
- Updated the `Index.search` docstring to document the experimental `personalize` option (Meilisearch >= v1.47.0).
- Added `test_search_serializes_personalize` to assert `"personalize"` is present in the serialized request body.

## Notes

This PR introduces functional SDK support (not only documentation) by wiring `personalize` into the request serialization and validating it with test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->