### PR TITLE
Add human-formatted sizes and internal database sizes to stats

### DIFF
--- a/meilisearch/client.py
+++ b/meilisearch/client.py
@@ -346,11 +346,24 @@ class Client:
             body=dict(queries),
         )
 
-    def get_all_stats(self) -> dict[str, Any]:
+    def get_all_stats(
+        self,
+        show_internal_database_sizes: bool = False,
+        size_format: str | None = None,
+    ) -> dict[str, Any]:
         """Get all stats of Meilisearch
 
         Get information about database size and all indexes
         https://www.meilisearch.com/docs/reference/api/stats
+
+        Parameters
+        ----------
+        show_internal_database_sizes (optional):
+            When True, each index stat object also contains an ``internalDatabaseSizes``
+            dictionary of internal database names and their current size.
+        size_format (optional):
+            "human" to return database sizes as strings with a unit (MiB, GiB, ...),
+            or "raw" (the default) to return them as byte counts.
 
         Returns
         -------
@@ -362,7 +375,15 @@ class Client:
         MeilisearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
         """
-        return self.http.get(self.config.paths.stat)
+        parameters: dict[str, str] = {}
+        if show_internal_database_sizes:
+            parameters["showInternalDatabaseSizes"] = "true"
+        if size_format is not None:
+            parameters["sizeFormat"] = size_format
+        url = self.config.paths.stat
+        if parameters:
+            url += f"?{parse.urlencode(parameters)}"
+        return self.http.get(url)
 
     def health(self) -> dict[str, str]:
         """Get health of the Meilisearch server.

--- a/meilisearch/index.py
+++ b/meilisearch/index.py
@@ -304,11 +304,24 @@ class Index:
         """
         return self.task_handler.wait_for_task(uid, timeout_in_ms, interval_in_ms)
 
-    def get_stats(self) -> IndexStats:
+    def get_stats(
+        self,
+        show_internal_database_sizes: bool = False,
+        size_format: str | None = None,
+    ) -> IndexStats:
         """Get stats of the index.
 
         Get information about the number of documents, field frequencies, ...
         https://www.meilisearch.com/docs/reference/api/stats
+
+        Parameters
+        ----------
+        show_internal_database_sizes (optional):
+            When True, the returned stats also contain an ``internal_database_sizes``
+            dictionary of internal database names and their current size.
+        size_format (optional):
+            "human" to return database sizes as strings with a unit (MiB, GiB, ...),
+            or "raw" (the default) to return them as byte counts.
 
         Returns
         -------
@@ -320,7 +333,15 @@ class Index:
         MeilisearchApiError
             An error containing details about why Meilisearch can't process your request. Meilisearch error codes are described here: https://www.meilisearch.com/docs/reference/errors/error_codes#meilisearch-errors
         """
-        stats = self.http.get(f"{self.config.paths.index}/{self.uid}/{self.config.paths.stat}")
+        parameters: dict[str, str] = {}
+        if show_internal_database_sizes:
+            parameters["showInternalDatabaseSizes"] = "true"
+        if size_format is not None:
+            parameters["sizeFormat"] = size_format
+        url = f"{self.config.paths.index}/{self.uid}/{self.config.paths.stat}"
+        if parameters:
+            url += f"?{parse.urlencode(parameters)}"
+        stats = self.http.get(url)
         return IndexStats(**stats)
 
     @version_error_hint_message

--- a/meilisearch/models/index.py
+++ b/meilisearch/models/index.py
@@ -31,6 +31,8 @@ class IndexStats(CamelBase):
     number_of_documents: int
     is_indexing: bool
     field_distribution: FieldDistribution
+    raw_database_size: int | None = None
+    internal_database_sizes: dict[str, Any] | None = None
 
     @field_validator("field_distribution", mode="before")
     @classmethod

--- a/tests/client/test_client_stats_meilisearch.py
+++ b/tests/client/test_client_stats_meilisearch.py
@@ -12,3 +12,19 @@ def test_get_all_stats(client):
     assert "indexes" in response
     assert "indexUID" in response["indexes"]
     assert "indexUID2" in response["indexes"]
+
+
+@pytest.mark.usefixtures("indexes_sample")
+def test_get_all_stats_human_size_format(client):
+    """Tests getting all stats with human-formatted sizes."""
+    response = client.get_all_stats(size_format="human")
+    assert isinstance(response, dict)
+    assert isinstance(response["databaseSize"], str)
+
+
+@pytest.mark.usefixtures("indexes_sample")
+def test_get_all_stats_internal_database_sizes(client):
+    """Tests getting all stats with internal database sizes."""
+    response = client.get_all_stats(show_internal_database_sizes=True)
+    assert isinstance(response, dict)
+    assert "internalDatabaseSizes" in response["indexes"]["indexUID"]

--- a/tests/index/test_index_stats_meilisearch.py
+++ b/tests/index/test_index_stats_meilisearch.py
@@ -15,3 +15,11 @@ def test_get_stats_default(index_with_documents):
     assert response.number_of_documents == 31
     assert hasattr(response.field_distribution, "genre")
     assert response.field_distribution.genre == 11
+
+
+def test_get_stats_internal_database_sizes(index_with_documents):
+    """Tests exposing internal database sizes."""
+    response = index_with_documents().get_stats(show_internal_database_sizes=True)
+    assert isinstance(response, IndexStats)
+    assert isinstance(response.internal_database_sizes, dict)
+    assert response.internal_database_sizes


### PR DESCRIPTION
## Related issue
Closes #1234

## What does this PR do?
- Add `show_internal_database_sizes` and `size_format` params to `client.get_all_stats()` and `Index.get_stats()`, sent as the `showInternalDatabaseSizes` and `sizeFormat` query params introduced in Meilisearch 1.44
- Expose the new `internalDatabaseSizes` (and `rawDatabaseSize`) keys on the `IndexStats` model as optional fields, so nothing breaks when they are absent
- Add live tests for the human size format and internal database sizes on both the client and index stats routes

## AI disclosure
None

## PR checklist
- [x] Have you read the contributing guidelines?
- [x] Does this PR fix an existing issue, or have you listed the changes applied in the PR description (and why they are needed)?
- [x] Have you made sure that the title is accurate and descriptive of the changes?


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Stats requests now support optional size-formatting and additional internal size details.
  * Index and instance stats responses can include more detailed storage information when requested.

* **Bug Fixes**
  * Improved stats request handling so optional parameters are included only when needed, preserving existing behavior by default.

* **Tests**
  * Added coverage for formatted database size output and internal database size fields in stats responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->