### PR TITLE
Add render template route

### DIFF
--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -611,6 +611,8 @@ update_embedders_1: |-
 reset_embedders_1: |-
   client.index('INDEX_NAME').reset_embedders()
 post_render_template_1: |-
+  client.update_experimental_features({"renderRoute": True})
+
   client.render_template(
     template={
       'kind': 'inlineDocumentTemplate',

--- a/.code-samples.meilisearch.yaml
+++ b/.code-samples.meilisearch.yaml
@@ -610,3 +610,14 @@ update_embedders_1: |-
   })
 reset_embedders_1: |-
   client.index('INDEX_NAME').reset_embedders()
+post_render_template_1: |-
+  client.render_template(
+    template={
+      'kind': 'inlineDocumentTemplate',
+      'inline': 'An inline document template rendered on {{doc.id}}'
+    },
+    input={
+      'kind': 'inlineDocument',
+      'inline': {'id': 'this document'}
+    }
+  )

--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -280,6 +280,45 @@ class Client:
             body={"queries": queries, "federation": federation},
         )
 
+    def render_template(
+        self,
+        template: Mapping[str, Any],
+        input: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Render a template against an input document.
+
+        This is an experimental route. Enable the ``renderRoute`` feature on your
+        Meilisearch instance before calling it, for example
+        ``client.update_experimental_features({"renderRoute": True})``.
+
+        https://www.meilisearch.com/docs/reference/api/template
+
+        Parameters
+        ----------
+        template:
+            Dictionary describing the template or fragment to render, for example
+            {"kind": "inlineDocumentTemplate", "inline": "Rendered on {{doc.id}}"}.
+        input (optional):
+            Dictionary describing what to render the template with, for example
+            {"kind": "inlineDocument", "inline": {"id": "this document"}}. When omitted
+            the route returns the unrendered template and ``rendered`` is null.
+
+        Returns
+        -------
+        rendered:
+            Dictionary with the unrendered ``template`` and the ``rendered`` result.
+
+        Raises
+        ------
+        MeilisearchApiError
+            An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
+        """
+        body: dict[str, Any] = {"template": template}
+        if input is not None:
+            body["input"] = input
+
+        return self.http.post(self.config.paths.render_template, body=body)
+
     def update_documents_by_function(
         self, index_uid: str, queries: dict[str, list[dict[str, Any]]]
     ) -> dict[str, Any]:

--- a/meilisearch/config.py
+++ b/meilisearch/config.py
@@ -49,6 +49,7 @@ class Config:
         experimental_features = "experimental-features"
         webhooks = "webhooks"
         export = "export"
+        render_template = "render-template"
 
     def __init__(
         self,

--- a/tests/client/test_client_render_template.py
+++ b/tests/client/test_client_render_template.py
@@ -1,0 +1,55 @@
+from unittest.mock import patch
+
+import pytest
+
+
+def test_render_template_calls_route(client):
+    """The SDK posts template and input to the render-template route."""
+    template = {"kind": "inlineDocumentTemplate", "inline": "Rendered on {{doc.id}}"}
+    document = {"kind": "inlineDocument", "inline": {"id": "42"}}
+
+    with patch.object(
+        client.http, "post", return_value={"template": "x", "rendered": "y"}
+    ) as mock_post:
+        client.render_template(template=template, input=document)
+
+    mock_post.assert_called_once_with(
+        "render-template",
+        body={"template": template, "input": document},
+    )
+
+
+def test_render_template_omits_input_when_none(client):
+    """Without an input the body only carries the template."""
+    template = {"kind": "inlineDocumentTemplate", "inline": "Rendered on {{doc.id}}"}
+
+    with patch.object(
+        client.http, "post", return_value={"template": "x", "rendered": None}
+    ) as mock_post:
+        client.render_template(template=template)
+
+    mock_post.assert_called_once_with("render-template", body={"template": template})
+
+
+@pytest.mark.usefixtures("enable_render_route")
+def test_render_template_inline(client):
+    """Renders an inline template with an inline document."""
+    response = client.render_template(
+        template={"kind": "inlineDocumentTemplate", "inline": "Rendered on {{doc.id}}"},
+        input={"kind": "inlineDocument", "inline": {"id": "42"}},
+    )
+
+    assert isinstance(response, dict)
+    assert {"template", "rendered"} <= set(response)
+    assert "42" in response["rendered"]
+
+
+@pytest.mark.usefixtures("enable_render_route")
+def test_render_template_without_input(client):
+    """Omitting the input returns the unrendered template and a null result."""
+    response = client.render_template(
+        template={"kind": "inlineDocumentTemplate", "inline": "Rendered on {{doc.id}}"},
+    )
+
+    assert isinstance(response, dict)
+    assert response["rendered"] is None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -352,3 +352,20 @@ def enable_network_options():
         json={"network": False},
         timeout=10,
     )
+
+
+@fixture
+def enable_render_route():
+    requests.patch(
+        f"{common.BASE_URL}/experimental-features",
+        headers={"Authorization": f"Bearer {common.MASTER_KEY}"},
+        json={"renderRoute": True},
+        timeout=10,
+    )
+    yield
+    requests.patch(
+        f"{common.BASE_URL}/experimental-features",
+        headers={"Authorization": f"Bearer {common.MASTER_KEY}"},
+        json={"renderRoute": False},
+        timeout=10,
+    )


### PR DESCRIPTION
## Related issue
Closes #1253

## What does this PR do?
- Add `client.render_template()` for the experimental `POST /render-template` route added in Meilisearch 1.48
- Send `template` with an optional `input`, and drop `input` from the body when it is not passed (the route returns the unrendered template with `rendered: null` in that case)
- Add unit tests for the request shape plus live tests gated by a `renderRoute` experimental-feature fixture
- Add the `post_render_template_1` code sample

The route is behind the `renderRoute` experimental feature, so callers enable it with `update_experimental_features({"renderRoute": True})` first. Tested the new cases against a local Meilisearch 1.48.0.

## AI disclosure
None

## PR checklist
- [x] Have you read the contributing guidelines?
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `render_template` to the client to render inline document templates, with optional document input.
* **Documentation**
  * Added a new Meilisearch documentation code sample demonstrating how to enable and use template rendering.
* **Bug Fixes**
  * Ensures request payloads include `input` only when provided.
* **Tests**
  * Added coverage for `render_template`, including scenarios with and without `input`.
  * Added a test fixture to enable/disable the experimental render feature during the test run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->