### PR TITLE
Do not swallow non-JSON http error responses

### DIFF
--- a/meilisearch/errors.py
+++ b/meilisearch/errors.py
@@ -37,10 +37,13 @@ class MeilisearchApiError(MeilisearchError):
         if request.text:
             try:
                 json_data = json.loads(request.text)
-                self.message = json_data.get("message") or request.text
-                self.code = json_data.get("code")
-                self.link = json_data.get("link")
-                self.type = json_data.get("type")
+                if isinstance(json_data, dict):
+                    self.message = json_data.get("message") or request.text
+                    self.code = json_data.get("code")
+                    self.link = json_data.get("link")
+                    self.type = json_data.get("type")
+                else:
+                    self.message = request.text
             except json.JSONDecodeError:
                 self.message = request.text
         else:

--- a/meilisearch/errors.py
+++ b/meilisearch/errors.py
@@ -35,11 +35,14 @@ class MeilisearchApiError(MeilisearchError):
         self.type = None
 
         if request.text:
-            json_data = json.loads(request.text)
-            self.message = json_data.get("message")
-            self.code = json_data.get("code")
-            self.link = json_data.get("link")
-            self.type = json_data.get("type")
+            try:
+                json_data = json.loads(request.text)
+                self.message = json_data.get("message") or request.text
+                self.code = json_data.get("code")
+                self.link = json_data.get("link")
+                self.type = json_data.get("type")
+            except json.JSONDecodeError:
+                self.message = request.text
         else:
             self.message = error
         super().__init__(self.message)

--- a/tests/errors/test_api_error_meilisearch.py
+++ b/tests/errors/test_api_error_meilisearch.py
@@ -55,6 +55,26 @@ def test_meilisearch_api_error_falls_back_to_raw_message_for_non_json_response(m
     assert exc.value.type is None
 
 
+@patch("requests.post")
+def test_meilisearch_api_error_falls_back_to_raw_message_for_non_object_json_response(mock_post):
+    """Uses raw response text when parsed JSON is not an object."""
+    mock_post.configure_mock(__name__="post")
+    mock_response = requests.models.Response()
+    mock_response.status_code = 502
+    mock_response._content = b'["Bad Gateway"]'  # pylint: disable=protected-access
+    mock_post.return_value = mock_response
+
+    with pytest.raises(MeilisearchApiError) as exc:
+        client = meilisearch.Client(BASE_URL, MASTER_KEY + "123")
+        client.create_index("some_index")
+
+    assert exc.value.status_code == 502
+    assert exc.value.message == '["Bad Gateway"]'
+    assert exc.value.code is None
+    assert exc.value.link is None
+    assert exc.value.type is None
+
+
 def test_version_error_hint_message():
     mock_response = requests.models.Response()
     mock_response.status_code = 408

--- a/tests/errors/test_api_error_meilisearch.py
+++ b/tests/errors/test_api_error_meilisearch.py
@@ -35,6 +35,26 @@ def test_meilisearch_api_error_no_code(mock_post):
         client.create_index("some_index")
 
 
+@patch("requests.post")
+def test_meilisearch_api_error_falls_back_to_raw_message_for_non_json_response(mock_post):
+    """Uses raw response text when an API error body is not valid JSON."""
+    mock_post.configure_mock(__name__="post")
+    mock_response = requests.models.Response()
+    mock_response.status_code = 502
+    mock_response._content = b"<html>Bad Gateway</html>"  # pylint: disable=protected-access
+    mock_post.return_value = mock_response
+
+    with pytest.raises(MeilisearchApiError) as exc:
+        client = meilisearch.Client(BASE_URL, MASTER_KEY + "123")
+        client.create_index("some_index")
+
+    assert exc.value.status_code == 502
+    assert exc.value.message == "<html>Bad Gateway</html>"
+    assert exc.value.code is None
+    assert exc.value.link is None
+    assert exc.value.type is None
+
+
 def test_version_error_hint_message():
     mock_response = requests.models.Response()
     mock_response.status_code = 408


### PR DESCRIPTION
# Pull Request

## Related issue
Fixes #129 

## What does this PR do?
- Use raw response text when an API error body is not valid JSON

## AI disclosure

Cursor with `gpt-5.4-low` and `codex-5.3-low`

## PR checklist
Please check if your PR fulfills the following requirements:
- [x] Did you use any AI tool while implementing this PR (code, tests, docs, etc.)? If yes, disclose it in the PR description and describe what it was used for. AI usage is allowed when it is disclosed.
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you read the contributing guidelines?
- [x] Have you made sure that the title is accurate and descriptive of the changes?

Thank you so much for contributing to Meilisearch!


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error handling for API failures when the response body is malformed or not a JSON object. The error message now reliably falls back to the raw response text instead of leaving it unset or causing parsing-related issues.

* **Tests**
  * Added regression tests covering non-JSON (e.g., HTML) and JSON-but-not-object (e.g., array) error responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->